### PR TITLE
Issue sweep: WSL allocator default, bench deps, DFLASH_TOKENS framing, fp16 guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ patches, `verify.sh`) — see [Setup](#setup). Then pick a mode:
 ### If you are the only user, do this
 
 The command above starts the conservative default — MTP speculation, 8 request
-slots, 64k context, 120 tok/s greedy at C1. Three settings are worth more than
-every other knob in this repo put together:
+slots, 64k context, 120 tok/s greedy at C1. Two settings are worth more than
+every other knob in this repo put together, and a third is worth a great deal on
+one particular workload:
 
 ```bash
-printf 'SPEC=dflash2\nDFLASH_TOKENS=15\nPREFIX_CACHE=1\n' >> .env
+printf 'SPEC=dflash2\nPREFIX_CACHE=1\n' >> .env
+# add DFLASH_TOKENS=15 if your answers quote your prompts — see below
 docker compose --profile single up -d
 ```
 
@@ -72,7 +74,7 @@ or, in the venv install:
 
 ```bash
 venv/bin/python prepare/fetch_dflash2.py   # once, 1.2 GB (Docker's prepare step does it for you)
-SPEC=dflash2 DFLASH_TOKENS=15 PREFIX_CACHE=1 bash single-user/start_qwen.sh
+SPEC=dflash2 PREFIX_CACHE=1 bash single-user/start_qwen.sh
 ```
 
 `SPEC=dflash2` swaps Qwen's MTP head for the DFlash2 block drafter: 7 tokens
@@ -98,13 +100,24 @@ reproduce them with `venv/bin/python bench/labd_bench.py <tag> --ctx 20000`.</su
 chat client: a second turn against that same 25k-token document takes 0.56 s to
 first token instead of 22.4 s, with the answers unchanged token for token.
 
+**Read that table by column, not by its last cell.** `SPEC=dflash2` is the upgrade
+for everyone; `DFLASH_TOKENS=15` is for one workload. On chat it is worth 1%,
+because the eight positions past the drafter's own block are filled from the
+prompt and a chat answer does not quote the prompt — measured over
+`bench/prompts_real.jsonl`, positions 7-14 take **72 of 11,069 accepted tokens
+(0.65%)**, and @changtimwu measured exactly zero for them on a TP=2 box in
+[#22](https://github.com/syv-ai/qwen38-27b-rtx3090/issues/22). What you pay for
+that 1% is half the request slots and 8k of context, because a 16-token verify
+block doubles the recurrent-state page every resident request holds (1.66 GiB
+against 0.88 by the gotcha-33 fit). So: set it if you are quoting documents or
+applying edits, where it is worth 47%, and leave it at the default 7 for a chat
+or agentic client. `DRAFT_TOKENS`/`DFLASH_TOKENS` is one variable you can flip
+per service.
+
 All of it is lossless: speculative decoding samples the same distribution as no
 speculation at all, the prefix cache resumes recurrent state rather than
-approximating it, and GSM8K reads 96.0-96.5% across the three columns. What
-`DFLASH_TOKENS=15` costs is half the request slots and 8k of context, because a
-16-token verify block doubles the recurrent-state page every resident request
-holds (1.66 GiB against 0.88 by the gotcha-33 fit) — so it is opt-in, and it is a one-user setting
-even by the standards of a mode that is already one-user
+approximating it, and GSM8K reads 96.0-96.5% across the three columns.
+`SPEC=dflash2` is a one-user mode either way
 (see [concurrency](#dflash2-at-240k-ctxhuge-kvarn-also-combines-with-specdflash2)).
 Every other knob: [single-user/](single-user/).
 

--- a/batch/start_qwen.sh
+++ b/batch/start_qwen.sh
@@ -111,8 +111,16 @@ else
 fi
 
 export PATH="$REPO/venv/bin:$PATH"
-# Overridable for WSL2 (see single-user/start_qwen.sh).
-export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
+# Off under WSL, where the VMM calls break Marlin repack — see the long note in
+# single-user/start_qwen.sh. Overridable both ways.
+if grep -qi microsoft /proc/sys/kernel/osrelease 2>/dev/null || [ -n "${WSL_DISTRO_NAME:-}" ]; then
+  ALLOC_DEFAULT=expandable_segments:False
+  [ -z "${PYTORCH_CUDA_ALLOC_CONF:-}" ] && echo \
+    "WSL detected: PYTORCH_CUDA_ALLOC_CONF=$ALLOC_DEFAULT (VMM breaks Marlin repack under the paravirt driver; set it explicitly to override)"
+else
+  ALLOC_DEFAULT=expandable_segments:True
+fi
+export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-$ALLOC_DEFAULT}
 # flashinfer's sampling.cu does not build with older system nvcc (12.0);
 # the attention kernels JIT fine. Remove this if you have a recent CUDA toolkit.
 export VLLM_USE_FLASHINFER_SAMPLER=0

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -8,3 +8,11 @@ compressed-tensors==0.17.0
 huggingface_hub==1.27.0
 hf_transfer==0.1.9
 ninja==1.13.0
+# bench/run_benchmarks.sh calls `vllm bench serve`, whose dataset loader imports
+# pandas through a PlaceholderModule -- so without this every cohort dies on
+# "Please install vllm[bench] for bench support" and the fix is not obvious from
+# the message (#22). Installing the vllm[bench] extra instead would reinstall
+# vLLM and revert the whole patch stack. Only pandas is needed: the extra's other
+# members are for HF-hosted --dataset-name values and the plotting subcommands,
+# and this repo's scripts use only `random` and `custom`.
+pandas==3.0.5

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -70,7 +70,7 @@ signatures and earlier five-profile matrix are in [issue #1](https://github.com/
 | `batch`, `KV=int4pth` | 437,414 tokens | 1,043.84 / 1,044.06 tok/s, C64 |
 | `batch`, `KV=kvarn` | 334,183 cold / 350,192 warm | 843.72 / 852.42 tok/s, C64 |
 
-Four WSL-specific memory behaviors are worth accounting for, and the first is a
+Five WSL-specific behaviors are worth accounting for, and the first is a
 hard abort rather than a tuning question:
 
 1. **`SPEC=dflash2` needs `VLLM_WSL2_ENABLE_PIN_MEMORY=1` in `.env`, on every
@@ -98,12 +98,45 @@ hard abort rather than a tuning question:
    `EXTRA_ARGS` on later starts. Stress concurrent prefill or
    `prompt_logprobs` before promoting it. Do not copy a byte value from a
    different card or profile.
-4. **`expandable_segments` can crash Marlin repack on some driver/dxgkrnl
-   combinations.** Both start scripts default to
-   `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`; its CUDA VMM calls
-   crashed the engine with `RuntimeError: CUDA driver error: device not
-   ready` inside `gptq_marlin_repack` on Windows driver 610.74 (WSL 2.1.5
-   and 2.7.12 alike — the `e81fa39` reproduction on driver 591.86 did not
-   hit this). The scripts respect a pre-set value, so put
-   `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False` in `.env` (Docker)
-   or the environment (venv) if you see that signature.
+4. **`expandable_segments` crashes Marlin repack under the paravirt driver, and
+   the start scripts now turn it off for you on WSL.** They detect WSL from
+   `/proc/sys/kernel/osrelease` (or `WSL_DISTRO_NAME`) and default to
+   `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False`, printing a line saying so;
+   native Linux keeps `:True`, where gotcha 3 applies. Set the variable explicitly
+   in `.env` (Docker) or the environment (venv) to override either way.
+
+   This is the most reported failure on Windows
+   ([#2](https://github.com/syv-ai/qwen38-27b-rtx3090/issues/2),
+   [#26](https://github.com/syv-ai/qwen38-27b-rtx3090/issues/26)), and it is worth
+   knowing all of its faces, because none of them says "allocator". Same CUDA VMM
+   rejection inside `process_weights_after_loading` / `gptq_marlin_repack`, four
+   different messages:
+
+   | signature | reported on |
+   |---|---|
+   | `RuntimeError: CUDA driver error: device not ready` | driver 610.74, 610.62, 610.57 (WSL 2.1.5, 2.7.11, 2.7.12) |
+   | `RuntimeError: CUDA driver error: out of memory` | driver 591.86 — **not** a real OOM: same failure at `GPU_UTIL` 0.75 and 0.90 with 23 GiB free for a 16 GiB model, and `:False` fixes it at 0.93 |
+   | `torch_call_dispatcher("aten::empty", ...) API call failed`, `ops.h:631` | driver 610.62 |
+   | `dxgkio_make_resident: Ioctl failed: -12` in `dmesg` | alongside all of the above |
+
+   Driver 591.86 does reproduce it, contrary to what this note said before —
+   thanks to @willy92wins for the counter-example. It is not driver-version-gated,
+   so the default is now WSL-gated instead.
+
+5. **Two more things the venv path needs on WSL2 that the container does not.**
+   Both from @willy92wins in
+   [#2](https://github.com/syv-ai/qwen38-27b-rtx3090/issues/2):
+
+   - **`nvcc` is not on `PATH`, and the error blames permissions.** Inductor
+     shells out to a bare `nvcc` and dies with
+     `PermissionError: [Errno 13] Permission denied: 'nvcc'`. It is not a
+     permissions problem: `nvcc` is not on `PATH` at all, but WSL inherits the
+     Windows `PATH`, which contains ACL-restricted directories, and `execvp`
+     reports EACCES rather than ENOENT when the search hits one. The venv already
+     ships one — prepend
+     `venv/lib/python3.12/site-packages/nvidia/cu13/bin` to `PATH`. The image
+     installs `cuda-nvcc` system-wide, which is why Docker never sees this.
+   - **The default fp8 KV cache makes FlashInfer JIT-compile its e4m3 prefill
+     kernel**, and that ninja build can fail here. `EXTRA_ARGS="--kv-cache-dtype
+     auto"` sidesteps it — `EXTRA_ARGS` is last on the command line, so it wins
+     over `KV_ARGS`.

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -413,6 +413,25 @@ else
   VISION_ARGS="--language-model-only"
 fi
 
+# fp16 activations do not work with the speculative path, and every way of finding
+# that out is late and cryptic (#27): the split-KV verify kernel hardcodes
+# tl.bfloat16 for the query cast and the dot accumulate
+# (patches/spec-decode-attn.patch), so it fails to *compile* at first attention with
+# "Both operands must be same dtype. Got bf16 and fp16"; disable it with SPEC_ATTN=0
+# and you get as far as the first sample, where the rejection sampler dies on a
+# device-side assert. Neither message names the dtype you set. Say so here instead.
+# This is a limitation of this repo's kernels, not of the checkpoint -- an fp16
+# target is fine with SPEC=none.
+case " ${EXTRA_ARGS:-} " in
+  *" --dtype float16 "*|*" --dtype=float16 "*|*" --dtype fp16 "*|*" --dtype=fp16 "*|*" --dtype half "*|*" --dtype=half "*)
+    if [ "${SPEC:-mtp}" != "none" ]; then
+      echo "--dtype float16 needs SPEC=none: this repo's speculative kernels are bf16-only." >&2
+      echo "  the split-KV verify attention casts to tl.bfloat16 (patches/spec-decode-attn.patch)," >&2
+      echo "  and the rejection sampler asserts device-side under fp16. See issue #27." >&2
+      exit 1
+    fi ;;
+esac
+
 export PATH="$REPO/venv/bin:$PATH"
 # expandable_segments needs CUDA VMM, which WSL2's paravirt driver rejects during
 # Marlin repack. It is the single most reported failure on Windows (#2, #26) and it

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -414,10 +414,24 @@ else
 fi
 
 export PATH="$REPO/venv/bin:$PATH"
-# Overridable: expandable_segments needs CUDA VMM, which WSL2's paravirt
-# driver rejects ("CUDA driver error: device not ready" during Marlin repack)
-# — set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False in .env on WSL2.
-export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
+# expandable_segments needs CUDA VMM, which WSL2's paravirt driver rejects during
+# Marlin repack. It is the single most reported failure on Windows (#2, #26) and it
+# does not announce itself as an allocator problem -- the same VMM rejection surfaces
+# as "CUDA driver error: device not ready", "CUDA driver error: out of memory" (on a
+# card with 23 GiB free for a 16 GiB model) or a torch stable-ABI error out of
+# aten::empty, with dmesg carrying "dxgkio_make_resident: Ioctl failed: -12". So
+# detect WSL and default it off there rather than documenting a workaround: three
+# separate reporters found the note in docs/docker.md only after losing a day.
+# Still overridable both ways, and untouched on native Linux, where gotcha 3 applies
+# and turning it off costs you the top of the GPU_UTIL range.
+if grep -qi microsoft /proc/sys/kernel/osrelease 2>/dev/null || [ -n "${WSL_DISTRO_NAME:-}" ]; then
+  ALLOC_DEFAULT=expandable_segments:False
+  [ -z "${PYTORCH_CUDA_ALLOC_CONF:-}" ] && echo \
+    "WSL detected: PYTORCH_CUDA_ALLOC_CONF=$ALLOC_DEFAULT (VMM breaks Marlin repack under the paravirt driver; set it explicitly to override)"
+else
+  ALLOC_DEFAULT=expandable_segments:True
+fi
+export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-$ALLOC_DEFAULT}
 export VLLM_USE_FLASHINFER_SAMPLER=0
 
 if [ -z "$VLLM_API_KEY" ] && [ -f "$REPO/api_key.txt" ]; then


### PR DESCRIPTION
Four things that came out of reading the open issues, each verified before shipping.

**`expandable_segments` off on WSL (#2, #26).** The most reported Windows failure, and a documented workaround was not enough — three people found the note only after losing a day. Now detected from `/proc/sys/kernel/osrelease` / `WSL_DISTRO_NAME`, with a banner; native Linux unchanged; explicit values win either way. The docs note now also carries the four different messages this one VMM rejection produces, and corrects its own claim that driver 591.86 is unaffected.

**`pandas` in `docker/requirements.txt` (#22).** `bench/run_benchmarks.sh` dies out of the box on `Please install vllm[bench] for bench support`, and installing that extra would revert the patch stack. Only `pandas` is needed — the reference box has no `datasets` and runs the full suite.

**`DFLASH_TOKENS=15` reframed (#22).** @changtimwu measured positions 7-14 accepting exactly zero on chat prompts under TP=2; reproduced here on one 3090 at 72 of 11,069 accepted tokens (0.65%). It moves out of the three-in-one recommendation and into a sentence about which workload you have.

**`--dtype float16` refused with a speculator (#27).** The split-KV verify kernel hardcodes `tl.bfloat16`, so fp16 fails to compile at first attention; `SPEC_ATTN=0` gets you to a device-side assert in the rejection sampler instead. Neither message names the dtype. `SPEC=none` remains the escape hatch.

## Verified

- Production on the reference 3090 restarted on this launcher: health 200, no WSL banner, KV pool unchanged at 57,669 tokens, k=15 as before.
- `--dtype float16` + `SPEC=dflash2` exits 1 without touching the GPU; `SPEC=none` passes through.
- WSL detection exercised on all three branches (native, simulated WSL, simulated WSL with an explicit override).
- `bash -n` on both start scripts.