### PR TITLE
Run the uncensored checkpoint: fetch it, requantize it, and size dflash2 for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,65 @@ answer, and 400 tokens of fluent Danish inventing a task the prompt never asked 
 sweeps all 128 residues and judges every answer on how much of the document came
 back, and `bench/verbatim.py` self-tests that rule against all three shapes.
 
+### A different checkpoint: the uncensored build
+
+`MODEL=` points the launchers at any Qwen3.8-27B checkpoint in the same
+`compressed-tensors` shape. The one verified here is
+[philbert440/Qwen3.8-27B-Uncensored-Aggressive-W4A16-AWQ](https://huggingface.co/philbert440/Qwen3.8-27B-Uncensored-Aggressive-W4A16-AWQ)
+— an abliterated (de-refused) Qwen3.8-27B, W4A16 AWQ, with the vision tower and
+the grafted MTP head both preserved. Prepare it once, then serve it:
+
+```bash
+venv/bin/python prepare/fetch_uncensored.py          # ~18.6 GB
+venv/bin/python prepare/quant_heads_stream.py models/Qwen3.8-27B-Uncensored-W4A16
+venv/bin/python prepare/build_draft_vocab.py  models/Qwen3.8-27B-Uncensored-W4A16 \
+  --ids prepare/draft_vocab_ids.json
+
+MODEL=$PWD/models/Qwen3.8-27B-Uncensored-W4A16 SPEC=mtp CTX=long PREFIX_CACHE=1 \
+  MAX_LEN=100000 bash single-user/start_qwen.sh
+```
+
+It needs `prepare/quant_heads_stream.py` rather than the three `quant_*.py` steps
+the base model uses, for two reasons that are properties of the checkpoint and not
+of the model: it ships as **one 18.6 GB shard**, which the three scripts read into
+RAM whole before rewriting, and its body is **asymmetric AWQ**, which those scripts
+would copy onto the symmetric tensors they write — vLLM then looks for a
+`weight_zero_point` that was never written. The streaming script handles both and
+produces the same tensors otherwise; `bash verify.sh --no-server` with `MODEL=` set
+checks the result exactly as it checks the base model.
+
+**`SPEC=dflash2` needs its pool resized for this checkpoint.** After requantization
+it is 15.68 GiB of weights against the fast variant's 14.71, and the DFlash2 branch
+pins the KV pool *in bytes* (`KV_MEM`) rather than sizing it from
+`--gpu-memory-utilization`, so the pool does not give that gigabyte back. The server
+loads, captures graphs, and then dies on the split-KV verify buffer:
+
+```
+Model loading took 15.71 GiB
+reserved 5.2 GiB memory for KV Cache as specified by kv_cache_memory_bytes config
+torch.OutOfMemoryError: Tried to allocate 960.00 MiB ... 926.44 MiB is free
+```
+
+Hand that gigabyte back and it comes up. `CTX=long` (int8 KV) is the one to spend it
+on, because it buys roughly twice the context per byte of pool that `CTX=fast` does:
+
+```bash
+MODEL=$PWD/models/Qwen3.8-27B-Uncensored-W4A16 SPEC=dflash2 CTX=long PREFIX_CACHE=1 \
+  KV_MEM=4456028569 DFLASH_MAX_LEN=98304 bash single-user/start_qwen.sh
+```
+
+Measured here, RTX 3090 at 250 W: a 4.15 GiB pool holding **103,033 tokens** at
+98,304 `max-model-len` (4.6% margin) and **85.7 tok/s** greedy on a 400-token
+answer. The checkpoint keeps its vision tower, and that run had `VISION=1` — images
+came back described correctly — so the numbers are an upper bound on what the
+default `VISION=0` needs, which drops the tower's weights entirely.
+
+`SPEC=mtp` needs no `KV_MEM` of its own: its pool is profiled from `GPU_UTIL` rather
+than pinned, so it absorbs the extra gigabyte by shrinking the pool for you. It is the
+mode to reach for first on this checkpoint. The pool it lands on will not hold
+`CTX=long`'s stock 150k, though, which is what the `MAX_LEN=100000` above is — the
+figure this checkpoint has been run at.
+
 ### More than one GPU
 
 Everything here is written for one 24 GB card, and that is the only configuration
@@ -483,6 +542,10 @@ venv/bin/python prepare/build_draft_vocab.py models/Qwen3.8-27B-W4A16-AutoRound 
 venv/bin/python prepare/fetch_fast_variant.py
 # optional: the W4A16 DFlash2 block drafter (1.2 GB) for SPEC=dflash2 single-user mode
 venv/bin/python prepare/fetch_dflash2.py
+# optional: the uncensored checkpoint instead of the base model (~18.6 GB, its own
+# requant step; serve it with MODEL= -- see "A different checkpoint" above)
+venv/bin/python prepare/fetch_uncensored.py
+venv/bin/python prepare/quant_heads_stream.py models/Qwen3.8-27B-Uncensored-W4A16
 
 # patch vllm (all written against 0.27.1; reapply after upgrades)
 for p in patches/*.patch; do

--- a/prepare/README.md
+++ b/prepare/README.md
@@ -24,6 +24,30 @@ score instead of the full 248k vocabulary; `draft_vocab_ids.json` is the shipped
 list, and `--corpus` counts your own instead. It needs
 [patches/qwen3_5-mtp-draft-vocab.patch](../patches/qwen3_5-mtp-draft-vocab.patch).
 
+## A different checkpoint
+
+`quant_heads_stream.py` does the work of `quant_lm_head.py` + `quant_embed.py` +
+`quant_mtp.py` in one pass, for checkpoints those three cannot open: **single-shard**
+ones (they read a shard into RAM whole; the uncensored build ships one 18.6 GB
+`model.safetensors`) and **asymmetric AWQ** bodies (they clone `config_groups.group_0`
+onto the symmetric tensors they write, so vLLM then looks for a `weight_zero_point`
+that does not exist). Same math, same output tensors, peak RSS of a few GB regardless
+of shard size.
+
+```bash
+$V prepare/fetch_uncensored.py                          # ~18.6 GB
+$V prepare/quant_heads_stream.py models/Qwen3.8-27B-Uncensored-W4A16
+$V prepare/build_draft_vocab.py  models/Qwen3.8-27B-Uncensored-W4A16 \
+  --ids prepare/draft_vocab_ids.json
+```
+
+Then `MODEL=$PWD/models/Qwen3.8-27B-Uncensored-W4A16 bash single-user/start_qwen.sh`.
+`SPEC=dflash2` additionally needs its pinned pool resized, because this checkpoint is
+~1 GB heavier than the one those constants were measured on — the command and the
+numbers are in the main README, "A different checkpoint: the uncensored build".
+`--mtp-bits 4` and `--keep-fc` exist for experimenting with the draft module; the
+defaults (int8, `mtp.fc` quantized) are what was verified.
+
 The two `fetch_*` scripts only download: the fast variant is the int4-GPTQ lm_head and
 drafter plus a draft vocabulary counted over the model's own outputs (worth ~15% in
 single-user mode), and `fetch_dflash2.py` is the W4A16 DFlash2 block drafter. Both are

--- a/prepare/fetch_uncensored.py
+++ b/prepare/fetch_uncensored.py
@@ -1,0 +1,34 @@
+"""Fetch the uncensored (abliterated) W4A16 checkpoint and say what to run next:
+philbert440/Qwen3.8-27B-Uncensored-Aggressive-W4A16-AWQ, an AWQ quant of the
+de-refused Qwen3.8-27B with the vision tower and the grafted MTP head preserved.
+
+  venv/bin/python prepare/fetch_uncensored.py [dst_dir]   # default models/Qwen3.8-27B-Uncensored-W4A16
+
+~18.6 GB. It is NOT servable on 24 GB as it ships, for the same reason the base
+model is not (bf16 lm_head, bf16 embeddings, bf16 MTP module) -- but the three
+prepare/quant_*.py scripts cannot fix this one: it is a single 18.6 GB shard and
+its body is asymmetric AWQ. prepare/quant_heads_stream.py handles both; this
+script prints the exact commands when the download finishes.
+"""
+import os, sys
+from huggingface_hub import snapshot_download
+
+HERE = os.path.dirname(os.path.abspath(__file__)); ROOT = os.path.dirname(HERE)
+REPO = "philbert440/Qwen3.8-27B-Uncensored-Aggressive-W4A16-AWQ"
+args = [a for a in sys.argv[1:] if not a.startswith("--")]
+D = (args[0] if args else os.path.join(ROOT, "models", "Qwen3.8-27B-Uncensored-W4A16")).rstrip("/")
+os.makedirs(D, exist_ok=True)
+
+# chat_template.jinja is not *.json and the server needs it: without it vLLM falls back
+# to the tokenizer's built-in template, which is not the one this checkpoint was tuned
+# with (and does not emit the XML tool-call format --tool-call-parser qwen3_coder reads).
+snapshot_download(REPO, local_dir=D,
+                  allow_patterns=["*.json", "*.jinja", "*.safetensors", "README.md"])
+
+rel = os.path.relpath(D, ROOT)
+print(f"\nuncensored checkpoint downloaded: {rel}")
+print("it is not servable yet -- requantize the heads (CPU only, ~15 min, needs ~20 GB free disk\n"
+      "for the .bak-orig originals):\n"
+      f"  venv/bin/python prepare/quant_heads_stream.py {rel}\n"
+      f"  venv/bin/python prepare/build_draft_vocab.py {rel} --ids prepare/draft_vocab_ids.json\n"
+      f"then:  MODEL=$PWD/{rel} bash single-user/start_qwen.sh")

--- a/prepare/quant_heads_stream.py
+++ b/prepare/quant_heads_stream.py
@@ -1,0 +1,236 @@
+"""Requantize lm_head, embed_tokens and the MTP module to int8/int4
+(group-128, symmetric) in compressed-tensors pack-quantized format, in place.
+
+Same math and output as quant_lm_head.py / quant_embed.py / quant_mtp.py, but
+for checkpoints those three cannot handle:
+
+  - single-shard checkpoints. They read a whole shard into a dict before
+    rewriting it; philbert440/Qwen3.8-27B-Uncensored-* ships one 18.6 GB
+    model.safetensors (2384 tensors), which does not fit in RAM here. This
+    streams the shard tensor-by-tensor instead, copying untouched tensors as
+    raw bytes, so peak RSS is a few GB regardless of shard size.
+
+  - asymmetric bodies. The three scripts deepcopy config_groups.group_0 and
+    override only num_bits/targets. AWQ exports have symmetric=false and
+    zp_dtype=torch.int8, so the cloned group would declare asymmetric quant
+    for the symmetric tensors written here and vLLM would look for a
+    weight_zero_point that does not exist. The groups written below always say
+    symmetric=true / zp_dtype=null.
+
+Usage: venv/bin/python prepare/quant_heads_stream.py /path/to/model [--mtp-bits 8|4] [--keep-fc]
+
+This is what the uncensored checkpoint needs (prepare/fetch_uncensored.py); the base
+model is 7 shards and symmetric, so quant_lm_head/quant_embed/quant_mtp serve it fine.
+
+The rewritten shards replace the originals; the pre-quant files are kept as
+<shard>.bak-orig (renamed, not copied). config.json and the safetensors index
+are backed up as .bak-quant.
+"""
+
+import copy
+import json
+import os
+import struct
+import sys
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+from compressed_tensors.compressors.pack_quantized.base import pack_to_int32
+
+GROUP = 128
+HEAD_BITS = 8
+MTP_BITS = int(sys.argv[sys.argv.index("--mtp-bits") + 1]) if "--mtp-bits" in sys.argv else 8
+KEEP_FC = "--keep-fc" in sys.argv
+ROWS = 16384  # quantize this many rows at a time, to bound peak RSS
+
+MTP_LINEARS = ([] if KEEP_FC else ["mtp.fc"]) + [
+    "mtp.layers.0.mlp.down_proj",
+    "mtp.layers.0.mlp.gate_proj",
+    "mtp.layers.0.mlp.up_proj",
+    "mtp.layers.0.self_attn.q_proj",
+    "mtp.layers.0.self_attn.k_proj",
+    "mtp.layers.0.self_attn.v_proj",
+    "mtp.layers.0.self_attn.o_proj",
+]
+
+d = sys.argv[1].rstrip("/") + "/"
+
+DTYPE_STR = {
+    torch.bfloat16: "BF16", torch.float16: "F16", torch.float32: "F32",
+    torch.int8: "I8", torch.int32: "I32", torch.int64: "I64", torch.uint8: "U8",
+}
+
+
+def quantize(w, bits):
+    """int-N group-wise symmetric quant, row-chunked. Returns packed/scale/err."""
+    qmax = 2 ** (bits - 1) - 1
+    out_f, in_f = w.shape
+    assert in_f % GROUP == 0, w.shape
+    packed_parts, scale_parts = [], []
+    num, den = 0.0, 0.0
+    for lo in range(0, out_f, ROWS):
+        chunk = w[lo:lo + ROWS].to(torch.float32)
+        g = chunk.reshape(chunk.shape[0], in_f // GROUP, GROUP)
+        s = torch.clamp(g.abs().amax(dim=-1, keepdim=True) / qmax, min=1e-10)
+        q = torch.clamp(torch.round(g / s), -qmax - 1, qmax).to(torch.int8)
+        deq = (q.to(torch.float32) * s).reshape(chunk.shape[0], in_f)
+        num += (deq - chunk).pow(2).sum().item()
+        den += chunk.pow(2).sum().item()
+        packed_parts.append(pack_to_int32(q.reshape(chunk.shape[0], in_f), bits, packed_dim=1).contiguous())
+        scale_parts.append(s.squeeze(-1).contiguous())
+        del chunk, g, q, deq
+    return torch.cat(packed_parts), torch.cat(scale_parts), (num / den) ** 0.5
+
+
+def read_header(path):
+    with open(path, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        hdr = json.loads(f.read(n))
+    return hdr, 8 + n
+
+
+def stream_rewrite(src, dst, drop, add):
+    """Copy src to dst, omitting tensor names in `drop` and appending `add`
+    (name -> tensor). Untouched tensors are copied as raw bytes."""
+    hdr, data_start = read_header(src)
+    meta = hdr.pop("__metadata__", None)
+    keep = [(k, v) for k, v in sorted(hdr.items(), key=lambda kv: kv[1]["data_offsets"][0])
+            if k not in drop]
+
+    new_hdr, off = {}, 0
+    if meta is not None:
+        new_hdr["__metadata__"] = meta
+    plan = []
+    for k, v in keep:
+        b0, b1 = v["data_offsets"]
+        size = b1 - b0
+        new_hdr[k] = {"dtype": v["dtype"], "shape": v["shape"], "data_offsets": [off, off + size]}
+        plan.append(("copy", data_start + b0, size))
+        off += size
+    for k, t in add.items():
+        t = t.contiguous()
+        size = t.numel() * t.element_size()
+        new_hdr[k] = {"dtype": DTYPE_STR[t.dtype], "shape": list(t.shape), "data_offsets": [off, off + size]}
+        plan.append(("write", t, size))
+        off += size
+
+    blob = json.dumps(new_hdr, separators=(",", ":")).encode()
+    blob += b" " * ((8 - len(blob) % 8) % 8)
+    with open(src, "rb") as fi, open(dst, "wb") as fo:
+        fo.write(struct.pack("<Q", len(blob)))
+        fo.write(blob)
+        for kind, a, size in plan:
+            if kind == "copy":
+                fi.seek(a)
+                left = size
+                while left:
+                    chunk = fi.read(min(left, 64 << 20))
+                    if not chunk:
+                        raise IOError(f"short read in {src}")
+                    fo.write(chunk)
+                    left -= len(chunk)
+            else:
+                # .numpy() has no bfloat16; reinterpret as bytes instead
+                fo.write(memoryview(a.contiguous().view(torch.uint8).numpy()))
+    return off
+
+
+idx_path = d + "model.safetensors.index.json"
+_orig_index = open(idx_path, "rb").read()
+open(idx_path + ".bak-quant", "wb").write(_orig_index)
+idx = json.loads(_orig_index)
+wm = idx["weight_map"]
+
+lm_key = "lm_head.weight"
+emb_key = next(k for k in wm if k.endswith("embed_tokens.weight"))
+big = wm[lm_key]
+assert wm[emb_key] == big, "lm_head and embed_tokens live in different shards"
+
+# ---- lm_head + embed_tokens, one streaming pass over the big shard ----
+add = {}
+with safe_open(d + big, framework="pt") as f:
+    for key, scale_dtype in ((lm_key, torch.float16), (emb_key, torch.bfloat16)):
+        w = f.get_tensor(key)
+        out_f, in_f = w.shape
+        packed, scale, err = quantize(w, HEAD_BITS)
+        print(f"  {key}: {(out_f, in_f)} int{HEAD_BITS} g{GROUP}, round-trip rel error {err:.4f}")
+        assert err < 0.01, f"quantization error too high for {key}, aborting"
+        base = key[:-len(".weight")]
+        add[base + ".weight_packed"] = packed
+        # linears take fp16 scales; the embedding path creates them in params_dtype
+        add[base + ".weight_scale"] = scale.to(scale_dtype)
+        add[base + ".weight_shape"] = torch.tensor([out_f, in_f], dtype=torch.int64)
+        del w, packed, scale
+
+print(f"rewriting {big} (streaming)")
+tmp = d + big + ".tmp"
+stream_rewrite(d + big, tmp, drop={lm_key, emb_key}, add=add)
+os.replace(d + big, d + big + ".bak-orig")
+os.replace(tmp, d + big)
+del add
+
+for key in (lm_key, emb_key):
+    base = key[:-len(".weight")]
+    del wm[key]
+    for s in ("weight_packed", "weight_scale", "weight_shape"):
+        wm[f"{base}.{s}"] = big
+
+# ---- MTP module (small shard, fits in RAM) ----
+mtp_shards = {wm[m + ".weight"] for m in MTP_LINEARS}
+assert len(mtp_shards) == 1, f"mtp weights span several shards: {mtp_shards}"
+mtp_shard = mtp_shards.pop()
+print(f"mtp linears live in {mtp_shard}, quantizing to int{MTP_BITS} g{GROUP}")
+
+tensors = {}
+with safe_open(d + mtp_shard, framework="pt") as f:
+    mtp_meta = f.metadata()
+    for k in f.keys():
+        tensors[k] = f.get_tensor(k)
+for m in MTP_LINEARS:
+    w = tensors.pop(m + ".weight")
+    out_f, in_f = w.shape
+    packed, scale, err = quantize(w, MTP_BITS)
+    print(f"  {m}: {(out_f, in_f)} round-trip rel error {err:.4f}")
+    tensors[m + ".weight_packed"] = packed
+    tensors[m + ".weight_scale"] = scale.to(torch.float16)
+    tensors[m + ".weight_shape"] = torch.tensor([out_f, in_f], dtype=torch.int64)
+    del wm[m + ".weight"]
+    for s in ("weight_packed", "weight_scale", "weight_shape"):
+        wm[f"{m}.{s}"] = mtp_shard
+os.replace(d + mtp_shard, d + mtp_shard + ".bak-orig")
+save_file(tensors, d + mtp_shard, metadata=mtp_meta or {"format": "pt"})
+del tensors
+
+json.dump(idx, open(idx_path, "w"), indent=2)
+
+# ---- config.json ----
+cfg_path = d + "config.json"
+c = json.load(open(cfg_path))
+json.dump(c, open(cfg_path + ".bak-quant", "w"), indent=2)
+qc = c["quantization_config"]
+
+
+def group(bits, targets):
+    g = copy.deepcopy(qc["config_groups"]["group_0"])
+    g["targets"] = targets
+    w = g["weights"]
+    w["num_bits"] = bits
+    # tensors written here are symmetric with no zero point, regardless of
+    # what the body group uses (AWQ bodies are asymmetric).
+    w["symmetric"] = True
+    w["zp_dtype"] = None
+    w["group_size"] = GROUP
+    w["strategy"] = "group"
+    w["type"] = "int"
+    return g
+
+
+qc["ignore"] = [i for i in qc["ignore"] if i != "lm_head" and i not in MTP_LINEARS]
+qc["config_groups"]["group_1"] = group(HEAD_BITS, ["re:.*lm_head$"])
+qc["config_groups"]["group_2"] = group(HEAD_BITS, ["re:.*embed_tokens$"])
+qc["config_groups"]["group_3"] = group(
+    MTP_BITS, ["re:^mtp\\.layers\\..*"] if KEEP_FC else ["re:^mtp\\..*"]
+)
+json.dump(c, open(cfg_path, "w"), indent=2)
+print("done")


### PR DESCRIPTION
[philbert440/Qwen3.8-27B-Uncensored-Aggressive-W4A16-AWQ](https://huggingface.co/philbert440/Qwen3.8-27B-Uncensored-Aggressive-W4A16-AWQ) is an abliterated Qwen3.8-27B in the same `compressed-tensors` shape this repo already serves, with the vision tower and the grafted MTP head both preserved. `MODEL=` already points the launchers anywhere, so **serving** it needs no code — but **preparing** it does, and one of the two speculative modes needs a number.

### `prepare/quant_heads_stream.py`

Does what `quant_lm_head.py` + `quant_embed.py` + `quant_mtp.py` do, for a checkpoint those three cannot open. Two reasons, both properties of this export rather than of the model:

- **One 18.6 GB shard** (2384 tensors). The three scripts read a shard into a dict before rewriting it, which does not fit in RAM on this box. This streams the shard tensor-by-tensor and copies untouched tensors as raw bytes, so peak RSS is a few GB whatever the shard size.
- **Asymmetric AWQ body.** The three `deepcopy` `config_groups.group_0` and override only `num_bits`/`targets`, so the cloned group would declare `symmetric=false` / `zp_dtype=torch.int8` over the *symmetric* tensors they write — and vLLM would then look for a `weight_zero_point` that was never written. The groups written here always say `symmetric=true` / `zp_dtype=null`.

Same math and same output tensors otherwise. `bash verify.sh --no-server` with `MODEL=` set passes the result exactly as it passes the base model:

```
  PASS  lm_head requantized to int8      PASS  MTP draft module quantized
  PASS  embed_tokens requantized to int8 PASS  40k-token draft head present
```

### `prepare/fetch_uncensored.py`

Downloads it and prints the two commands that follow. It pulls `*.jinja` as well as `*.json`: `chat_template.jinja` is not `*.json`, and without it vLLM falls back to the tokenizer's built-in template, which does not emit the XML tool-call format `--tool-call-parser qwen3_coder` reads.

### `SPEC=dflash2` needs its pool resized

The one thing not discoverable from the model dir. After requantization this checkpoint is **15.68 GiB** of weights against the fast variant's **14.71**, and the DFlash2 branch pins the KV pool *in bytes* (`KV_MEM`) instead of sizing it from `--gpu-memory-utilization` — so the pool does not give that gigabyte back. The server loads, captures graphs, and dies on the split-KV verify buffer:

```
Model loading took 15.71 GiB
reserved 5.2 GiB memory for KV Cache as specified by kv_cache_memory_bytes config
torch.OutOfMemoryError: Tried to allocate 960.00 MiB ... 926.44 MiB is free
```

`KV_MEM=4456028569 DFLASH_MAX_LEN=98304` hands it back. Measured on one RTX 3090 at 250 W: a 4.15 GiB pool holding **103,033 tokens** at 98,304 `max-model-len` (4.6% margin), **85.7 tok/s** greedy on a 400-token answer, and images answered correctly with `VISION=1`. `SPEC=mtp` needs none of it — its pool is profiled, so it shrinks itself.

Docs only for the resize; no launcher behaviour changes, so nothing here can affect the base model or the fast variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)