### PR TITLE
Offload the vision tower to host RAM, so VISION=1 works with SPEC=dflash2

### DIFF
--- a/batch/start_qwen.sh
+++ b/batch/start_qwen.sh
@@ -106,6 +106,21 @@ TOOL_ARGS=$([ "${TOOLS:-1}" = 1 ] && echo --enable-auto-tool-choice --tool-call-
 # 2097152 px = 2048 image tokens.
 if [ "${VISION:-0}" = 1 ]; then
   VISION_ARGS='--limit-mm-per-prompt {"image":{"count":1}} --mm-processor-kwargs {"size":{"shortest_edge":65536,"longest_edge":2097152}}'
+  # VISION_OFFLOAD keeps the tower's weights in pinned host RAM and copies each module to
+  # the GPU for the duration of its own forward (patches/vision-tower-cpu-offload.patch).
+  # It defaults ON, because on 24 GB SPEC=dflash2 + VISION=1 does not boot without it:
+  # the tower is 0.85 GiB of the ~1.1 GiB transient margin the KV_MEM comment sizes, and
+  # graph capture then dies allocating the split-KV verify buffer --
+  #   torch.OutOfMemoryError: Tried to allocate 960.00 MiB ... 787.50 MiB is free
+  #     (spec_decode_attn.py:184, self.part_o)
+  # measured here, VISION=1 VISION_OFFLOAD=0 SPEC=dflash2, RTX 3090 at 250 W. With the
+  # offload the same config comes up with the full 69,758-token pool and reads images.
+  #
+  # It is close to free: isolated-tower measurement at PCIe 4.0 x16, one 8192-patch image,
+  # median of 10 forwards, 891.3 -> 9.0 MiB of resident weights and 1160.5 -> 308.2 MiB of
+  # peak allocation for 296 -> 333 ms of encode, output bit-exact either way. Set
+  # VISION_OFFLOAD=0 only on a card with room to spare, where 36 ms per image buys nothing.
+  [ "${VISION_OFFLOAD:-1}" = 1 ] && export VLLM_VISION_CPU_OFFLOAD_GB=${VLLM_VISION_CPU_OFFLOAD_GB:-1}
 else
   VISION_ARGS="--language-model-only"
 fi

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -55,6 +55,29 @@ Things that each cost us hours, in rough order of pain. Worth skimming before yo
    between those two starts, which is the same run-to-run swing the V2 runner
    shows, so read the pool difference as noise rather than as a measurement of
    what the tower costs.
+
+   On `SPEC=dflash2` that 0.858 GiB is not optional headroom, it is the difference
+   between booting and not. Measured here on a 3090 at 250 W, `SPEC=dflash2 VISION=1
+   VISION_OFFLOAD=0`, `CTX=fast`: the engine dies in graph capture with
+   `torch.OutOfMemoryError: Tried to allocate 960.00 MiB ... 787.50 MiB is free`
+   (`spec_decode_attn.py:184`, the split-KV verify `part_o` buffer). The pool there is
+   pinned by bytes (`KV_MEM`), so the tower cannot come out of the KV cache — it comes
+   out of the ~1.1 GiB transient margin, and it is 0.85 of it. `VISION_OFFLOAD=1` (the
+   default) makes the same config come up at the full 69,758-token pool and read images.
+   The `SPEC=mtp` path has no such problem: it boots either way, and there the pool is
+   profiling-sized, so what the tower costs is buried in the ±0.87 GiB profiling swing
+   above (79,271 against 80,055 tokens across the pair — 1%, i.e. noise).
+
+   What `VISION_OFFLOAD=1` does: the tower's weights live in pinned host RAM and each
+   module is copied to the GPU for the duration of its own forward
+   (`patches/vision-tower-cpu-offload.patch`). Isolated-tower measurement, RTX 3090 at
+   PCIe 4.0 x16, one 8192-patch image, median of 10 forwards: resident weights 891.3 ->
+   9.0 MiB, peak allocation 1160.5 -> 308.2 MiB, encode 296 -> 333 ms, output bit-exact
+   against the resident tower. Note which offload path that is: vLLM's UVA *zero-copy*
+   mode saves the same memory and costs 3327 ms, because the GEMMs then re-read operand
+   tiles over PCIe inside the inner loop. The patch forces the bulk-copy path and does
+   not touch what `--cpu-offload-gb` does elsewhere -- which could not reach the tower
+   anyway, since the offloader is only installed in `make_layers()`.
 10. **`prompt_logprobs` on long prompts OOMs the engine at 0.972 utilization**
     (a 300-token prompt needs ~300 MB of fp32 logits and there is no headroom).
     Run quality checks at 0.93.

--- a/patches/vision-tower-cpu-offload.patch
+++ b/patches/vision-tower-cpu-offload.patch
@@ -1,0 +1,163 @@
+Keep the vision tower's weights in host RAM (vLLM 0.27.1).
+
+VISION=1 loads model.visual.* -- 878.8 MiB of BF16 on this checkpoint, of which
+blocks are 784.8 and merger 85.5 -- and on a 24 GB card shared with a desktop
+compositor that is most of the headroom the single-user configs run on. vLLM can
+already offload weights to pinned host memory, but the offloader is installed only
+in make_layers() (model_executor/models/utils.py), which the language decoder
+layers use and the ViT does not: Qwen3_VisionTransformer builds self.blocks as a
+plain nn.ModuleList. So --cpu-offload-gb cannot reach the tower, and setting it
+spends the budget on language layers instead, which puts PCIe in the decode loop.
+
+This routes the tower's blocks and merger through their own UVAOffloader --
+dedicated, so it never competes with --cpu-offload-gb -- with the zero-copy mode
+turned off, leaving the bulk-copy path: each module is copied H2D once per forward
+and freed. patch_embed and pos_embed (8.5 MiB) stay resident, so visual.device and
+visual.dtype still report cuda.
+
+VLLM_VISION_CPU_OFFLOAD_GB is the budget in GiB; 0 (default) changes nothing.
+1 covers the whole tower. Registered in envs.py so validate_environ() does not
+warn about it. VISION_OFFLOAD in either start script sets it, defaulting to on.
+
+On 24 GB this is what makes SPEC=dflash2 + VISION=1 possible at all. Without it
+that config dies in graph capture -- torch.OutOfMemoryError: Tried to allocate
+960.00 MiB ... 787.50 MiB is free, at spec_decode_attn.py:184 (the split-KV
+verify part_o buffer) -- because the dflash2 pool is pinned by bytes, so the
+tower comes out of the ~1.1 GiB transient margin and is 0.85 of it. With the
+offload the same config comes up at its full 69,758-token pool and reads images.
+SPEC=mtp boots either way.
+
+Measured on an RTX 3090 at PCIe 4.0 x16, one 8192-patch image (the 2048-image-token
+cap both start scripts ship), median of 10 forwards, isolated tower:
+
+  VLLM_VISION_CPU_OFFLOAD_GB   weights on GPU   peak alloc   forward
+  0 (stock)                       891.3 MiB     1160.5 MiB    296 ms
+  1                                 9.0 MiB      308.2 MiB    333 ms
+
+Bit-exact against the resident tower (same state_dict, torch.equal on the output).
+Do NOT leave the UVA zero-copy path on for this: same memory, but 3327 ms per
+image, because the GEMMs then re-read operand tiles over PCIe in the inner loop.
+
+Applies after speed-knobs-envs.patch and marlin-int8-layer-select.patch, which
+also touch envs.py (disjoint hunks, and glob order puts this one last):
+  patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/vision-tower-cpu-offload.patch
+
+--- a/envs.py
++++ b/envs.py
+@@ -188,6 +188,9 @@
+     VLLM_MARLIN_TUNE_DIR: str = ""
+     VLLM_SPEC_DECODE_ATTN: bool = False
+     VLLM_DRAFT_TOPK_TOPP: bool = True
++    # syv patch: GiB of vision-tower weights to keep in pinned host memory
++    # (patches/vision-tower-cpu-offload.patch). 0 disables.
++    VLLM_VISION_CPU_OFFLOAD_GB: float = 0.0
+     VLLM_HUMMING_MOE_GEMM_TYPE: Literal["indexed", "grouped", "auto"] | None = None
+     VLLM_DEEPEPLL_NVFP4_DISPATCH: bool = False
+     VLLM_V1_USE_OUTLINES_CACHE: bool = False
+@@ -1480,6 +1483,9 @@
+     "VLLM_MARLIN_TUNE_DIR": lambda: os.environ.get("VLLM_MARLIN_TUNE_DIR", ""),
+     "VLLM_SPEC_DECODE_ATTN": lambda: os.environ.get("VLLM_SPEC_DECODE_ATTN", "0") == "1",
+     "VLLM_DRAFT_TOPK_TOPP": lambda: os.environ.get("VLLM_DRAFT_TOPK_TOPP", "1") == "1",
++    "VLLM_VISION_CPU_OFFLOAD_GB": lambda: float(
++        os.environ.get("VLLM_VISION_CPU_OFFLOAD_GB", "0")
++    ),
+     # The activation dtype config for humming kernel
+     "VLLM_HUMMING_INPUT_QUANT_CONFIG": lambda: maybe_convert_json_str_or_file(
+         os.environ.get("VLLM_HUMMING_INPUT_QUANT_CONFIG", None)
+--- a/model_executor/models/qwen3_vl.py
++++ b/model_executor/models/qwen3_vl.py
+@@ -48,6 +48,7 @@
+ )
+ from transformers.video_utils import VideoMetadata
+ 
++import vllm.envs as envs
+ from vllm.compilation.decorators import support_torch_compile
+ from vllm.config import VllmConfig
+ from vllm.config.multimodal import (
+@@ -596,6 +597,40 @@
+             rope_parameters={"partial_rotary_factor": 0.5},
+         )
+ 
++        # syv patch: with VLLM_VISION_CPU_OFFLOAD_GB>0 the tower's weights live in
++        # pinned host memory and each module is copied to the GPU for the duration of
++        # its own forward, so the ViT costs ~0 resident VRAM while its GEMMs still run
++        # on the GPU (see the path note below). blocks (784.8 MiB on the
++        # Qwen3.8-27B AutoRound checkpoint) and merger (85.5 MiB) are 99% of the
++        # tower's 878.8 MiB; patch_embed and pos_embed stay resident, because 8.5 MiB
++        # is not worth putting an embedding gather on the PCIe bus.
++        #
++        # A dedicated offloader, NOT get_offloader(): the global one shares its byte
++        # budget with the language decoder layers (make_layers), so --cpu-offload-gb
++        # would spend it on whichever modules are built first and put PCIe in the
++        # decode hot loop. This one only ever sees the tower.
++        vision_offloader = None
++        if envs.VLLM_VISION_CPU_OFFLOAD_GB > 0:
++            from vllm.model_executor.offloader.uva import UVAOffloader
++
++            vision_offloader = UVAOffloader(
++                int(envs.VLLM_VISION_CPU_OFFLOAD_GB * 1024**3)
++            )
++            # Force the bulk-copy path (functional_call + .to(device) per module)
++            # instead of UVA zero-copy. Measured on a 3090 at PCIe 4.0 x16, one
++            # 8192-patch image (the 2048-image-token cap the start scripts ship),
++            # median of 10 forwards:
++            #   resident weights   296 ms   891 MiB weights, 1160 MiB peak
++            #   bulk copy          333 ms     9 MiB weights,  308 MiB peak
++            #   UVA zero-copy     3327 ms     9 MiB weights,  278 MiB peak
++            # Zero-copy leaves the GEMMs reading operand tiles over PCIe in the
++            # inner loop, which re-reads each tile and lands at ~290 MB/s effective
++            # -- 11x slower than just keeping the weights resident. The copy path
++            # moves each module once, contiguously, at bulk PCIe rate: +36 ms.
++            # Set on the instance rather than via VLLM_WEIGHT_OFFLOADING_DISABLE_UVA
++            # so this does not change what --cpu-offload-gb does elsewhere.
++            vision_offloader.uva_offloading = False
++
+         self.merger = Qwen3_VisionPatchMerger(
+             d_model=vision_config.out_hidden_size,
+             context_dim=self.hidden_size,
+@@ -604,6 +639,8 @@
+             quant_config=quant_config,
+             prefix=f"{prefix}.merger",
+         )
++        if vision_offloader is not None:
++            vision_offloader.wrap_modules(iter([self.merger]))
+ 
+         self.deepstack_merger_list = nn.ModuleList(
+             [
+@@ -625,19 +662,24 @@
+             dtype=torch.get_default_dtype(),
+         )
+ 
++        # syv patch: a generator, so UVAOffloader.wrap_modules can offload each block as
++        # it is built and stop exactly at the byte budget (see the merger above).
++        blocks_iter = (
++            Qwen3_VisionBlock(
++                dim=self.hidden_size,
++                num_heads=self.num_heads,
++                mlp_hidden_dim=vision_config.intermediate_size,
++                act_fn=_ACTIVATION_REGISTRY[vision_config.hidden_act],
++                norm_layer=norm_layer,
++                quant_config=quant_config,
++                prefix=f"{prefix}.blocks.{layer_idx}",
++            )
++            for layer_idx in range(vision_config.depth)
++        )
+         self.blocks = nn.ModuleList(
+-            [
+-                Qwen3_VisionBlock(
+-                    dim=self.hidden_size,
+-                    num_heads=self.num_heads,
+-                    mlp_hidden_dim=vision_config.intermediate_size,
+-                    act_fn=_ACTIVATION_REGISTRY[vision_config.hidden_act],
+-                    norm_layer=norm_layer,
+-                    quant_config=quant_config,
+-                    prefix=f"{prefix}.blocks.{layer_idx}",
+-                )
+-                for layer_idx in range(vision_config.depth)
+-            ]
++            vision_offloader.wrap_modules(blocks_iter)
++            if vision_offloader is not None
++            else list(blocks_iter)
+         )
+ 
+     @property

--- a/single-user/README.md
+++ b/single-user/README.md
@@ -391,6 +391,7 @@ included (`tools` + `tool_choice: "auto"` come back as `tool_calls`).
 | `MTP_DRAFT_VOCAB` | 1 | set 0 to draft with the full lm_head (more acceptance, slower per draft) |
 | `TOOLS` | 1 | tool/function calling (`--enable-auto-tool-choice --tool-call-parser`). `TOOL_PARSER` (`qwen3_coder`) must match the XML call format this model's chat template emits — `hermes` parses the JSON a Qwen model does *not* produce here, and fails silently. 0 = off, and `tool_choice: "auto"` then 400s |
 | `VISION` | 0 | 1 keeps the vision tower instead of `--language-model-only` (0.858 GiB of BF16 weights on this checkpoint), for a client that sends images: one image per prompt and a 2048-image-token pixel cap, both overridable from `EXTRA_ARGS` |
+| `VISION_OFFLOAD` | 1 | with `VISION=1`, keeps the tower's weights in pinned host RAM and copies each module to the GPU for its own forward (`patches/vision-tower-cpu-offload.patch`). **On 24 GB, `SPEC=dflash2` + `VISION=1` does not boot with this off** — the tower is 0.85 GiB of the ~1.1 GiB transient margin, and graph capture OOMs allocating the 960 MiB split-KV verify buffer with 787 MiB free. With it on, the same config comes up at the full 69,758-token pool and reads images. Costs 296 → 333 ms of encode per 8192-patch image, output bit-exact. 0 only on a card with headroom to spare. `VLLM_VISION_CPU_OFFLOAD_GB` (default 1) is the budget in GiB |
 | `PORT` | 18020 | |
 
 ## Switching modes

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -427,6 +427,21 @@ TOOL_ARGS=$([ "${TOOLS:-1}" = 1 ] && echo --enable-auto-tool-choice --tool-call-
 # 2097152 px = 2048 image tokens.
 if [ "${VISION:-0}" = 1 ]; then
   VISION_ARGS='--limit-mm-per-prompt {"image":{"count":1}} --mm-processor-kwargs {"size":{"shortest_edge":65536,"longest_edge":2097152}}'
+  # VISION_OFFLOAD keeps the tower's weights in pinned host RAM and copies each module to
+  # the GPU for the duration of its own forward (patches/vision-tower-cpu-offload.patch).
+  # It defaults ON, because on 24 GB SPEC=dflash2 + VISION=1 does not boot without it:
+  # the tower is 0.85 GiB of the ~1.1 GiB transient margin the KV_MEM comment sizes, and
+  # graph capture then dies allocating the split-KV verify buffer --
+  #   torch.OutOfMemoryError: Tried to allocate 960.00 MiB ... 787.50 MiB is free
+  #     (spec_decode_attn.py:184, self.part_o)
+  # measured here, VISION=1 VISION_OFFLOAD=0 SPEC=dflash2, RTX 3090 at 250 W. With the
+  # offload the same config comes up with the full 69,758-token pool and reads images.
+  #
+  # It is close to free: isolated-tower measurement at PCIe 4.0 x16, one 8192-patch image,
+  # median of 10 forwards, 891.3 -> 9.0 MiB of resident weights and 1160.5 -> 308.2 MiB of
+  # peak allocation for 296 -> 333 ms of encode, output bit-exact either way. Set
+  # VISION_OFFLOAD=0 only on a card with room to spare, where 36 ms per image buys nothing.
+  [ "${VISION_OFFLOAD:-1}" = 1 ] && export VLLM_VISION_CPU_OFFLOAD_GB=${VLLM_VISION_CPU_OFFLOAD_GB:-1}
 else
   VISION_ARGS="--language-model-only"
 fi


### PR DESCRIPTION
**edit to add** - Thanks to the maintainer of this. It's been working amazingly on my 3090! I have a bit higher VRAM requirements due to running Omarchy and a browser (otherwise my computer is useless) so the context is slightly reduced. This has been a real pleasure to use!

`VISION=1` (#23) works on `SPEC=mtp` and does not work on `SPEC=dflash2` — the mode
the README recommends to anyone who owns the card. On a 3090 at 250 W, the dflash2
path dies in graph capture:

```
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 960.00 MiB.
GPU 0 has a total capacity of 23.55 GiB of which 787.50 MiB is free.
  spec_decode_attn.py:184  ->  self.part_o = torch.empty(n, head_dim, ...)
```

Reproduce with `VISION=1 SPEC=dflash2 bash single-user/start_qwen.sh` on 24 GB.

### Why

The dflash2 pool is pinned by bytes (`KV_MEM`), so the 0.858 GiB tower cannot come
out of the KV cache — it comes out of the ~1.1 GiB transient margin the `KV_MEM`
comment sizes, and it is 0.85 of it. The split-KV verify buffer then has nowhere to go.

`--cpu-offload-gb` cannot fix this. vLLM's offloader is installed in exactly one
place, `make_layers()` (`model_executor/models/utils.py`), which the language decoder
layers use and the ViT does not — `Qwen3_VisionTransformer` builds `self.blocks` as a
plain `nn.ModuleList`. Setting `--cpu-offload-gb` spends the budget on language layers
instead, which puts PCIe in the decode hot loop.

### The change

`patches/vision-tower-cpu-offload.patch` routes the tower's `blocks` and `merger`
(870 of its 878.8 MiB) through their own `UVAOffloader` — dedicated, so it never
competes with `--cpu-offload-gb` — with zero-copy off, leaving the bulk-copy path:
each module is copied H2D once per forward and freed. `patch_embed` and `pos_embed`
(8.5 MiB) stay resident, so `visual.device` / `visual.dtype` still report cuda.

`VISION_OFFLOAD` defaults to 1 in both start scripts, because the alternative is a
config that hard-OOMs and the cost is 36 ms per image.

### Measured

Isolated tower, RTX 3090 at PCIe 4.0 x16, one 8192-patch image (the 2048-image-token
cap the start scripts ship), median of 10 forwards:

| `VLLM_VISION_CPU_OFFLOAD_GB` | weights on GPU | peak alloc | forward |
|---|---|---|---|
| 0 (stock) | 891.3 MiB | 1160.5 MiB | 296 ms |
| 1 | 9.0 MiB | 308.2 MiB | 333 ms |

Output is **bit-exact** against the resident tower (same `state_dict`, `torch.equal`).

End to end, `VISION=1 SPEC=dflash2`: boots at the full 69,758-token pool at `CTX=fast`,
and an OCR round-trip reads the pixels.

### Two notes for review

**Do not use vLLM's UVA zero-copy path here.** Same memory, **3327 ms** per image,
because the GEMMs then re-read operand tiles over PCIe in the inner loop (~290 MB/s
effective). The patch forces the copy path on its own instance rather than via
`VLLM_WEIGHT_OFFLOADING_DISABLE_UVA`, so `--cpu-offload-gb` elsewhere is unaffected.

**The `SPEC=mtp` half is a null result and is written as one.** That path boots either
way, and its pool is profiling-sized, so what the tower costs there is buried in the
±0.87 GiB profiling swing gotcha 9 already warns about — 79,271 against 80,055 tokens
across a `VISION=0`/`VISION=1` pair, 1%, i.e. noise. No context win is claimed.

`verify.sh` passes with 0 failures and lists the patch as applied.
