### PR TITLE
Serve images with VISION=1, instead of fighting --language-model-only from EXTRA_ARGS

### DIFF
--- a/batch/start_qwen.sh
+++ b/batch/start_qwen.sh
@@ -13,7 +13,8 @@
 #    change for +2.2% perplexity. Needs both marlin patches from patches/.
 #    INT8_LAYERS=gate_up is the gentler variant (+0.9% PPL, ~+15%);
 #    INT8_ACT= (empty) turns it off entirely (pure W4A16, quality-neutral).
-#  - --language-model-only skips the vision tower entirely (~2.7 GB saved)
+#  - --language-model-only skips the vision tower entirely (0.858 GiB on this
+#    checkpoint); VISION=1 keeps it for a client that sends images
 #  - expandable_segments is required: the DeltaNet prefill kernels allocate
 #    transient workspace and fragment the allocator, OOMs at util >= 0.978 without it
 #  - gpu-memory-utilization 0.972 is the sweet spot on a headless box
@@ -89,6 +90,26 @@ fi
 TOOL_PARSER=${TOOL_PARSER:-qwen3_coder}
 TOOL_ARGS=$([ "${TOOLS:-1}" = 1 ] && echo --enable-auto-tool-choice --tool-call-parser $TOOL_PARSER)
 
+# Vision. --language-model-only drops the vision tower cleanly -- no weights loaded,
+# 0.858 GiB on this checkpoint (gotcha 9) -- and stays the default. VISION=1 keeps
+# the tower, for a client that sends images: screenshots into a coding assistant,
+# captioning, document photos.
+#
+# Only --language-model-only needs a knob. It is hardcoded in the exec line below, so
+# the alternative is countering it with --no-language-model-only from EXTRA_ARGS and
+# depending on which flag argparse saw last -- which regresses silently: images are
+# still accepted and still counted as prompt tokens, and the model answers from
+# placeholder embeddings. The two flags VISION=1 adds have no such conflict and can
+# be overridden from EXTRA_ARGS, which is expanded after them. The pixel cap is
+# shipped rather than left to the processor default because vLLM profiles the encoder
+# at the largest image it will accept, and that peak comes out of the KV pool:
+# 2097152 px = 2048 image tokens.
+if [ "${VISION:-0}" = 1 ]; then
+  VISION_ARGS='--limit-mm-per-prompt {"image":{"count":1}} --mm-processor-kwargs {"size":{"shortest_edge":65536,"longest_edge":2097152}}'
+else
+  VISION_ARGS="--language-model-only"
+fi
+
 export PATH="$REPO/venv/bin:$PATH"
 # Overridable for WSL2 (see single-user/start_qwen.sh).
 export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
@@ -110,7 +131,7 @@ exec venv/bin/vllm serve "$MODEL" \
   --max-model-len $MAX_LEN \
   --max-num-seqs $MAX_SEQS \
   --api-server-count $API_SERVERS \
-  --language-model-only \
+  ${VISION_ARGS} \
   $KV_ARGS \
   --mamba-ssm-cache-dtype float16 \
   --async-scheduling \

--- a/batch/start_qwen.sh
+++ b/batch/start_qwen.sh
@@ -13,7 +13,8 @@
 #    change for +2.2% perplexity. Needs both marlin patches from patches/.
 #    INT8_LAYERS=gate_up is the gentler variant (+0.9% PPL, ~+15%);
 #    INT8_ACT= (empty) turns it off entirely (pure W4A16, quality-neutral).
-#  - --language-model-only skips the vision tower entirely (~2.7 GB saved)
+#  - --language-model-only skips the vision tower entirely (0.87 GiB on this
+#    checkpoint); VISION=1 keeps it for a client that sends images
 #  - expandable_segments is required: the DeltaNet prefill kernels allocate
 #    transient workspace and fragment the allocator, OOMs at util >= 0.978 without it
 #  - gpu-memory-utilization 0.972 is the sweet spot on a headless box
@@ -89,6 +90,30 @@ fi
 TOOL_PARSER=${TOOL_PARSER:-qwen3_coder}
 TOOL_ARGS=$([ "${TOOLS:-1}" = 1 ] && echo --enable-auto-tool-choice --tool-call-parser $TOOL_PARSER)
 
+# Vision. --language-model-only drops the vision tower cleanly -- no weights loaded,
+# 2.7 GB saved (gotcha 9) -- which is right for a text-only server and stays the
+# default. VISION=1 keeps the tower, for a client that sends images: screenshots
+# into a coding assistant, captioning, document photos.
+#
+# The pixel cap is the part worth setting rather than leaving to the processor
+# default: vLLM profiles the encoder at the largest image the processor will accept,
+# and that profiled peak comes out of the KV pool. VISION_MAX_PIXELS=2097152 is
+# 2048 image tokens.
+#
+# This is not something EXTRA_ARGS can do safely: --language-model-only would still
+# be passed below, and whether vision came on would depend on which flag argparse
+# saw last. It also regresses silently -- images are still accepted and still
+# counted as prompt tokens, and the model answers from placeholder embeddings.
+VISION_IMAGES=${VISION_IMAGES:-1}
+VISION_MIN_PIXELS=${VISION_MIN_PIXELS:-65536}
+VISION_MAX_PIXELS=${VISION_MAX_PIXELS:-2097152}
+if [ "${VISION:-0}" = 1 ]; then
+  VISION_ARGS="--limit-mm-per-prompt {\"image\":{\"count\":$VISION_IMAGES}}"
+  VISION_ARGS="$VISION_ARGS --mm-processor-kwargs {\"size\":{\"shortest_edge\":$VISION_MIN_PIXELS,\"longest_edge\":$VISION_MAX_PIXELS}}"
+else
+  VISION_ARGS="--language-model-only"
+fi
+
 export PATH="$REPO/venv/bin:$PATH"
 # Overridable for WSL2 (see single-user/start_qwen.sh).
 export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
@@ -110,7 +135,7 @@ exec venv/bin/vllm serve "$MODEL" \
   --max-model-len $MAX_LEN \
   --max-num-seqs $MAX_SEQS \
   --api-server-count $API_SERVERS \
-  --language-model-only \
+  ${VISION_ARGS} \
   $KV_ARGS \
   --mamba-ssm-cache-dtype float16 \
   --async-scheduling \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 #   docker compose run --rm single verify     # verify.sh inside the container
 #
 # Knobs go in a .env file next to this file (never committed): VLLM_API_KEY=...,
-# and any of the start-script variables (CTX, KV, MAX_LEN, MAX_SEQS, GPU_UTIL,
+# and any of the start-script variables (CTX, KV, MAX_LEN, MAX_SEQS, GPU_UTIL, VISION,
 # SPEC_ATTN, DRAFT_TOKENS, EXTRA_ARGS, ...) — .env is passed straight into the
 # container. Fastest single-user decode, if the card is yours alone (README,
 # "If you are the only user"; the drafter it needs is already downloaded by

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -42,7 +42,19 @@ Things that each cost us hours, in rough order of pain. Worth skimming before yo
 8. **Benchmark twice.** The first run after any restart includes JIT warmup
    and reads 30-50% low.
 9. **`--language-model-only` drops the vision tower cleanly** (no weights
-   loaded). If you don't need images, that's 2.7 GB.
+   loaded), and it is the default in both start scripts. `VISION=1` keeps the
+   tower for a client that sends images. The tower is **0.858 GiB**, not the
+   2.7 GB this entry used to give: `model.visual.*` sums to 0.858 GiB of BF16 in both
+   `Qwen3.8-27B-W4A16-AutoRound` and the `-fast` variant, and a runtime A/B
+   agrees — model loading reads 15.13 GiB against 14.26 with
+   `--language-model-only`, same server, same config, with non-weight overhead
+   0.42 against 0.41 GiB either way. Quantization is not the explanation: the
+   tower is BF16 in both dirs. Where 2.7 GB came from I could not work out.
+   The KV pool came out within 0.4% across that pair (183,673 against 184,438
+   tokens at 150k/fp8) — but the profiled activation peak differed by 0.87 GiB
+   between those two starts, which is the same run-to-run swing the V2 runner
+   shows, so read the pool difference as noise rather than as a measurement of
+   what the tower costs.
 10. **`prompt_logprobs` on long prompts OOMs the engine at 0.972 utilization**
     (a 300-token prompt needs ~300 MB of fp32 logits and there is no headroom).
     Run quality checks at 0.93.

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -42,7 +42,15 @@ Things that each cost us hours, in rough order of pain. Worth skimming before yo
 8. **Benchmark twice.** The first run after any restart includes JIT warmup
    and reads 30-50% low.
 9. **`--language-model-only` drops the vision tower cleanly** (no weights
-   loaded). If you don't need images, that's 2.7 GB.
+   loaded), and it is the default in both start scripts. `VISION=1` keeps the
+   tower for a client that sends images. On the W4A16 checkpoint the tower is
+   **0.87 GiB**, not the 2.7 GB of the bf16 original: model loading reads 15.13
+   GiB against 14.26 with `--language-model-only`, same server, same config.
+   The KV pool came out within 0.4% across that pair (183,673 against 184,438
+   tokens at 150k/fp8) — but the profiled activation peak differed by 0.87 GiB
+   between those two starts, which is the same run-to-run swing the V2 runner
+   shows, so read the pool difference as noise rather than as a measurement of
+   what the tower costs.
 10. **`prompt_logprobs` on long prompts OOMs the engine at 0.972 utilization**
     (a 300-token prompt needs ~300 MB of fp32 logits and there is no headroom).
     Run quality checks at 0.93.

--- a/single-user/README.md
+++ b/single-user/README.md
@@ -368,6 +368,7 @@ included (`tools` + `tool_choice: "auto"` come back as `tool_calls`).
 | `GPU_UTIL` | 0.93 | soak-tested with a 100k prompt and 4×6k-token generations; batch mode's 0.972 OOMs in the MTP path (docs/gotchas.md, gotcha 4) |
 | `MTP_DRAFT_VOCAB` | 1 | set 0 to draft with the full lm_head (more acceptance, slower per draft) |
 | `TOOLS` | 1 | tool/function calling (`--enable-auto-tool-choice --tool-call-parser`). `TOOL_PARSER` (`qwen3_coder`) must match the XML call format this model's chat template emits — `hermes` parses the JSON a Qwen model does *not* produce here, and fails silently. 0 = off, and `tool_choice: "auto"` then 400s |
+| `VISION` | 0 | 1 keeps the vision tower instead of `--language-model-only` (0.858 GiB of BF16 weights on this checkpoint), for a client that sends images: one image per prompt and a 2048-image-token pixel cap, both overridable from `EXTRA_ARGS` |
 | `PORT` | 18020 | |
 
 ## Switching modes

--- a/single-user/README.md
+++ b/single-user/README.md
@@ -368,6 +368,7 @@ included (`tools` + `tool_choice: "auto"` come back as `tool_calls`).
 | `GPU_UTIL` | 0.93 | soak-tested with a 100k prompt and 4×6k-token generations; batch mode's 0.972 OOMs in the MTP path (docs/gotchas.md, gotcha 4) |
 | `MTP_DRAFT_VOCAB` | 1 | set 0 to draft with the full lm_head (more acceptance, slower per draft) |
 | `TOOLS` | 1 | tool/function calling (`--enable-auto-tool-choice --tool-call-parser`). `TOOL_PARSER` (`qwen3_coder`) must match the XML call format this model's chat template emits — `hermes` parses the JSON a Qwen model does *not* produce here, and fails silently. 0 = off, and `tool_choice: "auto"` then 400s |
+| `VISION` | 0 | 1 keeps the vision tower instead of `--language-model-only` (0.87 GiB of weights on this checkpoint), for a client that sends images. `VISION_IMAGES` (1) images per prompt, `VISION_MIN_PIXELS` (65536) / `VISION_MAX_PIXELS` (2097152 = 2048 image tokens) the processor's resize bounds — the cap is worth setting because vLLM profiles the encoder at the largest image it will accept, and that profiled peak comes out of the KV pool |
 | `PORT` | 18020 | |
 
 ## Switching modes

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -275,6 +275,30 @@ ASYNC_ARGS=$([ "${ASYNC_SCHED:-1}" = 1 ] && echo --async-scheduling || echo --no
 TOOL_PARSER=${TOOL_PARSER:-qwen3_coder}
 TOOL_ARGS=$([ "${TOOLS:-1}" = 1 ] && echo --enable-auto-tool-choice --tool-call-parser $TOOL_PARSER)
 
+# Vision. --language-model-only drops the vision tower cleanly -- no weights loaded,
+# 2.7 GB saved (gotcha 9) -- which is right for a text-only server and stays the
+# default. VISION=1 keeps the tower, for a client that sends images: screenshots
+# into a coding assistant, captioning, document photos.
+#
+# The pixel cap is the part worth setting rather than leaving to the processor
+# default: vLLM profiles the encoder at the largest image the processor will accept,
+# and that profiled peak comes out of the KV pool. VISION_MAX_PIXELS=2097152 is
+# 2048 image tokens.
+#
+# This is not something EXTRA_ARGS can do safely: --language-model-only would still
+# be passed below, and whether vision came on would depend on which flag argparse
+# saw last. It also regresses silently -- images are still accepted and still
+# counted as prompt tokens, and the model answers from placeholder embeddings.
+VISION_IMAGES=${VISION_IMAGES:-1}
+VISION_MIN_PIXELS=${VISION_MIN_PIXELS:-65536}
+VISION_MAX_PIXELS=${VISION_MAX_PIXELS:-2097152}
+if [ "${VISION:-0}" = 1 ]; then
+  VISION_ARGS="--limit-mm-per-prompt {\"image\":{\"count\":$VISION_IMAGES}}"
+  VISION_ARGS="$VISION_ARGS --mm-processor-kwargs {\"size\":{\"shortest_edge\":$VISION_MIN_PIXELS,\"longest_edge\":$VISION_MAX_PIXELS}}"
+else
+  VISION_ARGS="--language-model-only"
+fi
+
 export PATH="$REPO/venv/bin:$PATH"
 # Overridable: expandable_segments needs CUDA VMM, which WSL2's paravirt
 # driver rejects ("CUDA driver error: device not ready" during Marlin repack)
@@ -293,7 +317,7 @@ exec venv/bin/vllm serve "$MODEL" \
   --max-model-len $MAX_LEN \
   --max-num-seqs $MAX_SEQS \
   --api-server-count $API_SERVERS \
-  --language-model-only \
+  ${VISION_ARGS} \
   $ATTN_ARGS \
   --mamba-ssm-cache-dtype float16 \
   ${ASYNC_ARGS} \

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -275,6 +275,26 @@ ASYNC_ARGS=$([ "${ASYNC_SCHED:-1}" = 1 ] && echo --async-scheduling || echo --no
 TOOL_PARSER=${TOOL_PARSER:-qwen3_coder}
 TOOL_ARGS=$([ "${TOOLS:-1}" = 1 ] && echo --enable-auto-tool-choice --tool-call-parser $TOOL_PARSER)
 
+# Vision. --language-model-only drops the vision tower cleanly -- no weights loaded,
+# 0.858 GiB on this checkpoint (gotcha 9) -- and stays the default. VISION=1 keeps
+# the tower, for a client that sends images: screenshots into a coding assistant,
+# captioning, document photos.
+#
+# Only --language-model-only needs a knob. It is hardcoded in the exec line below, so
+# the alternative is countering it with --no-language-model-only from EXTRA_ARGS and
+# depending on which flag argparse saw last -- which regresses silently: images are
+# still accepted and still counted as prompt tokens, and the model answers from
+# placeholder embeddings. The two flags VISION=1 adds have no such conflict and can
+# be overridden from EXTRA_ARGS, which is expanded after them. The pixel cap is
+# shipped rather than left to the processor default because vLLM profiles the encoder
+# at the largest image it will accept, and that peak comes out of the KV pool:
+# 2097152 px = 2048 image tokens.
+if [ "${VISION:-0}" = 1 ]; then
+  VISION_ARGS='--limit-mm-per-prompt {"image":{"count":1}} --mm-processor-kwargs {"size":{"shortest_edge":65536,"longest_edge":2097152}}'
+else
+  VISION_ARGS="--language-model-only"
+fi
+
 export PATH="$REPO/venv/bin:$PATH"
 # Overridable: expandable_segments needs CUDA VMM, which WSL2's paravirt
 # driver rejects ("CUDA driver error: device not ready" during Marlin repack)
@@ -293,7 +313,7 @@ exec venv/bin/vllm serve "$MODEL" \
   --max-model-len $MAX_LEN \
   --max-num-seqs $MAX_SEQS \
   --api-server-count $API_SERVERS \
-  --language-model-only \
+  ${VISION_ARGS} \
   $ATTN_ARGS \
   --mamba-ssm-cache-dtype float16 \
   ${ASYNC_ARGS} \


### PR DESCRIPTION
## The problem

`--language-model-only` is hardcoded in both exec lines, so the only way to serve
images is to pass `--no-language-model-only` through `EXTRA_ARGS` and rely on
argparse taking the last flag. That works today only because `${EXTRA_ARGS}` is
expanded last — this update moved `${TOOL_ARGS}` in one line above it.

The failure mode when it does break is the bad kind: nothing errors. Images are
still accepted, still counted as prompt tokens, and the model answers from
placeholder embeddings — which reads as the model being bad at vision rather than
as a server that quietly dropped the tower.

## The change

One knob, `VISION`, in both start scripts, in the same shape as `TOOLS`:

- `VISION=0` (default) → `--language-model-only`, exactly as now. The command line
  is unchanged for anyone who does not set it.
- `VISION=1` → `--limit-mm-per-prompt {"image":{"count":1}}` plus a 2048-image-token
  pixel cap.

Only `--language-model-only` gets a knob, because it is the only one that cannot be
countered from `EXTRA_ARGS`. The two flags `VISION=1` adds have no competing
hardcoded flag and stay overridable there, since `${EXTRA_ARGS}` is expanded after
them. The pixel cap is shipped rather than left to the processor default because
vLLM profiles the encoder at the largest image it will accept, and that peak comes
out of the KV pool.

## Gotcha 9's 2.7 GB does not hold on these checkpoints

The tower is **0.858 GiB**, confirmed two independent ways:

- `model.visual.*` sums to 0.858 GiB of BF16, read from the safetensors headers, in
  both `Qwen3.8-27B-W4A16-AutoRound` and the `-fast` variant.
- A runtime A/B on one server, one variable changed (`CTX=long`, `PREFIX_CACHE=1`,
  `SPEC=mtp`, fast variant, RTX 3090): model loading 15.13 GiB with the tower against
  14.26 without. Non-weight overhead comes to 0.42 GiB and 0.41 GiB respectively, so
  the delta is the tower and not something else.

Quantization is not the explanation — the tower is BF16 in both dirs. Where the
2.7 GB came from I could not work out, so the entry now gives the measured figure and
says as much.

I am also not claiming the KV pool difference means anything. It came out within 0.4%
across that pair (183,673 against 184,438 tokens at 150k/fp8), but the profiled
activation peak differed by 0.87 GiB between the two starts — the same run-to-run
swing the V2 runner shows — which is larger than the effect being measured.

## Testing

- `VISION=0`: loads 14.26 GiB and logs `running in text-only mode` — the pre-change
  path, unchanged.
- `VISION=1`: 15.13 GiB and 183,673 tokens, identical to the same server run with the
  old `EXTRA_ARGS` trick, so the knob is behaviour-preserving rather than a new path.
- OCR round-trip through `/v1/messages` (rendered text in a PNG, transcribed back):
  3/3 exact.
- Tool calling unaffected alongside it (`qwen3_coder`, real `tool_use` block).
- C1 decode 84.4 tok/s against 84.3 before the change.
- `bash -n` on both scripts; `docker compose build` clean, all 14 patches PASS.

Docs: gotcha 9, a `VISION` row in the single-user Knobs table, the compose knob list,
and the batch script header.

---

NOTE:
To be clear, while I looked at these changes and it seemed reasonable to me and I'm a software developer, this is not an area where I have expertise, and I did not make these changes myself.
I did not run extensive benchmarking, as this is a knob that defaults to off, it maintains existing functionality, but creates an easy access point to enable a feature some people might want.