### PR TITLE
Add mode-aware vision tower placement

### DIFF
--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -340,3 +340,19 @@ Things that each cost us hours, in rough order of pain. Worth skimming before yo
     instead of length; `bench/labd_bench.py` sends two warm-ups on `doc[:4000]`,
     which arms the trigger for everything after it. `bench/bugb_sweep.py` prints
     the `mod 128` column for this.
+
+14. **The vision tower cannot be selected by vLLM's built-in offloader.**
+    `--cpu-offload-params` only matches modules built through `make_layers()`
+    (the decoder), on names *relative to the wrapped module* — the Qwen3.5
+    tower is one module constructed directly in `__init__` (names
+    `blocks.N` / `merger` / `patch_embed`), so it can never match `visual`
+    from the CLI, and a bare `--cpu-offload-gb N` takes the first N GB of
+    decoder layers — exactly the weights read on every decode step.
+    `patches/qwen3_5-visual-uva.patch` routes the tower through the same
+    UVAOffloader after `load_weights` (what `VISION=uva` in the single-user
+    script uses); it is a no-op on pure-text servers. Related trap: any
+    vision-enabled start must cap `max_pixels` (the script sets 1M) and the
+    modality counts (four images, video disabled by default). The checkpoint's
+    16.7M-pixel / 768-frame defaults make profiling and request memory unsafe
+    on 24 GB; enable video only with an explicit small `VISION_VIDEOS` plus
+    frame/size limits.

--- a/patches/qwen3_5-visual-uva.patch
+++ b/patches/qwen3_5-visual-uva.patch
@@ -1,0 +1,123 @@
+CPU-resident vision tower for Qwen3.8-27B (vLLM 0.27.1).
+
+Qwen3.8 is a VL checkpoint: the Qwen3_5ForConditionalGeneration target model
+carries a 921 MB BF16 vision tower (27-layer ViT, hidden 1152).
+--language-model-only drops it entirely; without this patch there is no way
+to keep the *tower* out of the GPU selectively. vLLM's built-in offloader
+(UVAOffloader: --offload-backend uva --cpu-offload-gb N
+--cpu-offload-params <segments>) only wraps modules built through
+make_layers() (the decoder), and its segment matching runs against names
+*relative to the wrapped module* - so the tower, one module constructed
+directly in __init__ with names like blocks.N / merger / patch_embed, can
+never match "visual" from the CLI. (The non-selective budget mode is worse:
+it takes the first N GB of *decoder* layers, i.e. exactly the weights read
+on every decode step.)
+
+The patch routes the tower through the same UVAOffloader once
+load_weights() is done: weights move to pinned CPU memory and the GPU
+dereferences them over PCIe (zero-copy UVA view) whenever the encoder runs.
+The tower only executes during image prefill, never per decode step. On this
+3090/WSL2 box a 768x512 image's warm TTFT was ~1.42 s with UVA vs ~0.45 s
+with GPU weights (image/interconnect dependent); the KV pool keeps the ~0.9
+GB the tower weights would otherwise occupy, while encoder profile/cache
+still consume some GPU memory. That is what lets CTX=fast
+(bf16 KV, 64 KB per token) run with vision and still hold the full 65,536
+context: the measured pool is 72,475 tokens, and the tower on the GPU would
+shrink it to ~56k, which does not fit 64k.
+
+Only active when the server is started with UVA offloading and exactly
+--cpu-offload-params visual (--offload-backend uva --cpu-offload-gb > 0); on
+a pure-text start it is a no-op, and visual matches no decoder parameter, so the
+built-in offloader's LLM side stays empty either way. If the UVA view is
+unavailable (e.g. VLLM_WSL2_ENABLE_PIN_MEMORY unset, or
+VLLM_WEIGHT_OFFLOADING_DISABLE_UVA=1), UVAOffloader falls back to copying
+the tower to the GPU per forward - still prefill-only, ~40-60 ms per image
+on this box.
+
+MTP and DFlash2 speculation are both covered: they use
+Qwen3_5ForConditionalGeneration as the target model (the MTP draft module
+carries no visual). Not patched: Qwen3_5MoeForConditionalGeneration
+(MoE checkpoints only; the same ten lines would port).
+
+Apply from the repo root:
+  patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/qwen3_5-visual-uva.patch
+--- a/model_executor/models/qwen3_5.py
++++ b/model_executor/models/qwen3_5.py
+@@ -475,6 +475,7 @@
+         )
+         self.visual_dim = config.vision_config.out_hidden_size
+         self.multiscale_dim = self.visual_dim * self.deepstack_num_level
++        self.vllm_config = vllm_config
+ 
+         with self._mark_tower_model(vllm_config, {"image", "video"}):
+             self.visual = Qwen3_VisionTransformer(
+@@ -568,7 +569,68 @@
+             self,
+             skip_prefixes=["mtp."],
+         )
+-        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
++        result = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
++        self._offload_visual_tower()
++        return result
++
++    def _offload_visual_tower(self) -> None:
++        """Move the BF16 vision tower to CPU memory after weight loading.
++
++        vLLM's built-in offloader only wraps modules built through
++        make_layers() (the decoder), and --cpu-offload-params matches on
++        relative parameter names, so the tower - one module constructed
++        directly in __init__, with names like blocks.N / merger /
++        patch_embed - can never be selected from the CLI. This routes it
++        through the same UVAOffloader once all weights are in place:
++        parameters move to pinned CPU memory and the GPU dereferences them
++        over PCIe (zero-copy UVA) whenever the encoder runs. The tower only
++        executes during image prefill, never per decode step. On this
++        3090/WSL2 box a 768x512 image's warm TTFT was ~1.42 s with UVA vs
++        ~0.45 s with GPU weights (image/interconnect dependent); the KV
++        pool keeps the ~0.9 GB tower-weight allocation, while encoder
++        profile/cache still consume some GPU memory. No-op unless the
++        server was started with UVA offloading (the repo's start script
++        does that for VISION=uva); pure-text servers are unaffected.
++        """
++        if getattr(self, "_visual_tower_offloaded", False):
++            return
++
++        offload_config = self.vllm_config.offload_config
++        if offload_config is None:
++            return
++        backend = offload_config.offload_backend
++        if backend == "auto" and offload_config.uva.cpu_offload_gb > 0:
++            backend = "uva"
++        if backend != "uva":
++            return
++        # This dedicated wrapper has its own byte counter. Restrict it to the
++        # repo's visual-only configuration so the CLI budget cannot be spent
++        # once by the global decoder offloader and again by this tower wrapper.
++        # It also keeps --cpu-offload-params experts (for example) from
++        # unexpectedly moving the vision tower.
++        if offload_config.uva.cpu_offload_params != {"visual"}:
++            return
++        from vllm.model_executor.offloader.uva import UVAOffloader
++
++        budget = int(offload_config.uva.cpu_offload_gb * 1024**3)
++        tower_bytes = sum(p.numel() * p.element_size() for p in self.visual.parameters())
++        if budget < tower_bytes:
++            required_gib = tower_bytes / 1024**3
++            raise ValueError(
++                f"Visual UVA budget is too small: --cpu-offload-gb must be "
++                f">= {required_gib:.2f} GiB (got "
++                f"{offload_config.uva.cpu_offload_gb:.2f})"
++            )
++
++        offloader = UVAOffloader(
++            cpu_offload_max_bytes=budget,
++            # Empty set = every parameter of the wrapped module. The CLI's
++            # "visual" segment would not match the tower's relative names,
++            # so scope the wrapper to the tower itself instead.
++            cpu_offload_params=set(),
++        )
++        offloader.wrap_modules(iter((self.visual,)))
++        self._visual_tower_offloaded = True
+ 
+     @classmethod
+     def get_mamba_state_dtype_from_config(

--- a/single-user/README.md
+++ b/single-user/README.md
@@ -351,12 +351,29 @@ Point your chat client at `http://<host>:18020/v1` with the key from
 `api_key.txt`. Works with anything that speaks the OpenAI API, tool calling
 included (`tools` + `tool_choice: "auto"` come back as `tool_calls`).
 
+## Vision
+
+Qwen3.8 is a VL checkpoint; with `VISION` set (see the knobs table;
+`VISION=auto` enables adaptive placement) the server takes images through the
+standard OpenAI chat API —
+`{"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}`.
+Both tower modes cap images at 1M pixels (1,024 visual tokens), allow four
+images per prompt, and disable video by default; set `VISION_IMAGES` /
+`VISION_VIDEOS` explicitly to change those limits. `uva` needs
+`VLLM_WSL2_ENABLE_PIN_MEMORY=1` on
+WSL2 for the zero-copy path (it is in the sample `.env`) and falls back to a
+per-image PCIe copy otherwise. In `uva` mode each encoder-cache miss reads the
+vision weights over PCIe; text-only requests never execute the tower and retain
+the `VISION=0` decode performance. On this 3090/WSL2 box a 768×512 image's warm
+TTFT was ~1.42 s with UVA vs ~0.45 s on GPU (image/hardware dependent).
+
 ## Knobs
 
 | var | default | notes |
 |---|---|---|
 | `MODEL` | `models/Qwen3.8-27B-W4A16-AutoRound-fast` if present, else the base dir | the fast variant (`prepare/fetch_fast_variant.py`) is +15% |
 | `CTX` | `fast` | `fast`: bf16 KV / FlashAttention / 64k / 4 drafts / split-KV attention. `long`: fp8 KV / FlashInfer / 150k / 3 drafts, ~15% slower at C1, faster from C4 up. `huge`: KVarN 4/2-bit KV / 200k / 3 drafts (needs `bash kvarn/install.sh`; docs/long-context.md) — buys 1.7x the pool for **half the decode rate past ~100k** (32.0 vs 68.1 tok/s at 112k), so take it when the request would not otherwise fit, not for speed |
+| `VISION` | 0 | 0 = pure text (`--language-model-only`). `gpu` = tower in VRAM, images capped at 1M pixels. Measured `CTX=long` pools: ~210k (`0`), ~207k (`uva`), ~182-183k (`gpu`); all retain full 150k. `uva` keeps the 0.86 GiB weights in pinned CPU RAM (`patches/qwen3_5-visual-uva.patch`) but encoder profile/cache still consumes some GPU memory; a 768×512 image added ~0.97 s warm TTFT vs GPU on this box. `auto` = `gpu` for `CTX=long`, `uva` otherwise: long spends 24k pool tokens for lower image latency and still fits 150k; fast/huge prioritize capacity. `VISION_IMAGES` (4) / `VISION_VIDEOS` (0) set per-prompt modality limits |
 | `PREFIX_CACHE` | 0 | 1 = reuse a shared prompt prefix across requests (`--enable-prefix-caching --mamba-cache-mode align`): 20x faster follow-up turns, ~16% smaller KV pool |
 | `LOOKUP` | 1 (`SPEC=dflash2`) | draft from the request's own context when it repeats itself (`patches/dflash2-lookup-drafting.patch`), and fill the verify positions the drafter's block does not reach. `VLLM_DFLASH2_LOOKUP_NMIN` (6) is the shortest suffix that may match, `_NMAX` (12) the longest — the kernel prefers the longest match and breaks ties by recency, so a higher cap makes it choose an older long match over a newer short one, which is the worse predictor — `_NSTRONG` (6) the match length trusted on its own, `_AGREE` (0) how many tokens the drafter must independently agree on for a shorter match to be taken, `_NMIN_TAIL` (4) the same for positions the drafter never proposed, `_ADAPTIVE` (1 = ask the scheduler for the long block only while a copy is running, 0 = always long), `_LONGMIN` (6) the match length that counts as a fillable tail, `_STICKY` (3) steps to hold the long block after the flag drops, with one request in flight only — copies do not end when the flag says so, and re-entry costs two steps, but the counter is batch-wide and holding it across a mixed batch makes the block length depend on when the other requests arrived — `_CHEAP_CTX` (0 = off) a context length below which the long block is taken unconditionally |
 | `SPEC` | `mtp` | `dflash2`: the DFlash2 block drafter (`prepare/fetch_dflash2.py`; `CTX=fast` or `CTX=long`, V2 model runner). `DRAFT` overrides the drafter dir, `DFLASH_TOKENS` (7) the *verify* block — the drafter always proposes the 7 it was trained for, and 15 here is reproduction mode (4 request slots, 56k context) — `DFLASH_MAX_LEN` (65536, or 57344 at `DFLASH_TOKENS=15`) the context, `KV_MEM` (5583457484 = 5.2 GiB) pins the KV pool — set `KV_MEM=` to size it from `GPU_UTIL` instead; `VLLM_DFLASH2_DRAFT_TOPK_TOPP=0` disables the proposal truncation, `VLLM_DFLASH2_TORCH_TOPK=1` avoids the FlashInfer top-k JIT |

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -60,6 +60,32 @@ API_SERVERS=${API_SERVERS:-1}
 #           falling from 2.56 to 2.38 tokens per step. Take it when the request
 #           would not otherwise fit, not for speed (see docs/long-context.md).
 CTX=${CTX:-fast}
+# VISION: where the 921 MB BF16 vision tower lives (Qwen3.8 is a VL checkpoint).
+#  auto (recommended when you want images): CTX=long -> gpu, otherwise uva.
+#  gpu: tower in VRAM. On tested CTX=long starts the KV pool is ~182-183k
+#       vs ~210k with VISION=0, so the full 150k max still
+#       fits. Explicit gpu on CTX=fast remains conservative at 54k.
+#  uva: tower in pinned CPU RAM (patches/qwen3_5-visual-uva.patch); only the
+#       encoder profile/cache stays on GPU (long pool: 206,632). A 768x512
+#       image added ~0.97 s warm TTFT vs gpu on this WSL2 box (hardware/image
+#       dependent), but text requests never read the tower.
+#  0 (default): pure text, --language-model-only, all published numbers hold.
+# Both tower modes cap images at 1M pixels (1024 visual tokens each), allow up
+# to VISION_IMAGES=4 images and disable video by default (VISION_VIDEOS=0).
+# The checkpoint's 16.7M-pixel / 768-frame defaults are unsafe on 24 GB.
+VISION=${VISION:-0}
+[ "$VISION" = auto ] && { [ "$CTX" = long ] && VISION=gpu || VISION=uva; }
+case "$VISION" in
+  0) VISION_ARGS="--language-model-only" ;;
+  gpu|uva)
+    VISION_ARGS="--limit-mm-per-prompt {\"image\":${VISION_IMAGES:-4},\"video\":${VISION_VIDEOS:-0}} --mm-processor-kwargs {\"max_pixels\":1048576}"
+    [ "$VISION" = uva ] &&
+      VISION_ARGS="$VISION_ARGS --offload-backend uva --cpu-offload-gb ${UVA_GB:-2} --cpu-offload-params visual"
+    [ "$CTX" = huge ] && [ "$VISION" = gpu ] &&
+      echo "VISION=gpu on CTX=huge: the KVarN pool is a 15% fraction of free memory, so the ~1 GB tower shrinks it - check the pool printed at startup and lower MAX_LEN if 200k no longer fits" >&2
+    ;;
+  *) echo "VISION must be 0, auto, gpu or uva (got: $VISION)" >&2; exit 1 ;;
+esac
 # SPEC=mtp (default): Qwen's own MTP head, k drafts chained (the numbers above).
 # SPEC=dflash2: the DFlash2 block drafter (incoai/Qwen3.8-27B-DFlash2, requantized
 #   to W4A16 by this repo: prepare/fetch_dflash2.py), 7 drafts in ONE non-autoregressive
@@ -71,7 +97,9 @@ SPEC=${SPEC:-mtp}
 # SPEC_ATTN=1: split-KV Triton attention for the multi-query verify step
 # (patches/spec-decode-attn.patch); bf16 KV only, so CTX=fast only.
 if [ "$CTX" = "fast" ]; then
-  MAX_LEN=${MAX_LEN:-65536}
+  # 65,536 fits the measured 68,605-token DFlash2 bf16 pool with VISION=uva;
+  # explicit VISION=gpu is not a shipped preset and conservatively drops to 54k.
+  MAX_LEN=${MAX_LEN:-$([ "$VISION" = gpu ] && echo 54000 || echo 65536)}
   DRAFT_TOKENS=${DRAFT_TOKENS:-4}
   ATTN_ARGS="--attention-backend FLASH_ATTN --kv-cache-dtype bfloat16"
   export VLLM_SPEC_DECODE_ATTN=${SPEC_ATTN:-1}
@@ -81,6 +109,8 @@ elif [ "$CTX" = "huge" ]; then
   ATTN_ARGS="--kv-cache-dtype kvarn_k4v2_g128 --block-size 128"
   export KVARN_POOL_MEM_FRAC=${KVARN_POOL_MEM_FRAC:-0.15}
 else
+  # Measured at 0.93 util + PREFIX_CACHE=1: pool ~210k with VISION=0,
+  # ~207k with UVA, ~182-183k with the 1M-pixel GPU tower. Full 150k fits.
   MAX_LEN=${MAX_LEN:-150000}
   DRAFT_TOKENS=${DRAFT_TOKENS:-3}
   ATTN_ARGS="--kv-cache-dtype fp8"
@@ -293,7 +323,7 @@ exec venv/bin/vllm serve "$MODEL" \
   --max-model-len $MAX_LEN \
   --max-num-seqs $MAX_SEQS \
   --api-server-count $API_SERVERS \
-  --language-model-only \
+  $VISION_ARGS \
   $ATTN_ARGS \
   --mamba-ssm-cache-dtype float16 \
   ${ASYNC_ARGS} \


### PR DESCRIPTION
First, thank you to the original author and contributors for this project. The carefully engineered optimizations in this repository deliver a major leap in Qwen3.8 decoding speed on a single RTX 3090—particularly through speculative decoding, targeted quantization, optimized attention and KV-cache paths, and GPU kernel tuning—making low-latency local inference genuinely practical on this hardware. This PR builds on that high-performance text-inference foundation by enabling the checkpoint's existing vision capability while preserving the text-only default and balancing image latency, VRAM use, and context capacity across operating modes.

## Summary

This PR adds opt-in, mode-aware placement of the Qwen3.8 vision tower for the single-user server:

- `VISION=0` (default): retain the current text-only behavior via `--language-model-only`.
- `VISION=gpu`: keep the vision tower in VRAM for lower image TTFT.
- `VISION=uva`: keep the 0.86 GiB BF16 vision tower in pinned CPU RAM and let the GPU access it through vLLM's UVA zero-copy path during image encoder cache misses.
- `VISION=auto`: use GPU placement for `CTX=long`, and UVA placement for `CTX=fast` / `CTX=huge`.

The default remains `VISION=0`, so existing users retain the current memory use, context limits, and text-only behavior unless vision is explicitly enabled.

## Why a vLLM patch is needed

vLLM 0.27.1 already provides `UVAOffloader`, `--cpu-offload-gb`, and `--cpu-offload-params`, but its normal offloader hook only wraps modules constructed through `make_layers()` (the decoder layers). The Qwen3.5/Qwen3.8 vision tower is constructed directly as one `Qwen3_VisionTransformer` module, and parameter matching is performed against names relative to the wrapped module. Therefore `--cpu-offload-params visual` does not reach the tower, while non-selective offloading would move decoder weights that are read on every decode step.

`patches/qwen3_5-visual-uva.patch` routes the dense `Qwen3_5ForConditionalGeneration.visual` module through the existing `UVAOffloader` after weight loading. It also:

- activates only for the exact visual-only UVA configuration;
- validates that `--cpu-offload-gb` is large enough for the complete tower, avoiding partial offload;
- is idempotent if weight loading is invoked more than once;
- leaves decoder weights untouched;
- is a no-op for text-only and GPU-vision configurations.

The CUDA view retains ownership of the pinned CPU tensor in vLLM's C++ implementation, so the CPU storage remains alive after the local offloader helper returns.

## Placement policy

The `auto` policy reflects measured capacity and latency trade-offs:

- **Fast / DFlash2 / BF16 KV:** UVA preserves the full 65,536-token limit. The measured pool remained 68,605 tokens.
- **Long / MTP / FP8 KV:** GPU placement reduced the pool from approximately 210k tokens (text-only) to approximately 182-183k, but still preserved the full 150,000-token request limit while reducing image TTFT.
- **Huge / KVarN:** UVA prioritizes the context capacity that this mode exists to provide.

On the tested platform, for a 768x512 image with thinking disabled and a one-token streamed response, warm TTFT was approximately:

- GPU tower: 0.45 s
- UVA tower: 1.42 s

The approximately 0.97 s difference is image/interconnect/platform dependent. Text-only requests do not execute the vision encoder, and the selective UVA path does not add vision-weight PCIe reads to text decoding. The main measurable cost of GPU vision placement is reduced KV-cache capacity. Fresh WSL2 starts showed noticeable runtime and speculative-acceptance variance, so decode tok/s should be compared with matched warm runs and per-step timing rather than with a single absolute number.

## Multimodal safety limits

The checkpoint's processor permits very large inputs (16.7M image pixels and up to 768 video frames), which is unsafe as a default on a 24 GiB card. Vision-enabled starts therefore use:

- `max_pixels=1,048,576` (about 1,024 visual tokens per image);
- up to four images per prompt by default (`VISION_IMAGES=4`);
- video disabled by default (`VISION_VIDEOS=0`).

A 2048x2048 input image tokenized to about 1,080 total prompt tokens, confirming that the 1M-pixel resize cap was applied. Four images were accepted; a fifth image was rejected with the expected HTTP 400 limit error.

## Validation

### Test platform

- GPU: NVIDIA GeForce RTX 3090, 24,576 MiB
- NVIDIA driver: 610.88
- Host: Ubuntu 22.04.5 LTS under WSL2
- Kernel: `6.18.33.2-microsoft-standard-WSL2`
- Docker: 29.1.3
- Docker Compose: 2.40.3
- vLLM: 0.27.1
- PyTorch: 2.13.0+cu130
- CUDA runtime/toolkit: 13.0 / nvcc 13.0.88
- Model: the repository's `Qwen3.8-27B-W4A16-AutoRound-fast` variant

### Build and static validation

- Built the Docker image with every `patches/*.patch` applied in repository order.
- `verify.sh --install`: 0 failures.
- Applied all patches to a clean vLLM 0.27.1 source tree.
- Compiled the patched `qwen3_5.py` with `py_compile`.
- `patches/_check_applied.py` passed for the new patch.
- `bash -n single-user/start_qwen.sh` passed.
- `git diff --check` passed.

### Functional vision validation

A generated 768x512 test image contained:

- 2 red squares;
- 3 blue circles;
- 1 green triangle.

Both GPU and UVA modes returned the correct result (`red=2, blue=3, green=1`) through the OpenAI-compatible `image_url` chat API.

### Decode A/B testing

To measure whether vision placement changes pure-text decoding, the same server was restarted for each configuration and tested without sending any images. Each case used greedy sampling, disabled thinking, a fixed 768-token output, streaming timing from the first output token onward, a complete warm-up, and three measured repetitions. We tested 4K single-stream, 4K four-stream, and 50K single-stream prompts for Fast; Long additionally used 100K single-stream prompts. Speculative-decoding acceptance metrics were recorded alongside decode timing.

The most stable comparison was Fast 4K single-stream: `VISION=0` measured 27.96 ms per speculative step and `VISION=uva` measured 27.89 ms per step. The corresponding effective rates were 101.6 and 106.2 tok/s, but UVA accepted 2.969 tokens per step versus 2.856 for text-only, so the tok/s difference came from speculative acceptance rather than a slower or faster decoder step. A second matched run at 50K measured 39.63 ms/step for text-only and 35.63 ms/step for UVA, again with different acceptance (3.084 versus 3.448 tokens/step).

Long-mode absolute tok/s varied more across fresh WSL2 starts: GPU vision measured 61.5/52.0/50.0 tok/s at 4K/50K/100K, while text-only measured 65.1/55.4/60.0 tok/s and UVA measured 78.7/62.3/77.5 tok/s. Since UVA cannot be faster through a vision-weight path that pure-text requests never execute, these results show that startup state, GPU clocks, asynchronous scheduling, and speculative acceptance dominate the cross-restart variance. The reliable result is that the vision tower is absent from the pure-text decode path; GPU placement costs VRAM and KV capacity, while UVA preserves nearly all of that capacity.

### Fast mode: UVA vision plus near-limit context

Observed at startup:

- CPU-offloaded vision parameters: 0.86 GiB
- GPU KV cache: 68,605 tokens
- configured maximum: 65,536 tokens

A combined image + long-text request completed successfully with:

- prompt tokens: 65,304
- total tokens: 65,411
- correct image answer
- HTTP 200 / normal stop

### Long mode: GPU vision plus near-limit context

Observed at startup:

- GPU KV cache: approximately 182-183k tokens
- configured maximum: 150,000 tokens

A combined image + long-text request completed successfully with:

- prompt tokens: 149,654
- total tokens: 149,741
- correct image answer
- HTTP 200 / normal stop
- no CUDA OOM or engine failure after completion

The pure-text decode A/B test above found no measurable Fast UVA decoder-step penalty and did not establish a fixed Long-mode tok/s penalty attributable to the vision tower. The Long-mode trade-off that was consistently measurable was memory capacity.

For comparison, measured long-mode pools on repeated starts were approximately:

- `VISION=0`: 210k
- `VISION=uva`: 207k
- `VISION=gpu`: 182-183k

All three retained the full 150,000-token per-request limit.

## Scope and limitations

- The vLLM patch targets the dense `Qwen3_5ForConditionalGeneration` used by this 27B checkpoint. The MoE conditional-generation class is not patched.
- The patch is written and validated against vLLM 0.27.1, matching this repository.
- UVA requires pinned host memory. On WSL2, `VLLM_WSL2_ENABLE_PIN_MEMORY=1` is required; Windows/WDDM pinned-memory limits still apply.
- Video remains disabled by default. It should only be enabled together with explicit, conservative frame and size limits.

## AI contribution disclosure

The solution design, implementation, code changes, review, and the validation described in this PR were primarily completed by **GPT-5.6-sol**, with the user providing the requirements, access to the RTX 3090 test platform, and supervision of the work.
