### PR TITLE
Windows/WSL2 compatibility: LF endings, stdout-safe path capture, overridable allocator config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Everything in this repo executes on Linux (bash, patch, python inside the
+# container image via `COPY . .`), so CRLF working trees break it. Force LF
+# regardless of the cloning machine's core.autocrlf.
+* text=auto eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY docker/requirements.txt docker/requirements.txt
 RUN venv/bin/pip install -r docker/requirements.txt
 
 COPY . .
-RUN set -e; SP=$(venv/bin/python -c 'import vllm, os; print(os.path.dirname(vllm.__file__))'); \
+RUN set -e; SP=$(venv/bin/python -c 'import vllm, os; print(os.path.dirname(vllm.__file__))' | tail -n1); \
     for p in patches/*.patch; do echo "== $p"; patch -p1 -d "$SP" < "$p"; done; \
     bash kvarn/install.sh; \
     bash verify.sh --install

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ signatures and earlier five-profile matrix are in [issue #1](../../issues/1).
 | `batch`, `KV=int4pth` | 437,414 tokens | 1,043.84 / 1,044.06 tok/s, C64 |
 | `batch`, `KV=kvarn` | 334,183 cold / 350,192 warm | 843.72 / 852.42 tok/s, C64 |
 
-Two WSL-specific memory behaviors are worth accounting for:
+Three WSL-specific memory behaviors are worth accounting for:
 
 1. **The ordinary batch default may fail vLLM's startup free-memory gate.**
    On an otherwise clean card, WSL reported 22.75/24.0 GiB free, less than
@@ -400,9 +400,15 @@ Two WSL-specific memory behaviors are worth accounting for:
    `EXTRA_ARGS` on later starts. Stress concurrent prefill or
    `prompt_logprobs` before promoting it. Do not copy a byte value from a
    different card or profile.
-
-The separate Marlin-repack allocator observation from issue #1 is not changed
-by this documentation PR; it may belong in vLLM rather than this recipe.
+3. **`expandable_segments` can crash Marlin repack on some driver/dxgkrnl
+   combinations.** Both start scripts default to
+   `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`; its CUDA VMM calls
+   crashed the engine with `RuntimeError: CUDA driver error: device not
+   ready` inside `gptq_marlin_repack` on Windows driver 610.74 (WSL 2.1.5
+   and 2.7.12 alike — the `e81fa39` reproduction on driver 591.86 did not
+   hit this). The scripts respect a pre-set value, so put
+   `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False` in `.env` (Docker)
+   or the environment (venv) if you see that signature.
 
 ## Gotchas
 

--- a/batch/start_qwen.sh
+++ b/batch/start_qwen.sh
@@ -61,7 +61,8 @@ INT8_ACT=${INT8_ACT-int8}
 INT8_LAYERS=${INT8_LAYERS-mlp}
 
 export PATH="$REPO/venv/bin:$PATH"
-export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+# Overridable for WSL2 (see single-user/start_qwen.sh).
+export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
 # flashinfer's sampling.cu does not build with older system nvcc (12.0);
 # the attention kernels JIT fine. Remove this if you have a recent CUDA toolkit.
 export VLLM_USE_FLASHINFER_SAMPLER=0

--- a/kvarn/install.sh
+++ b/kvarn/install.sh
@@ -7,7 +7,7 @@ set -e
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="$(dirname "$HERE")"
 PY=${PY:-$REPO/venv/bin/python}
-SP=$("$PY" -c 'import vllm, os; print(os.path.dirname(vllm.__file__))' 2>/dev/null)
+SP=$("$PY" -c 'import vllm, os; print(os.path.dirname(vllm.__file__))' 2>/dev/null | tail -n1)
 [ -n "$SP" ] && [ -d "$SP" ] || { echo "cannot import vllm with $PY (README: Setup)"; exit 1; }
 cp -r "$HERE/files/vllm/." "$SP/"
 patch -p1 -N -r /dev/null -d "$SP" < "$HERE/kvarn-0.27.1.patch" || true

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -74,7 +74,10 @@ else
 fi
 
 export PATH="$REPO/venv/bin:$PATH"
-export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+# Overridable: expandable_segments needs CUDA VMM, which WSL2's paravirt
+# driver rejects ("CUDA driver error: device not ready" during Marlin repack)
+# — set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False in .env on WSL2.
+export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
 export VLLM_USE_FLASHINFER_SAMPLER=0
 
 if [ -z "$VLLM_API_KEY" ] && [ -f "$REPO/api_key.txt" ]; then

--- a/verify.sh
+++ b/verify.sh
@@ -23,9 +23,9 @@ PY=${PY:-$HERE/venv/bin/python}
 
 echo "== environment"
 [ -x "$PY" ] && ok "python: $PY" || { fail "no $PY (see README Setup)"; exit 1; }
-VER=$($PY -c "import vllm; print(vllm.__version__)" 2>/dev/null)
+VER=$($PY -c "import vllm; print(vllm.__version__)" 2>/dev/null | tail -n1)
 [ "$VER" = "0.27.1" ] && ok "vllm $VER" || warn "vllm ${VER:-missing} (patches were written against 0.27.1)"
-SP=$($PY -c "import vllm, os; print(os.path.dirname(vllm.__file__))" 2>/dev/null)
+SP=$($PY -c "import vllm, os; print(os.path.dirname(vllm.__file__))" 2>/dev/null | tail -n1)
 [ -n "$SP" ] && [ -d "$SP" ] && ok "vllm package at $SP" || { fail "cannot import vllm with $PY"; exit 1; }
 if [ $INSTALL = 0 ]; then
 $PY - <<'EOF' 2>/dev/null || fail "torch cannot see a CUDA GPU"


### PR DESCRIPTION
Three fixes from bringing the Docker setup up on Windows 10 + Docker Desktop (WSL2 backend), RTX 3090, Windows driver 610.74. With these, `docker compose --profile single up -d` works end-to-end on WSL2: all `verify.sh` checks pass and single-user mode serves at 76–107 tok/s greedy.

### 1. Force LF line endings (`.gitattributes`)

Cloning on Windows with `core.autocrlf=true` checks out CRLF, and `COPY . .` ships that into the image: bash fails on every script (`set: -\r: invalid option`) and `patch` warns on every hunk. A `* text=auto eol=lf` attribute makes Windows clones build identically to Linux ones.

### 2. vLLM package-path capture breaks under WSL2 (`tail -n1`)

Importing vllm under WSL2 prints `Using 'pin_memory=False' as WSL is detected` **to stdout**, so `SP=$(python -c 'print(os.path.dirname(vllm.__file__))')` captures the warning glued to the path and the Docker build fails at the patch step with `patch: Can't change to directory`. The path is always the last line printed; `| tail -n1` keeps only it. Applied to the Dockerfile, `verify.sh` (path + version capture), and `kvarn/install.sh`. The existing `2>/dev/null` guards don't help because the warning goes to stdout.

### 3. `expandable_segments` crashes Marlin repack on some WSL2 drivers

Both start scripts hard-code `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`. Its CUDA VMM allocation path is rejected by some driver/dxgkrnl combinations: on Windows driver 610.74 (WSL 2.1.5 and 2.7.12 alike) the engine crash-loops with

```
RuntimeError: CUDA driver error: device not ready
```

inside `gptq_marlin_repack` — this looks like the "separate Marlin-repack allocator observation" from issue #1. The `e81fa39` reproduction on driver 591.86 did not hit it, so it appears driver-dependent rather than universal. The scripts now respect a pre-set `PYTORCH_CUDA_ALLOC_CONF`, so affected users put `expandable_segments:False` in `.env`; native Linux keeps the tuned default. Documented as WSL2 note 3 in the README (replacing the issue-#1 caveat paragraph it supersedes).

## Testing

On Windows 10 (19045) + Docker Desktop 29.2.0 + WSL 2.7.12 + RTX 3090 + driver 610.74:

- Docker image builds cleanly; all 8 patches apply; `verify.sh --install` passes at build time.
- Without fix 3: 12+ crash-loop restarts, 100% reproducible at repack. With fix 3: server healthy, full `verify.sh` passes (0 failures), including the live-server chat check.
- Single-user fast-variant mode: 76–107 tok/s greedy across varied 500-token completions.
- Fixes 1–2 are inert on native Linux (LF stays LF; `tail -n1` of single-line output is the same line). Fix 3 keeps `expandable_segments:True` unless the caller sets the variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
