### PR TITLE
KVarN on the V2 runner: SPEC=dflash2 + CTX=huge — DFlash2 speed at 240k context, prefix caching included

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,15 +128,22 @@ collapses to about one token per step, and on bare metal the output degrades
 outright. It is the capture rather than the drafter (eager is clean, and so is
 PIECEWISE, which keeps the compiled graphs and leaves only the multi-query
 verify uncaptured), so `CTX=huge` runs PIECEWISE and keeps prefix caching.
-Same box, same script, only the capture toggled:
 
-| `copy`, 25k prompt | tok per verify step | tok/s |
-|---|---|---|
-| `CUDAGRAPH_MODE=FULL_AND_PIECEWISE` | 1.97 | 39 |
-| PIECEWISE (the default here) | 7.83 | 130 |
+It is a trade rather than a free win: dropping the full decode graphs costs
+short-prompt throughput. Same box, same script, only the capture toggled,
+three runs each:
 
-`CUDAGRAPH_MODE=FULL_AND_PIECEWISE` puts the captured verify back once that is
-understood; the hunt is in the PR thread.
+| | `copy` @25k | de | en | code |
+|---|---|---|---|---|
+| `FULL_AND_PIECEWISE` | 38 tok/s (1.97/step) | 78 | 125 | 202 |
+| PIECEWISE (default here) | **132 tok/s (7.83/step)** | 74 | 102 | 176 |
+
+3.5x on the long shared prefix this mode exists for, 13-18% off short-prompt
+decode. The capture mode is fixed at boot, so `CTX=huge` takes the trade that
+matches what it is for. `CUDAGRAPH_MODE=FULL_AND_PIECEWISE` switches back, but
+treat that as unsafe until the capture bug is understood — here it only cost
+speed, on a bare-metal tree it corrupted the output. The hunt is in the PR
+thread.
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,38 @@ approximating it, and GSM8K reads 96.0-96.5% across the three columns. What
 the whole reason it is opt-in, and why the default stays where it is for anyone
 serving more than a few people. Every other knob: [single-user/](single-user/).
 
+### DFlash2 at 240k: `CTX=huge` (KVarN) also combines with `SPEC=dflash2`
+
+```bash
+bash kvarn/install.sh                # applies kvarn-v2-runner.patch as its second stage
+SPEC=dflash2 CTX=huge PREFIX_CACHE=1 bash single-user/start_qwen.sh
+```
+
+Where `CTX=long` doubles the DFlash2 pool with int8 KV (138k), the KVarN cache
+takes the same idea further: 268k tokens of pool at 245760 max-model-len, on the
+same pinned budget. No kernel work — the KVarN Triton kernels run unmodified on
+the V2 runner; the seven fixes in `kvarn/kvarn-v2-runner.patch` are allocator and
+geometry logic (the patch header walks through them, including an upstream vLLM
+bug in the mamba align resume path, and a NaN path in the DFlash2 candidate
+selector that KVarN noise exposes on verbatim-reproduction content). RTX 3090
+under WSL2 at a 200 W power limit (all numbers in this section are WSL2 —
+bare-metal validation pending), `bench/labd_bench.py --ctx 20000`:
+
+| `SPEC=dflash2 CTX=huge PREFIX_CACHE=1` | tok/s |
+|---|---|
+| copy / edit (reproduction, 6.4 tok per verify step) | 114 / 109 |
+| code / quote / summary / qa | 85 / 44 / 38 / 34 |
+| GSM8K exact-match (200 q, greedy, thinking off) | 95.5% |
+| KV capacity at 240k max-model-len | 268k tokens |
+| 200k-deep needle | correct |
+| turn 2 over a 200k cached prefix | 4.4 s (vs ~7.5 min cold) |
+
+One caveat to the "all of it is lossless" paragraph above: the speculation here
+is still exact, but this mode inherits KVarN's 4/2-bit KV cache, which is lossy —
+the same trade `CTX=huge` already makes (deep-needle retrieval passes at 200k).
+On WSL2, set `VLLM_WSL_PIN_MEMORY=1` — the V2 runner's UVA buffers work fine on
+the paravirt driver; vLLM's blanket pin-memory ban predates it.
+
 ## Benchmarks
 
 Full tables per mode in [batch/README.md](batch/README.md) and

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ bare-metal validation pending), `bench/labd_bench.py --ctx 20000`:
 | copy (reproduction, 7.8 tok per verify step) | 130 |
 | code / edit / quote / summary / qa | 89 / 65 / 44 / 38 / 36 |
 | all six tasks together (3.0 tok per verify step) | 53 |
-| GSM8K exact-match (200 q, greedy, thinking off) | 95.5% |
+| GSM8K exact-match (200 q, thinking off; author reference 96.0-96.5) | 97.0% |
 | KV capacity at 245760 max-model-len | 268,169 tokens |
 | 100k-deep needle, both turns | correct |
 | turn 2 over a 100k cached prefix | 4.7 s (vs 169 s cold) |

--- a/README.md
+++ b/README.md
@@ -102,23 +102,41 @@ the V2 runner; the seven fixes in `kvarn/kvarn-v2-runner.patch` are allocator an
 geometry logic (the patch header walks through them, including an upstream vLLM
 bug in the mamba align resume path, and a NaN path in the DFlash2 candidate
 selector that KVarN noise exposes on verbatim-reproduction content). RTX 3090
-under WSL2 at a 200 W power limit (all numbers in this section are WSL2 —
+under WSL2 at a 250 W power limit (all numbers in this section are WSL2 —
 bare-metal validation pending), `bench/labd_bench.py --ctx 20000`:
 
 | `SPEC=dflash2 CTX=huge PREFIX_CACHE=1` | tok/s |
 |---|---|
-| copy / edit (reproduction, 6.4 tok per verify step) | 114 / 109 |
-| code / quote / summary / qa | 85 / 44 / 38 / 34 |
+| copy (reproduction, 7.8 tok per verify step) | 130 |
+| code / edit / quote / summary / qa | 89 / 65 / 44 / 38 / 36 |
+| all six tasks together (3.0 tok per verify step) | 53 |
 | GSM8K exact-match (200 q, greedy, thinking off) | 95.5% |
-| KV capacity at 240k max-model-len | 268k tokens |
-| 200k-deep needle | correct |
-| turn 2 over a 200k cached prefix | 4.4 s (vs ~7.5 min cold) |
+| KV capacity at 245760 max-model-len | 268,169 tokens |
+| 100k-deep needle, both turns | correct |
+| turn 2 over a 100k cached prefix | 4.7 s (vs 169 s cold) |
 
 One caveat to the "all of it is lossless" paragraph above: the speculation here
 is still exact, but this mode inherits KVarN's 4/2-bit KV cache, which is lossy —
 the same trade `CTX=huge` already makes (deep-needle retrieval passes at 200k).
-On WSL2, set `VLLM_WSL_PIN_MEMORY=1` — the V2 runner's UVA buffers work fine on
-the paravirt driver; vLLM's blanket pin-memory ban predates it.
+On WSL2, set `VLLM_WSL2_ENABLE_PIN_MEMORY=1` — the V2 runner needs pinned
+memory, and vLLM leaves it off by default there; its UVA buffers work fine on
+the paravirt driver.
+
+One knob this mode sets for you: `cudagraph_mode=PIECEWISE`. Prefix caching and
+a *captured* (FULL) verify step do not currently mix on this path — acceptance
+collapses to about one token per step, and on bare metal the output degrades
+outright. It is the capture rather than the drafter (eager is clean, and so is
+PIECEWISE, which keeps the compiled graphs and leaves only the multi-query
+verify uncaptured), so `CTX=huge` runs PIECEWISE and keeps prefix caching.
+Same box, same script, only the capture toggled:
+
+| `copy`, 25k prompt | tok per verify step | tok/s |
+|---|---|---|
+| `CUDAGRAPH_MODE=FULL_AND_PIECEWISE` | 1.97 | 39 |
+| PIECEWISE (the default here) | 7.83 | 130 |
+
+`CUDAGRAPH_MODE=FULL_AND_PIECEWISE` puts the captured verify back once that is
+understood; the hunt is in the PR thread.
 
 ## Benchmarks
 

--- a/kvarn/install.sh
+++ b/kvarn/install.sh
@@ -11,6 +11,9 @@ SP=$("$PY" -c 'import vllm, os; print(os.path.dirname(vllm.__file__))' 2>/dev/nu
 [ -n "$SP" ] && [ -d "$SP" ] || { echo "cannot import vllm with $PY (README: Setup)"; exit 1; }
 cp -r "$HERE/files/vllm/." "$SP/"
 patch -p1 -N -r /dev/null -d "$SP" < "$HERE/kvarn-0.27.1.patch" || true
+# V2-runner port: lets SPEC=dflash2 run with CTX=huge (KVarN KV + prefix caching, 240k).
+# Depends on hunks from both the patches/ set and kvarn-0.27.1.patch, hence applied last.
+patch -p1 -N -r /dev/null -d "$SP" < "$HERE/kvarn-v2-runner.patch" || true
 find "$SP" -type d -name __pycache__ -path "*kvarn*" -prune -exec rm -rf {} + 2>/dev/null || true
 "$PY" - <<'PY'
 from typing import get_args
@@ -21,5 +24,9 @@ print("KVarN backend:", AttentionBackendEnum.KVARN.get_class().get_name())
 from vllm.model_executor.layers.quantization.kvarn.config import KVarNConfig
 c = KVarNConfig.from_cache_dtype("kvarn_k4v2_g128", 256)
 print("tile bytes", c.tile_bytes, "-> per token per head", c.tile_bytes_aligned // c.group, "B (fp8: 256 B)")
+import inspect
+from vllm.v1.worker.gpu.model_states import mamba_hybrid
+assert "port(kvarn-v2)" in inspect.getsource(mamba_hybrid), "kvarn-v2-runner.patch missing"
+print("kvarn-v2 runner port present (DFlash2 + CTX=huge)")
 PY
 echo "kvarn installed"

--- a/kvarn/install.sh
+++ b/kvarn/install.sh
@@ -15,7 +15,9 @@ patch -p1 -N -r /dev/null -d "$SP" < "$HERE/kvarn-0.27.1.patch" || true
 # Depends on hunks from both the patches/ set and kvarn-0.27.1.patch, hence applied last.
 patch -p1 -N -r /dev/null -d "$SP" < "$HERE/kvarn-v2-runner.patch" || true
 find "$SP" -type d -name __pycache__ -path "*kvarn*" -prune -exec rm -rf {} + 2>/dev/null || true
-"$PY" - <<'PY'
+"$PY" - "$SP" "$HERE" <<'PY'
+import sys
+from pathlib import Path
 from typing import get_args
 from vllm.config.cache import CacheDType
 assert "kvarn_k4v2_g128" in get_args(CacheDType)
@@ -24,9 +26,37 @@ print("KVarN backend:", AttentionBackendEnum.KVARN.get_class().get_name())
 from vllm.model_executor.layers.quantization.kvarn.config import KVarNConfig
 c = KVarNConfig.from_cache_dtype("kvarn_k4v2_g128", 256)
 print("tile bytes", c.tile_bytes, "-> per token per head", c.tile_bytes_aligned // c.group, "B (fp8: 256 B)")
-import inspect
-from vllm.v1.worker.gpu.model_states import mamba_hybrid
-assert "port(kvarn-v2)" in inspect.getsource(mamba_hybrid), "kvarn-v2-runner.patch missing"
-print("kvarn-v2 runner port present (DFlash2 + CTX=huge)")
+
+# Check the result, not the exit code. `patch --forward` cannot tell "already
+# applied" (a legitimate rerun) from "does not apply" (a vLLM tree this patch
+# was not cut against) -- both exit non-zero -- which is why the calls above
+# end in `|| true`. That makes a stale hunk fail SILENTLY: you get a partial
+# port and no warning. Every hunk here adds a port(kvarn-v2) marker, so
+# counting them per file says exactly which ones did not land.
+sp, here = Path(sys.argv[1]), Path(sys.argv[2])
+want, current = {}, None
+for line in (here / "kvarn-v2-runner.patch").read_text().splitlines():
+    if line.startswith("+++ b/"):
+        current = line[len("+++ b/"):].strip()
+        want.setdefault(current, 0)
+    elif current and line.startswith("+") and "port(kvarn-v2)" in line:
+        want[current] += 1
+short = []
+for rel, expected in sorted(want.items()):
+    target = sp / rel
+    found = target.read_text().count("port(kvarn-v2)") if target.is_file() else 0
+    if found < expected:
+        short.append(f"  {rel}: {found}/{expected} markers")
+if short:
+    print("\nERROR: kvarn-v2-runner.patch did not apply completely:", file=sys.stderr)
+    print("\n".join(short), file=sys.stderr)
+    print(
+        "\nThis vLLM tree differs from the one the patch was cut against.\n"
+        "Re-cut the failing hunks before using SPEC=dflash2 CTX=huge -- a\n"
+        "partially applied port runs, but silently drops correctness fixes.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+print(f"kvarn-v2 runner port complete ({sum(want.values())} markers across {len(want)} files)")
 PY
 echo "kvarn installed"

--- a/kvarn/kvarn-v2-runner.patch
+++ b/kvarn/kvarn-v2-runner.patch
@@ -1,0 +1,240 @@
+KVarN 4/2-bit KV on the V2 runner: DFlash2 + 240k context + prefix caching together.
+
+Six fixes, none of them kernel work -- the KVarN Triton kernels run unmodified on the
+V2 runner; every blocker was allocator/geometry logic:
+ 1. qwen3_dflash.py: the drafter's sliding-window layers get a bf16 cache_config copy
+    (the SW backend path has no KVarN support, and the drafter doesn't need it).
+ 2. attention.py: SW specs without a shared page pad to the mamba page under KVarN --
+    otherwise each 16-token SW block burns a full 1.83 MB uniform page (84% of the pool).
+ 3. attention.py: _largest_kernel_block_within scales MultipleOf backends up to the page
+    budget, preferring divisors of the primary block in 128-token steps. 128 is the only
+    block size that is simultaneously a divisor of 2176 (=17x128), a FlashAttention-2
+    multiple of 16, and a KVarN tile multiple.
+ 4. kv_cache_utils.py: sliding-window groups (the drafter) stay out of the scheduler
+    LCM / hash GCD; an explicit --prefix-match-unit now beats the mamba-divergence
+    fallback (which silently ignored it).
+ 5. kv_cache_coordinator.py / single_type_kv_cache_manager.py: the hash-unit assert
+    accepts SW blocks smaller than the hash unit; the SW manager returns a clean miss
+    instead of asserting (prefix reuse is meaningless for a rolling window anyway).
+ 6. mamba_hybrid.py: add_request seeded the running mamba state column with
+    cache_config.block_size instead of the mamba group's block size. With
+    --block-size 128 (KVarN tile) a resume from a 100k cached prefix indexed column
+    781 of a ~61-column block table -> illegal memory access in the align pre-copy.
+    (Upstream vLLM bug: any hybrid with an explicit --block-size != mamba block size,
+    prefix caching, and mamba_cache_mode=align hits this on the second request.)
+
+ 7. dflash2/speculator.py: on degenerate (ultra-peaked) distributions the
+    candidate selector's scores can go NaN -- KVarN quantization noise on
+    verbatim-reproduction content tips them over, which is why CTX=fast never
+    showed it. NaN made the path-walk kernel index past the candidate row
+    (garbage token id -> the illegal memory access in the replayed decode
+    graph on labd copy tasks) and poisoned the cached draft logits the
+    rejection sampler divides by (silently WRONG tokens: greedy copy
+    degenerated into repetition). Three-part fix: sanitize the scores to
+    finite values before sampling/caching, clamp the walk index, initialize
+    the selector token buffer with zeros instead of empty. Verified: 6/6
+    labd tasks pass at 240k (copy 6.36 tok/step), copy output verbatim
+    (599/600 chars vs the source, identical to MTP), GSM8K 95.0-95.5%
+    (n=100/200, author reference 96.0-96.5), 200k needle + prefix resume
+    unchanged.
+
+Measured on an RTX 3090 (WSL2, 200 W power limit), fast variant,
+bench/labd_bench.py --ctx 20000:
+  copy 114 / edit 109 / code 85 / quote 44 / summary 38 / qa 34 tok/s
+  (copy at 6.4 tokens per verify step), 240k max-model-len with 268k tokens
+  of KV, 200k-deep needle correct, and a 200k prefix-cache hit takes the
+  follow-up turn from ~7.5 min of prefill to 4.4 s.
+
+Apply AFTER kvarn-0.27.1.patch and the patches/ set (kvarn/install.sh does both):
+  patch -p1 -d venv/lib/python3.12/site-packages/vllm < kvarn/kvarn-v2-runner.patch
+
+Written against vLLM 0.27.1 + this repo's patch set.
+
+--- a/model_executor/models/qwen3_dflash.py
++++ b/model_executor/models/qwen3_dflash.py
+@@ -222,6 +222,11 @@
+         )
+ 
+         self.sliding_window = sliding_window
++        # port(kvarn-v2): KVarN has no sliding-window path — drafter layers stay bf16.
++        if cache_config is not None and str(getattr(cache_config, "cache_dtype", "auto")).startswith("kvarn"):
++            from copy import copy as _kv_copy
++            cache_config = _kv_copy(cache_config)
++            cache_config.cache_dtype = "auto"
+         self.attn = Attention(
+             self.num_heads,
+             self.head_dim,
+--- a/model_executor/layers/attention/attention.py
++++ b/model_executor/layers/attention/attention.py
+@@ -110,8 +110,33 @@
+ 
+     sizes = attn_backend.get_supported_kernel_block_sizes()
+     candidates = [s for s in sizes if isinstance(s, int)]
++    # port(kvarn-v2): MultipleOf backends (FA2: MultipleOf(16)) support ANY
++    # multiple — scale up to the page budget instead of offering only the base,
++    # or every 16-token SW block burns a whole shared page.
++    mults = [s.base for s in sizes if isinstance(s, MultipleOf)]
++    if mults and page_budget and per_token_bytes > 0:
++        base = min(mults)
++        budget_tokens = page_budget // per_token_bytes
++        scaled = budget_tokens // base * base
++        # port(kvarn-v2): prefer a DIVISOR of ``fallback`` (the primary
++        # block) so the scheduler LCM and the prefix hash work out — otherwise
++        # the SW block breaks block-size uniformity.
++        if fallback and fallback > 0:
++            # KVarN tile compatibility: prefer multiples of 128, then any
++            # divisor of the primary block.
++            for step in (128, base):
++                found = 0
++                for d in range(budget_tokens, step - 1, -1):
++                    if fallback % d == 0 and d % step == 0:
++                        found = d
++                        break
++                if found:
++                    scaled = found
++                    break
++        if scaled >= base:
++            candidates.append(scaled)
+     if not candidates:
+-        candidates = [s.base for s in sizes if isinstance(s, MultipleOf)]
++        candidates = mults
+     if not candidates:
+         return fallback
+     smallest = min(candidates)
+@@ -643,6 +668,13 @@
+             # bytes per block. Otherwise (page_size_padded is None) the smallest
+             # block is fine — ``unify`` scales it up by an integer ratio.
+             shared_page = vllm_config.cache_config.skip_page_size_padded
++            # port(kvarn-v2): hybrid without skip layers — pad the drafter's
++            # SW pages to the mamba/primary page instead of wasting 16-token
++            # blocks inside 1.8 MB uniform pages (26x overhead).
++            if shared_page is None and str(
++                vllm_config.cache_config.cache_dtype
++            ).startswith("kvarn"):
++                shared_page = vllm_config.cache_config.mamba_page_size_padded
+             sw_per_token = SlidingWindowSpec(
+                 block_size=1,
+                 num_kv_heads=self.num_kv_heads,
+--- a/v1/core/kv_cache_utils.py
++++ b/v1/core/kv_cache_utils.py
+@@ -656,6 +656,16 @@
+         else g.kv_cache_spec.block_size
+         for g in groups
+     ]
++    # port(kvarn-v2): sliding-window groups (the DFlash drafter) take no part
++    # in prefix matching and must not skew the LCM/GCD; their block is a
++    # divisor of the primary block by construction.
++    from vllm.v1.kv_cache_interface import SlidingWindowSpec as _SWS
++    _non_sw = [
++        bs for g, bs in zip(groups, group_block_sizes)
++        if not isinstance(g.kv_cache_spec, _SWS)
++    ]
++    if _non_sw:
++        group_block_sizes = _non_sw
+     scheduler_block_size = math.lcm(*group_block_sizes)
+ 
+     # Block hashes are only consumed by prefix caching and KV connectors
+@@ -668,7 +678,9 @@
+     # Mamba groups with block_size != cache_config.block_size
+     # (mamba_cache_mode != "align") break divisibility; back off to the
+     # scheduler block size.
+-    if any(
++    # port(kvarn-v2): an explicit --prefix-match-unit beats the mamba
++    # divergence fallback (which used to silently ignore it).
++    if cache_config.prefix_match_unit is None and any(
+         isinstance(g.kv_cache_spec, MambaSpec)
+         and g.kv_cache_spec.block_size != cache_config.block_size
+         for g in groups
+--- a/v1/core/kv_cache_coordinator.py
++++ b/v1/core/kv_cache_coordinator.py
+@@ -560,8 +560,13 @@
+         group_block_sizes = [
+             manager.block_size for manager in self.single_type_managers
+         ]
++        # port(kvarn-v2): sliding-window groups (the DFlash drafter) take no
++        # part in prefix matching; for them it suffices that the hash unit is
++        # an integer multiple of their block (e.g. 2176 = 17 x 128).
+         assert all(
+-            block_size % hash_block_size == 0 for block_size in group_block_sizes
++            block_size % hash_block_size == 0
++            or hash_block_size % block_size == 0
++            for block_size in group_block_sizes
+         ), (
+             "Each KV cache group's real block_size must be divisible by "
+             f"hash_block_size. block_sizes={group_block_sizes}, "
+--- a/v1/core/single_type_kv_cache_manager.py
++++ b/v1/core/single_type_kv_cache_manager.py
+@@ -915,6 +915,11 @@
+         assert alignment_tokens % kv_cache_spec.block_size == 0, (
+             "SlidingWindowManager does not support fine-grained (partial) cache hits"
+         )
++        # port(kvarn-v2): the drafter's SW block can be smaller than the hash
++        # unit (2176). Prefix reuse is meaningless for a rolling window anyway
++        # — so report a clean miss instead of asserting.
++        if kv_cache_spec.block_size % block_pool.hash_block_size != 0:
++            return tuple([] for _ in kv_cache_group_ids), 0
+         block_hashes = resolve_block_hashes(
+             block_hashes,
+             block_pool.hash_block_size,
+--- a/v1/worker/gpu/model_states/mamba_hybrid.py
++++ b/v1/worker/gpu/model_states/mamba_hybrid.py
+@@ -100,8 +100,18 @@
+         self.num_accepted_tokens_gpu[req_index].fill_(1)
+         if self._align_mode:
+             # Seed the running state block from the resumed/prefilled position.
++            # port(kvarn-v2): use the MAMBA spec block size, not
++            # cache_config.block_size -- with an explicit --block-size (KVarN
++            # needs 128) the two diverge (128 vs 2176) and the seed indexes far
++            # past the mamba block table -> illegal memory access in the align
++            # precopy on prefix-cache resume. _mamba_spec is populated by the
++            # first batch's preprocess_state; resumes can only happen after
++            # that, and fresh requests (num_computed==0) seed -1 either way.
++            mamba_bs = (self._mamba_spec.block_size
++                        if self._mamba_spec is not None
++                        else self.cache_config.block_size)
+             self._mamba_state_idx_gpu[req_index].fill_(
+-                (new_req_data.num_computed_tokens - 1) // self.cache_config.block_size
++                (new_req_data.num_computed_tokens - 1) // mamba_bs
+             )
+ 
+     def _get_mamba_group_info(
+--- a/v1/worker/gpu/spec_decode/dflash2/speculator.py
++++ b/v1/worker/gpu/spec_decode/dflash2/speculator.py
+@@ -105,6 +105,11 @@
+             realized,
+             mask=mask & valid,
+         )
++        # port(kvarn-v2): NaN scores make `scores == best` match nowhere, so
++        # index becomes BLOCK_K and the load below reads past the candidate
++        # row -- a garbage token id that later kills the embedding gather.
++        # Clamp to candidate 0; a wrong draft is just rejected by the verify.
++        index = tl.where(index >= top_k, 0, index)
+         token = tl.load(candidate_ptr + candidate_base + index, mask=valid, other=0)
+         tl.store(tokens_ptr + flat, token, mask=valid)
+         previous = index
+@@ -157,7 +162,9 @@
+             torch.arange(self.max_num_reqs, dtype=torch.int64, device=device)
+             * self.num_query_per_req
+         )
+-        self._selector_tokens = torch.empty_like(self.draft_tokens)
++        # port(kvarn-v2): zeros, not empty -- an unwritten slot must hold a
++        # valid token id, never uninitialized VRAM.
++        self._selector_tokens = torch.zeros_like(self.draft_tokens)
+         self._selector_scores = torch.empty(
+             self.max_num_reqs,
+             self.num_speculative_steps,
+@@ -291,6 +298,14 @@
+             hidden_states,
+             anchor_token_ids,
+         )
++        # port(kvarn-v2): degenerate (ultra-peaked) distributions can NaN the
++        # selector scores -- KVarN quantization noise on verbatim-reproduction
++        # content tips them over. NaN poisons both the path walk (index runs
++        # past the candidate row) and the cached draft logits the rejection
++        # sampler divides by, silently accepting wrong tokens. Sanitize to
++        # finite values: affected candidates keep a valid q, verify stays
++        # exact. Pure GPU op, cudagraph-capture-safe.
++        scores = torch.nan_to_num(scores, nan=-1e30, posinf=1e30, neginf=-1e30)
+         self._sample_path(candidate_ids, scores, num_reqs)
+         self._cache_draft_logits(candidate_ids, num_sample)
+         self.draft_tokens[:num_reqs].copy_(self._selector_tokens[:num_reqs])

--- a/kvarn/kvarn-v2-runner.patch
+++ b/kvarn/kvarn-v2-runner.patch
@@ -38,8 +38,9 @@ V2 runner; every blocker was allocator/geometry logic:
     finite values before sampling/caching, clamp the walk index, initialize
     the selector token buffer with zeros instead of empty. Verified: 6/6
     labd tasks pass at 240k, copy output verbatim (599/600 chars vs the
-    source, identical to MTP), GSM8K 95.0-95.5% (n=100/200, author reference
-    96.0-96.5), needle + prefix resume unchanged. NOTE the third part was
+    source, identical to MTP), GSM8K 97.0% (n=200 on the shipped config,
+    author reference 96.0-96.5), needle + prefix resume unchanged. NOTE the
+    third part was
     re-cut for current main: lookup-v2 gave _selector_tokens an explicit
     (max_num_reqs, draft_block) shape, so the old torch.empty_like pre-image
     is gone and the hunk silently dropped on newer trees. kvarn/install.sh

--- a/kvarn/kvarn-v2-runner.patch
+++ b/kvarn/kvarn-v2-runner.patch
@@ -176,6 +176,27 @@ Written against vLLM 0.27.1 + this repo's patch set.
          block_hashes = resolve_block_hashes(
              block_hashes,
              block_pool.hash_block_size,
+@@ -1091,6 +1096,20 @@
+         """
+         return 0
+ 
++    def cache_blocks(
++        self, request, num_tokens: int, retention_interval: int | None = None
++    ) -> None:
++        # port(kvarn-v2): write-side twin of the read short-circuit above —
++        # when the SW block does not divide the hash unit, skip caching this
++        # group instead of asserting in resolve_block_hashes. Rolling-window
++        # reuse is meaningless, so nothing is lost. This is also the assert
++        # reported from cache_full_blocks -> resolve_block_hashes when the
++        # flag is dropped, and on multi-GPU geometries where per-GPU page
++        # sizes give the SW group a block the hash unit no longer divides.
++        if self.block_size % self.block_pool.hash_block_size != 0:
++            return
++        super().cache_blocks(request, num_tokens, retention_interval)
++
+ 
+ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
+     def __init__(self, kv_cache_spec: ChunkedLocalAttentionSpec, **kwargs) -> None:
 --- a/v1/worker/gpu/model_states/mamba_hybrid.py
 +++ b/v1/worker/gpu/model_states/mamba_hybrid.py
 @@ -100,8 +100,18 @@
@@ -200,7 +221,7 @@ Written against vLLM 0.27.1 + this repo's patch set.
      def _get_mamba_group_info(
 --- a/v1/worker/gpu/spec_decode/dflash2/speculator.py
 +++ b/v1/worker/gpu/spec_decode/dflash2/speculator.py
-@@ -105,6 +105,11 @@
+@@ -106,6 +106,11 @@
              realized,
              mask=mask & valid,
          )
@@ -212,18 +233,18 @@ Written against vLLM 0.27.1 + this repo's patch set.
          token = tl.load(candidate_ptr + candidate_base + index, mask=valid, other=0)
          tl.store(tokens_ptr + flat, token, mask=valid)
          previous = index
-@@ -157,7 +162,9 @@
+@@ -161,7 +166,9 @@
              torch.arange(self.max_num_reqs, dtype=torch.int64, device=device)
              * self.num_query_per_req
          )
--        self._selector_tokens = torch.empty_like(self.draft_tokens)
+-        self._selector_tokens = torch.empty(
 +        # port(kvarn-v2): zeros, not empty -- an unwritten slot must hold a
 +        # valid token id, never uninitialized VRAM.
-+        self._selector_tokens = torch.zeros_like(self.draft_tokens)
-         self._selector_scores = torch.empty(
-             self.max_num_reqs,
-             self.num_speculative_steps,
-@@ -291,6 +298,14 @@
++        self._selector_tokens = torch.zeros(
+             (self.max_num_reqs, self.draft_block),
+             dtype=self.draft_tokens.dtype,
+             device=device,
+@@ -424,6 +431,14 @@
              hidden_states,
              anchor_token_ids,
          )
@@ -237,4 +258,4 @@ Written against vLLM 0.27.1 + this repo's patch set.
 +        scores = torch.nan_to_num(scores, nan=-1e30, posinf=1e30, neginf=-1e30)
          self._sample_path(candidate_ids, scores, num_reqs)
          self._cache_draft_logits(candidate_ids, num_sample)
-         self.draft_tokens[:num_reqs].copy_(self._selector_tokens[:num_reqs])
+         self.draft_tokens[:num_reqs, : self.draft_block].copy_(

--- a/kvarn/kvarn-v2-runner.patch
+++ b/kvarn/kvarn-v2-runner.patch
@@ -53,6 +53,11 @@ capture rather than the drafter -- eager is clean, and so is PIECEWISE, which
 keeps the compiled graphs and leaves only the multi-query verify uncaptured.
 single-user/start_qwen.sh therefore runs SPEC=dflash2 CTX=huge with
 cudagraph_mode=PIECEWISE; anyone driving vllm serve directly needs the same.
+It is a trade rather than a free win -- 3 runs each at 250 W: long context
+(labd copy@20k) 1.97 -> 7.83 tok/step and 38 -> 132 tok/s, but short-prompt
+decode drops 13-18% (de/en/code 78/125/202 -> 74/102/176 tok/s) with the full
+decode graphs gone. The capture mode is fixed at boot, so this mode takes the
+trade that matches long shared prefixes.
 
 Measured on an RTX 3090 (WSL2, 250 W power limit), fast variant, through
 single-user/start_qwen.sh itself, bench/labd_bench.py --ctx 20000:

--- a/kvarn/kvarn-v2-runner.patch
+++ b/kvarn/kvarn-v2-runner.patch
@@ -1,6 +1,6 @@
 KVarN 4/2-bit KV on the V2 runner: DFlash2 + 240k context + prefix caching together.
 
-Six fixes, none of them kernel work -- the KVarN Triton kernels run unmodified on the
+Seven fixes, none of them kernel work -- the KVarN Triton kernels run unmodified on the
 V2 runner; every blocker was allocator/geometry logic:
  1. qwen3_dflash.py: the drafter's sliding-window layers get a bf16 cache_config copy
     (the SW backend path has no KVarN support, and the drafter doesn't need it).
@@ -15,7 +15,11 @@ V2 runner; every blocker was allocator/geometry logic:
     fallback (which silently ignored it).
  5. kv_cache_coordinator.py / single_type_kv_cache_manager.py: the hash-unit assert
     accepts SW blocks smaller than the hash unit; the SW manager returns a clean miss
-    instead of asserting (prefix reuse is meaningless for a rolling window anyway).
+    on the read side and skips caching on the write side, instead of asserting
+    (prefix reuse is meaningless for a rolling window anyway). Without the write-side
+    half, cache_full_blocks -> resolve_block_hashes asserts as soon as the drafter's
+    SW group is in the picture, which is what made --prefix-match-unit 128 look like a
+    multi-GPU workaround; it is neither optional nor TP-specific.
  6. mamba_hybrid.py: add_request seeded the running mamba state column with
     cache_config.block_size instead of the mamba group's block size. With
     --block-size 128 (KVarN tile) a resume from a 100k cached prefix indexed column
@@ -33,17 +37,31 @@ V2 runner; every blocker was allocator/geometry logic:
     degenerated into repetition). Three-part fix: sanitize the scores to
     finite values before sampling/caching, clamp the walk index, initialize
     the selector token buffer with zeros instead of empty. Verified: 6/6
-    labd tasks pass at 240k (copy 6.36 tok/step), copy output verbatim
-    (599/600 chars vs the source, identical to MTP), GSM8K 95.0-95.5%
-    (n=100/200, author reference 96.0-96.5), 200k needle + prefix resume
-    unchanged.
+    labd tasks pass at 240k, copy output verbatim (599/600 chars vs the
+    source, identical to MTP), GSM8K 95.0-95.5% (n=100/200, author reference
+    96.0-96.5), needle + prefix resume unchanged. NOTE the third part was
+    re-cut for current main: lookup-v2 gave _selector_tokens an explicit
+    (max_num_reqs, draft_block) shape, so the old torch.empty_like pre-image
+    is gone and the hunk silently dropped on newer trees. kvarn/install.sh
+    now counts the port(kvarn-v2) markers per file and refuses to leave a
+    partially applied port behind.
 
-Measured on an RTX 3090 (WSL2, 200 W power limit), fast variant,
-bench/labd_bench.py --ctx 20000:
-  copy 114 / edit 109 / code 85 / quote 44 / summary 38 / qa 34 tok/s
-  (copy at 6.4 tokens per verify step), 240k max-model-len with 268k tokens
-  of KV, 200k-deep needle correct, and a 200k prefix-cache hit takes the
-  follow-up turn from ~7.5 min of prefill to 4.4 s.
+One thing this patch does NOT fix, so the caller has to: with prefix caching on,
+the DFlash2 verify step must not be a CAPTURED cuda graph. Acceptance collapses
+to ~1 token per step, and on some trees the output degrades outright. It is the
+capture rather than the drafter -- eager is clean, and so is PIECEWISE, which
+keeps the compiled graphs and leaves only the multi-query verify uncaptured.
+single-user/start_qwen.sh therefore runs SPEC=dflash2 CTX=huge with
+cudagraph_mode=PIECEWISE; anyone driving vllm serve directly needs the same.
+
+Measured on an RTX 3090 (WSL2, 250 W power limit), fast variant, through
+single-user/start_qwen.sh itself, bench/labd_bench.py --ctx 20000:
+  copy 130 / code 89 / edit 65 / quote 44 / summary 38 / qa 36 tok/s
+  (copy at 7.8 tokens per verify step; 53 tok/s over all six tasks),
+  245760 max-model-len with 268,169 tokens of KV, 100k-deep needle correct
+  in both turns, and a 100k prefix-cache hit takes the follow-up turn from
+  169 s of prefill to 4.7 s. With the captured verify instead: copy drops to
+  1.97 tok/step and 39 tok/s.
 
 Apply AFTER kvarn-0.27.1.patch and the patches/ set (kvarn/install.sh does both):
   patch -p1 -d venv/lib/python3.12/site-packages/vllm < kvarn/kvarn-v2-runner.patch

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -212,6 +212,20 @@ if [ "${PREFIX_CACHE:-0}" = "1" ]; then
   # KVarN runs --block-size 128; match the prefix hash unit to its tile so cache
   # hits land on tile boundaries (a non-multiple of 128 corrupts the pool).
   [ "$CTX" = "huge" ] && EXTRA_ARGS="--prefix-match-unit 128 ${EXTRA_ARGS}"
+  # DFlash2 only: prefix caching and a CAPTURED (FULL) verify step do not mix on
+  # that path -- acceptance collapses to ~1 token per step, and on some trees the
+  # output degrades outright. It is the capture, not the drafter: eager is clean,
+  # and so is PIECEWISE, which keeps the compiled graphs and leaves only the
+  # multi-query verify uncaptured. labd copy@20k through this script, prefix
+  # caching on:
+  #   FULL       1.97 tok/step,  39 tok/s
+  #   PIECEWISE  7.83 tok/step, 130 tok/s
+  # MTP is untouched here: its verify step is short and captures correctly, so
+  # forcing PIECEWISE would cost it decode speed for nothing. Set
+  # CUDAGRAPH_MODE=FULL_AND_PIECEWISE to get the captured verify back once that
+  # is fixed upstream.
+  [ "$SPEC" = "dflash2" ] && [ "$CTX" = "huge" ] &&
+    CG_MODE=",\"cudagraph_mode\":\"${CUDAGRAPH_MODE:-PIECEWISE}\""
 fi
 
 # ASYNC_SCHED=0 (set above for a long DFlash2 verify block) runs the scheduler
@@ -244,6 +258,6 @@ exec venv/bin/vllm serve "$MODEL" \
   ${ASYNC_ARGS} \
   --max-num-batched-tokens 2048 \
   --speculative-config "$SPEC_CFG" \
-  --compilation-config "{\"max_cudagraph_capture_size\":$CG,\"custom_ops\":[\"+rms_norm\",\"+silu_and_mul\"]}" \
+  --compilation-config "{\"max_cudagraph_capture_size\":$CG,\"custom_ops\":[\"+rms_norm\",\"+silu_and_mul\"]${CG_MODE}}" \
   --reasoning-parser qwen3 \
   ${EXTRA_ARGS}

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -64,8 +64,9 @@ CTX=${CTX:-fast}
 # SPEC=dflash2: the DFlash2 block drafter (incoai/Qwen3.8-27B-DFlash2, requantized
 #   to W4A16 by this repo: prepare/fetch_dflash2.py), 7 drafts in ONE non-autoregressive
 #   pass + a path selector; runs on vLLM's V2 model runner
-#   (patches/dflash2-backport.patch). CTX=fast only (bf16 KV / FLASH_ATTN; the
-#   drafter's block attention is non-causal); see README "DFlash2".
+#   (patches/dflash2-backport.patch). CTX=fast (bf16, 64k), CTX=long (int8,
+#   128k) or, with kvarn/install.sh, CTX=huge (KVarN 4/2-bit, 240k + prefix
+#   caching); see README "DFlash2".
 SPEC=${SPEC:-mtp}
 # SPEC_ATTN=1: split-KV Triton attention for the multi-query verify step
 # (patches/spec-decode-attn.patch); bf16 KV only, so CTX=fast only.
@@ -96,8 +97,14 @@ if [ "$SPEC" = "dflash2" ] && [ "$CTX" = "long" ]; then
   # mode for a RAG or coding front-end that loads a document once, not for general chat.
   ATTN_ARGS="--attention-backend TRITON_ATTN --kv-cache-dtype int8_per_token_head"
   export VLLM_SPEC_DECODE_ATTN=${SPEC_ATTN:-1}
+elif [ "$SPEC" = "dflash2" ] && [ "$CTX" = "huge" ]; then
+  # KVarN 4/2-bit KV on the V2 runner (kvarn/, with kvarn-v2-runner.patch as its
+  # second stage): the pinned pool holds 268k tokens at 245760 max-model-len.
+  # The split-KV verify attention is bf16-KV only -- the KVarN backend brings
+  # its own dequant path, so the env stays off here.
+  export VLLM_SPEC_DECODE_ATTN=0
 elif [ "$SPEC" = "dflash2" ] && [ "$CTX" != "fast" ]; then
-  echo "SPEC=dflash2 supports CTX=fast (bf16/FLASH_ATTN, 64k) and CTX=long (int8/TRITON_ATTN, 128k); CTX=$CTX keeps SPEC=mtp" >&2
+  echo "SPEC=dflash2 supports CTX=fast (bf16, 64k), CTX=long (int8, 128k) and CTX=huge (KVarN, 240k; kvarn/install.sh); CTX=$CTX keeps SPEC=mtp" >&2
   SPEC=mtp
 fi
 if [ "$SPEC" = "dflash2" ]; then
@@ -148,7 +155,15 @@ if [ "$SPEC" = "dflash2" ]; then
   # state page per speculative block. That second term is what scales -- NOT the slot
   # count: 1 slot and 8 slots differ by about 8 MiB in total, so cutting MAX_SEQS buys no
   # context. Single-user mode keeps 4 slots when the block is long for the graphs.
-  if [ "$CTX" = "long" ]; then
+  if [ "$CTX" = "huge" ]; then
+    # KVarN pool: ~20 KB/token effective. 5.26 GiB pinned -> 268,169 tokens of
+    # KV at 245760 max-model-len with 2 slots (single-user long-context; the
+    # graphs stay at the k=7 size).
+    MAX_SEQS=${MAX_SEQS:-2}
+    MAX_LEN=${DFLASH_MAX_LEN:-245760}
+    KV_MEM=${KV_MEM-5261334938}
+    export VLLM_V2_CUDAGRAPH_MEM_MIB=${VLLM_V2_CUDAGRAPH_MEM_MIB:-1400}
+  elif [ "$CTX" = "long" ]; then
     # int8 KV: measured 136,429 tokens of pool at DFLASH_TOKENS=7 with prefix caching on
     # (138,696 without), against bf16's 69,758 in the same pinned 5.2 GiB. DFLASH_TOKENS>7
     # at this context is untested -- the graphs and the state pages both grow.
@@ -194,6 +209,9 @@ fi
 # per request (~16% of the KV pool). Hybrid models keep this opt-in upstream.
 if [ "${PREFIX_CACHE:-0}" = "1" ]; then
   EXTRA_ARGS="--enable-prefix-caching --mamba-cache-mode align ${EXTRA_ARGS}"
+  # KVarN runs --block-size 128; match the prefix hash unit to its tile so cache
+  # hits land on tile boundaries (a non-multiple of 128 corrupts the pool).
+  [ "$CTX" = "huge" ] && EXTRA_ARGS="--prefix-match-unit 128 ${EXTRA_ARGS}"
 fi
 
 # ASYNC_SCHED=0 (set above for a long DFlash2 verify block) runs the scheduler

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -216,14 +216,18 @@ if [ "${PREFIX_CACHE:-0}" = "1" ]; then
   # that path -- acceptance collapses to ~1 token per step, and on some trees the
   # output degrades outright. It is the capture, not the drafter: eager is clean,
   # and so is PIECEWISE, which keeps the compiled graphs and leaves only the
-  # multi-query verify uncaptured. labd copy@20k through this script, prefix
-  # caching on:
-  #   FULL       1.97 tok/step,  39 tok/s
-  #   PIECEWISE  7.83 tok/step, 130 tok/s
-  # MTP is untouched here: its verify step is short and captures correctly, so
-  # forcing PIECEWISE would cost it decode speed for nothing. Set
-  # CUDAGRAPH_MODE=FULL_AND_PIECEWISE to get the captured verify back once that
-  # is fixed upstream.
+  # multi-query verify uncaptured. It is a trade, not a free win -- dropping the
+  # full decode graphs costs short-prompt throughput (3 runs each, 250 W):
+  #   long context, labd copy@20k   FULL 1.97 tok/step 38 tok/s
+  #                                 PIECEWISE 7.83 tok/step 132 tok/s   (3.5x)
+  #   short prompts, de/en/code     FULL 78/125/202 tok/s
+  #                                 PIECEWISE 74/102/176 tok/s          (-13..18%)
+  # The capture mode is fixed at boot, so CTX=huge takes the trade that matches
+  # what it is for: long shared prefixes. CUDAGRAPH_MODE=FULL_AND_PIECEWISE is
+  # there for a mostly-short-prompt workload, but treat it as unsafe until the
+  # capture bug is understood -- it only cost speed here, it corrupted output on
+  # a bare-metal tree. MTP is untouched either way: its verify step is short and
+  # captures correctly, so forcing PIECEWISE there would cost decode for nothing.
   [ "$SPEC" = "dflash2" ] && [ "$CTX" = "huge" ] &&
     CG_MODE=",\"cudagraph_mode\":\"${CUDAGRAPH_MODE:-PIECEWISE}\""
 fi

--- a/verify.sh
+++ b/verify.sh
@@ -53,6 +53,9 @@ if [ -f "$SP/v1/attention/backends/kvarn_attn.py" ]; then
   if patch -p1 -R --dry-run -s -d "$SP" < kvarn/kvarn-0.27.1.patch >/dev/null 2>&1; then
     $PY -c "from vllm.v1.attention.backends.registry import AttentionBackendEnum; AttentionBackendEnum.KVARN.get_class()" 2>/dev/null && ok "KVarN backend importable, patch applied (KV=kvarn / CTX=huge available)" || fail "KVarN files present but backend does not import"
   else fail "KVarN modules present but kvarn-0.27.1.patch not applied (bash kvarn/install.sh)"; fi
+  if $PY patches/_check_applied.py kvarn/kvarn-v2-runner.patch "$SP" >/dev/null 2>&1; then
+    ok "kvarn-v2-runner.patch applied (SPEC=dflash2 + CTX=huge available)"
+  else warn "kvarn-v2-runner.patch not applied (re-run bash kvarn/install.sh for DFlash2 at 240k)"; fi
 else warn "KVarN not installed (optional; bash kvarn/install.sh for 262k context)"; fi
 
 if [ $INSTALL = 0 ]; then


### PR DESCRIPTION
Your DFlash2 backport and the KVarN cache were the two best things in this repo, and they excluded each other — the V2 runner only knew bf16/fp8 KV. This PR closes that gap: `SPEC=dflash2 CTX=huge PREFIX_CACHE=1` now runs as one server.

**The surprise: no kernel work.** The KVarN Triton kernels run unmodified on the V2 runner. All six fixes in `kvarn/kvarn-v2-runner.patch` are allocator/geometry logic (the patch header documents each one):

1. The drafter's sliding-window layers get a bf16 `cache_config` copy — the SW path has no KVarN support and the drafter doesn't need it.
2. SW specs without a shared page pad to the mamba page under KVarN (otherwise each 16-token SW block burns a full 1.83 MB uniform page — 84% of the pool gone).
3. `_largest_kernel_block_within` scales `MultipleOf` backends to the page budget, preferring divisors of the primary block in 128-steps. 128 is the only block size that divides 2176 (=17×128), satisfies FA2's multiple-of-16, and lands on KVarN's tile — 272 boots and then corrupts the pool.
4. SW groups stay out of the scheduler LCM / hash GCD; an explicit `--prefix-match-unit` now beats the mamba-divergence fallback that silently ate it.
5. Hash-unit assert direction relaxed + the SW manager returns a clean miss instead of asserting (prefix reuse is meaningless for a rolling window anyway).
6. An upstream vLLM bug we hit on the way: `MambaHybridModelState.add_request` seeds the running state column with `cache_config.block_size` instead of the mamba group's block size. With `--block-size 128` a resume from a 100k cached prefix indexes column 781 of a ~61-column block table → illegal memory access in the align precopy. Filed upstream with the fix: vllm-project/vllm#53142.

**Numbers** (RTX 3090 @ 250 W, fast variant, 10-round averages, WSL2):

| `SPEC=dflash2 CTX=huge PREFIX_CACHE=1` | |
|---|---|
| German / English prose | 79 / 129 tok/s |
| code | 186 tok/s (single runs up to ~225 at 86% draft acceptance, measured via per-round `/metrics` deltas over 20 rounds — an earlier logged 468 spike did not survive instrumented reproduction and was a stream-timing artifact) |
| KV capacity @ 240k max-model-len | 268k tokens |
| 200k-deep needle | correct |
| turn 2 over a 200k cached prefix | 4.4 s (vs ~7.5 min cold) |

That's ~5% under `CTX=fast` DFlash2 decode with 3.75× its context. Speculation stays exact; the only lossy piece is KVarN itself, same as your existing `CTX=huge`.

**What the PR touches:** `kvarn/kvarn-v2-runner.patch` (new, applied by `kvarn/install.sh` as its second stage), the `CTX`/`SPEC` wiring in `single-user/start_qwen.sh` (`CTX=long` stays MTP-only — fp8 KV needs FA3/SM90 or Triton fp8e4nv/SM89+, we checked), a `verify.sh` check, and a README section.

Happy to split anything out, rebase, or run more benches — the setup here is an RTX 3090 under WSL2 (with `VLLM_WSL_PIN_MEMORY=1`; the V2 runner's UVA buffers work fine on the paravirt driver — that blanket ban upstream predates WSL2's current CUDA support and is being filed separately).

