### PR TITLE
fix(docker): install libcurand-dev so SPEC=dflash2 can JIT-compile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM nvidia/cuda:13.0.1-base-ubuntu24.04
 ENV DEBIAN_FRONTEND=noninteractive PIP_NO_CACHE_DIR=1 PYTHONUNBUFFERED=1
 RUN apt-get update && apt-get install -y --no-install-recommends \
       python3.12 python3.12-venv python3.12-dev \
-      cuda-nvcc-13-0 cuda-cudart-dev-13-0 \
+      cuda-nvcc-13-0 cuda-cudart-dev-13-0 libcurand-dev-13-0 \
       build-essential patch curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
One-word fix to the Dockerfile's apt line: `SPEC=dflash2` can't JIT-compile without `curand.h`.

## The bug

The image installs `cuda-nvcc-13-0` and `cuda-cudart-dev-13-0`, but FlashInfer JIT-compiles the DFlash2 kernels against `$CUDA_HOME/include` and needs `curand.h`, which lives in `libcurand-dev-13-0`. Without it, every dflash2 launch logs:

```
WARNING [qwen3_dflash2.py:74] /app/venv/.../flashinfer/sampling.cuh:20:10:
fatal error: curand.h: No such file or directory
```

and the request never completes. Plain completions are unaffected, which is why a chat benchmark doesn't surface it — only `SPEC=dflash2` hits the JIT path, so it's specifically the headline single-user mode that breaks.

Worth noting the package is `libcurand-dev-13-0`; `cuda-curand-dev-13-0` doesn't exist in the ubuntu2404 repo (I tried that first).

## Verified

RTX 3090 Ti, driver 580.167.08, ECC off, desktop running. With the header present, `SPEC=dflash2 DFLASH_TOKENS=15` starts clean — zero curand errors — and:

| prompt | `SPEC=mtp` | `SPEC=dflash2` |
|---|---:|---:|
| code (red-black tree, 600 tok) | 125.4 tok/s | **174.0 tok/s** |
| prose essay (1024 tok) | 118.7 | 121.0 |
| count to 400 (1024 tok) | 296.4 | 295.7 |

So the fix is worth +39% on code generation here. For reference, on the same card and model I measure llama.cpp at ~48 tok/s and ninfer-3090 at ~54 tok/s, so your stack is ~3.6x and ~3.2x those respectively.

## Two other things I hit, if useful

**1. Tool calling is off by default.** Neither start script passes `--enable-auto-tool-choice --tool-call-parser`, so any agentic client gets:

```
"auto" tool choice requires --enable-auto-tool-choice and --tool-call-parser to be set
```

`--tool-call-parser qwen3_xml` matches the model's chat template (it emits `<tool_call>` wrapping `<function`). With that plus `--default-chat-template-kwargs '{"enable_thinking":false}'`, opencode drives it correctly — tool calls parse cleanly, no malformed arguments. Happy to send a PR adding an `EXTRA_ARGS`-style opt-in or a documented recipe if you'd want one; I didn't want to change defaults that affect your benchmark numbers.

**2. `KV_MEM` assumes a headless card.** Your comment already says "lower it if you also run something else on the card" — just confirming that's exactly what happens. With Xorg + gnome-shell + Chrome taking ~1.3 GiB, the pinned 5.2 GiB pool leaves less than the 1.5 GiB the spec-decode `part_o` buffer needs and the engine OOMs at `spec_decode_attn.py:152`. Dropping `KV_MEM` to 4.0 GiB fixed it. Might be worth a line in the README for desktop users, since the failure mode is an OOM well after startup looks healthy.

## A question, if you have a moment

`SPEC=dflash2` is `CTX=fast`-only because the drafter's block attention is non-causal and only the bf16 `FLASH_ATTN` path implements it. Is that a fundamental constraint, or would DFlash2 work against the KVarN backend if someone wrote the non-causal variant? The combination — 200k context at DFlash2 speeds — would be the single most valuable thing in this repo for agentic coding, where 64k is limiting. I'm trying to gauge whether that's a week of kernel work or a dead end before anyone sinks time into it.

## Unrelated, but earned

Your benchmarking discipline is the reason I switched to this stack. Publishing the cumulative table of what each of the nine steps buys, measuring quality alongside speed (IFBench/GSM8K/perplexity, not just tok/s), documenting what *didn't* work, and pointing out that random tokens are a bad yardstick for speculative decoding — that's rare, and it's why I trusted these numbers enough to spend a day on them. They reproduced. Thanks for the writeups as much as the code.
