### PR TITLE
MAX_SEQS above 12 at CTX=huge kills the engine; the gotcha-38 cap does not cover it

### DIFF
--- a/bench/seat_ttft.py
+++ b/bench/seat_ttft.py
@@ -1,0 +1,110 @@
+"""Is the eight-seat cell's ~1.8x TTFT at N=1 the seat count, or is it warmup?
+
+@mjungnickel18 measured 21.8 s against 12.2 s for the same single 4k prompt at N=1 with
+only MAX_SEQS differing, fresh boot each -- a cell where the seat count cannot matter,
+because there is one request. He declined to draw a conclusion and asked for a rerun
+with the cells interleaved. This is the client half of that.
+
+  venv/bin/python bench/seat_ttft.py <tag> [ctx_tokens] [reps]
+
+Two things his run could not separate, because it measured one request per boot:
+
+  cold   the FIRST request a server ever sees, which pays whatever lazy init survived
+         graph capture
+  warm   the same shape afterwards, which is the steady state a user actually meets
+
+Each prompt carries its own salt, so no request is ever served out of the prefix cache
+and "warm" means warm engine, not warm cache.
+"""
+import json, os, sys, time, urllib.request
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
+
+
+def _key():  # a key is optional; keyless servers ignore the header
+    try:
+        return open(os.path.join(REPO, "api_key.txt")).read().strip()
+    except OSError:
+        return ""
+
+
+KEY = os.environ.get("VLLM_API_KEY") or _key()
+BASE = "http://127.0.0.1:" + os.environ.get("PORT", "18020")
+TAG = sys.argv[1]
+CTXTOK = int(sys.argv[2]) if len(sys.argv) > 2 else 4096
+REPS = int(sys.argv[3]) if len(sys.argv) > 3 else 4
+
+# ~1.4 tokens per word for this filler; overshoot slightly and let the count speak
+FILLER = ("The quick brown fox jumps over the lazy dog near the riverbank at dawn. "
+          "Meanwhile the engineer reviews the throughput numbers one more time. ")
+WORDS_PER_REP = 26
+
+
+def prompt(salt):
+    reps = max(1, int(CTXTOK / (WORDS_PER_REP * 1.15)))
+    return f"[seat probe {salt}] " + FILLER * reps + "\nSummarise the passage in one sentence."
+
+
+def ttft(salt):
+    """Time to the first streamed content chunk, plus the prompt length the server saw."""
+    body = json.dumps({
+        "model": "qwen3.8-27b",
+        "messages": [{"role": "user", "content": prompt(salt)}],
+        "temperature": 0, "max_tokens": 32, "stream": True,
+        "stream_options": {"include_usage": True},
+        "chat_template_kwargs": {"enable_thinking": False},
+    }).encode()
+    req = urllib.request.Request(BASE + "/v1/chat/completions", data=body, headers={
+        "Content-Type": "application/json", "Authorization": "Bearer " + KEY})
+    t0 = time.perf_counter()
+    first = None
+    ptok = None
+    with urllib.request.urlopen(req, timeout=1800) as r:
+        for raw in r:
+            line = raw.decode().strip()
+            if not line.startswith("data: "):
+                continue
+            payload = line[6:]
+            if payload == "[DONE]":
+                break
+            ev = json.loads(payload)
+            if ev.get("usage"):
+                ptok = ev["usage"]["prompt_tokens"]
+            ch = ev.get("choices") or []
+            if first is None and ch and (ch[0].get("delta") or {}).get("content"):
+                first = time.perf_counter() - t0
+    return first, time.perf_counter() - t0, ptok
+
+
+rows = []
+for i in range(REPS):
+    kind = "cold" if i == 0 else "warm"
+    # A stream that yields no content chunk is a data point, not a crash: it is what a
+    # dead engine looks like from the client side, and formatting None as a float ends
+    # the run with a TypeError that hides it. Same failure @mjungnickel18 fixed in
+    # bugb_sweep.py with `content or ""`.
+    try:
+        f, tot, ptok = ttft(f"{TAG}-{i}")
+    except Exception as e:
+        print(f"[{TAG}] req {i} ({kind:4s}): FAILED {type(e).__name__}: {e}", flush=True)
+        rows.append((kind, None))
+        continue
+    if f is None:
+        print(f"[{TAG}] req {i} ({kind:4s}): NO CONTENT after {tot:.2f} s "
+              f"(prompt={ptok} tok) -- engine may be dead, check /health", flush=True)
+        rows.append((kind, None))
+        continue
+    rows.append((kind, f))
+    print(f"[{TAG}] req {i} ({kind:4s}): TTFT={f*1000:8.1f} ms  total={tot:6.2f} s  prompt={ptok} tok",
+          flush=True)
+
+warm = [f for k, f in rows if k == "warm" and f is not None]
+cold = rows[0][1]
+if not warm:
+    print(f"[{TAG}] SUMMARY cold={'n/a' if cold is None else f'{cold*1000:.1f} ms'}  "
+          f"no usable warm samples of {max(0, REPS - 1)}")
+else:
+    print(f"[{TAG}] SUMMARY cold={'n/a' if cold is None else f'{cold*1000:.1f} ms'}  "
+          f"warm_median={sorted(warm)[len(warm)//2]*1000:.1f} ms  "
+          f"warm_min={min(warm)*1000:.1f} ms  n_warm={len(warm)}")

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -410,3 +410,37 @@ Things that each cost us hours, in rough order of pain. Worth skimming before yo
     `CG` at 64, which leaves every shipped default untouched and makes the oversized
     batches run piecewise instead of not at all. Set `CG` explicitly to override, and
     raise `VLLM_V2_CUDAGRAPH_MEM_MIB` with it.
+
+39. **Capping the graph budget did not close the seat-count death — `MAX_SEQS > 12` at
+    `CTX=huge` still kills the engine, and the graphs are innocent.** Same visible
+    failure as gotcha 38 (boots, captures, `/health` 200, dies on the first prompt with
+    `torch.OutOfMemoryError`), different bill. `CG` is pinned at its 64 cap in every one
+    of the runs below, so the memory is going to allocations that scale with
+    `max_num_seqs` itself, not with the captured batch. Free VRAM after boot on one
+    24 GiB 3090, `SPEC=dflash2 CTX=huge PREFIX_CACHE=1` k=7, then a single ~3.7k-token
+    prompt:
+
+    | `MAX_SEQS` | free after boot | one ~3.7k prompt |
+    |---|---|---|
+    | 8 | 596 MiB | ok |
+    | 10 | 456 MiB | ok |
+    | 12 | 416 MiB | ok |
+    | **16** | **356 MiB** | **dead** |
+
+    The allocator says it plainly: `expandable_segments: memory mapping failed with OOM
+    on device 0 while trying to map 20971520 bytes (free: 20578304, total:
+    25272516608)` — 20 MB wanted against 20 MB left, on a card with 24 GB. It needs no
+    concurrency at all: `num_running_reqs=1`, `step_counter=0`, `kv_cache_usage=0.18`.
+    Reproduced twice with byte-identical counters. The prefill's transient working set
+    is ~356 MiB at `--max-num-batched-tokens 2048`, which is why 12 survives by ~60 MiB
+    and 16 does not survive at all.
+
+    The launcher warns above 12 rather than clamping, because unlike `CG` this is a VRAM
+    budget rather than a shape: a card bigger than 24 GiB has room where this one does
+    not. If you want the seats, buy them with `KV_MEM` — the pinned pool is what left no
+    headroom. And note the shipped `CTX=huge` default is `MAX_SEQS=2`, so nothing here
+    is reachable without an override.
+
+    Worth reading next to the concurrency section of the README: seats above the
+    residency were already useless (they queue, then preempt). Past 12 at `CTX=huge`
+    they stop being useless and become fatal.

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -271,6 +271,24 @@ if [ "$SPEC" = "dflash2" ]; then
            "MAX_SEQS=$MAX_SEQS admits more than that and the rest queue."
     fi
   fi
+  # Above ~12 seats at CTX=huge the seats stop being merely useless and become fatal, and
+  # not through the graph budget that gotcha 38 caps -- CG is already pinned at 64 in
+  # every one of these. The per-seat runner allocations eat the transient headroom the
+  # first prefill needs, so the engine boots, captures, answers /health 200, and then
+  # dies on the first real prompt with torch.OutOfMemoryError inside the caching
+  # allocator. Measured on one 24 GiB 3090, SPEC=dflash2 k=7, free VRAM after boot
+  # against a single ~3.7k-token prompt (gotcha 39):
+  #   MAX_SEQS=8   596 MiB  ok      MAX_SEQS=12  416 MiB  ok
+  #   MAX_SEQS=10  456 MiB  ok      MAX_SEQS=16  356 MiB  DEAD, twice, same byte counts
+  # The prefill's transient set is ~356 MiB at --max-num-batched-tokens 2048, so 12
+  # clears it by ~60 MiB. Warning rather than a clamp: the number is a VRAM budget, and a
+  # card larger than 24 GiB will have room where this one does not. Lower KV_MEM if you
+  # genuinely need the seats.
+  if [ "$CTX" = "huge" ] && [ "$MAX_SEQS" -gt 12 ]; then
+    echo "[start_qwen] WARNING: MAX_SEQS=$MAX_SEQS at CTX=huge killed the engine on the" \
+         "first prompt on a 24 GiB card (boots, serves /health, then OutOfMemoryError)." \
+         "12 is the highest verified here. Lower MAX_SEQS or lower KV_MEM." >&2
+  fi
   [ -n "$KV_MEM" ] && EXTRA_ARGS="--kv-cache-memory=$KV_MEM ${EXTRA_ARGS}"
 else
   MAX_SEQS=${MAX_SEQS:-8}


### PR DESCRIPTION
Found while trying to reproduce @mjungnickel18's thrashing cell in [#25](https://github.com/syv-ai/qwen38-27b-rtx3090/issues/25).

Same visible failure as gotcha 38 — boots, captures graphs, answers `/health` 200, dies on the first prompt with `torch.OutOfMemoryError` — but a **different bill**, and capping `CG` does not prevent it. `CG` sits at its 64 cap in every run below, so the memory is going to allocations that scale with `max_num_seqs` itself.

| `MAX_SEQS` | free after boot | one ~3.7k prompt |
|---|---|---|
| 8 | 596 MiB | ok |
| 10 | 456 MiB | ok |
| 12 | 416 MiB | ok |
| **16** | **356 MiB** | **dead** |

```
expandable_segments: memory mapping failed with OOM on device 0 while trying to
map 20971520 bytes (free: 20578304, total: 25272516608)
```

20 MB wanted against 20 MB left, on a 24 GB card. No concurrency needed — `num_running_reqs=1`, `step_counter=0`, `kv_cache_usage=0.18`. Reproduced twice with byte-identical counters.

**Warns rather than clamps.** Unlike `CG` this is a VRAM budget rather than a shape, so a card above 24 GiB may be fine where this one is not; `KV_MEM` is the knob that buys the headroom back. The shipped `CTX=huge` default is `MAX_SEQS=2`, so this is unreachable without an override.

Also adds `bench/seat_ttft.py`, the probe that found it — cold-then-warm TTFT at N=1, per-request salt so "warm" means warm engine not warm cache. It reports a contentless stream as a data point rather than raising, which is the same trap as the `content or ""` fix in `bugb_sweep.py` and is what made this visible instead of a `TypeError`.

## Verified
- Guard fires at `CTX=huge MAX_SEQS>12` only; silent at 8/12 and at every `CTX=fast` seat count.
- `bash -n` on the launcher; probe smoke-tested against live production with no hardcoded paths.
- Production on the reference 3090 restored and healthy after every run.