### PR TITLE
Speculative decoding at depth: offload WSL2 fix, int4 MQ-3D kernel (opt-in), prefix-cache fix, token-true measurement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ venv/
 drafter/data/
 drafter/runs/
 .env
+# local reproduction artifacts (symlinks here, so no trailing slash)
+venv
+models
+api_key.txt
+bench/results/

--- a/README.md
+++ b/README.md
@@ -482,6 +482,12 @@ memory system's ramp on 16-92 MB reads, not the kernel).
 
 ## Setup
 
+> **Python 3.14 works natively** — nothing in this repo needs changing, but
+> `python3.14-dev` does need installing. See [docs/python-314.md](docs/python-314.md),
+> with a full RTX 3090 reproduction of the tables below in
+> [docs/reproductions/threadchip-3090.md](docs/reproductions/threadchip-3090.md).
+
+
 You need: a 24 GB Ampere or newer NVIDIA card, a recent driver, Python 3.12,
 ~40 GB disk. Everything below is CPU-safe to run while the GPU does other
 things. (Or skip the venv and use the container: [docs/docker.md](docs/docker.md).)

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ manual venv path is for hacking on the stack, or running it bare-metal.
 > **Python 3.14 works natively** — nothing in this repo needs changing, but
 > `python3.14-dev` does need installing. See [docs/python-314.md](docs/python-314.md),
 > with a full RTX 3090 reproduction of the tables below in
-> [docs/reproductions/threadchip-3090.md](docs/reproductions/threadchip-3090.md).
+> [docs/reproductions/native-3090.md](docs/reproductions/native-3090.md).
 
 You need: a 24 GB Ampere or newer NVIDIA card, a recent driver, Python 3.12,
 ~40 GB disk. Everything below is CPU-safe to run while the GPU does other

--- a/README.md
+++ b/README.md
@@ -483,6 +483,10 @@ other only loosely, and not rows for the table above:
   prompts, output length and rate definition, so deliberately not in the table
   (their own insistence, and correct). Setup gotchas and the full ladder:
   [#35](https://github.com/syv-ai/qwen38-27b-rtx3090/issues/35).
+- **RTX 4090, Windows 11 / WSL2 (Docker path)**: reproduces with zero repo
+  changes; CTX ladder incl. huge's pool byte-identical to the 3090 reference
+  (268,169), concurrency ladder to N=8, and a measured both-ways case for
+  leaving the `KV_MEM` pin alone — [docs/wsl2-4090.md](docs/wsl2-4090.md).
 - **Dual-GPU reports**: the controlled 1-vs-2×3090 A/B in
   [#40](https://github.com/syv-ai/qwen38-27b-rtx3090/issues/40) (+16–35%,
   161.6 C1 greedy at 275 W, PCIe x8 without NVLink; independently reproduced

--- a/docs/MR-DRAFT.md
+++ b/docs/MR-DRAFT.md
@@ -1,257 +1,260 @@
-# MR draft — speculative decoding at depth, the CPU tier, and two fixes
+# MR draft: speculative decoding at depth, the CPU tier, and two fixes
 
-> **DRAFT — not filed.** This is the assembled body for the single upstream MR
-> covering both boxes (RTX 4090 / WSL2 / Windows 11 · RTX 3090 / native
-> Ubuntu). Michael files it. Every planned measurement on both boxes is in;
-> every number below traces to the bench record and the 3090 seat has
-> reviewed its own rows (no misquotes found); the load-bearing claims are
-> measured on both boxes.
+> This file is the source for the PR #46 description; the live body on GitHub
+> is generated from it. Edit here first.
 
 ## Summary
 
-This MR carries two fixes, one kernel, one measurement correction, and the
-operating doctrine that fell out of measuring them:
+This PR is the writeup of a two box effort: an RTX 4090 under Windows 11 / WSL2
+(Docker) and an RTX 3090 on native Ubuntu (Python 3.14, venv, no container).
+Everything below was measured on at least one of the boxes, and the load
+bearing claims were measured on both. The detailed notes ship with the PR:
+[docs/wsl2-4090.md](docs/wsl2-4090.md), [docs/ubuntu-3090.md](docs/ubuntu-3090.md),
+and [docs/reproductions/native-3090.md](docs/reproductions/native-3090.md).
 
-1. **OffloadingConnector fix for non-UVA platforms** (`patches/offload-wsl2-devptr.patch`)
-   — the CPU offload tier crashes with an illegal memory access on WSL2;
-   root-caused to host-VA dereference in the Triton swap kernel, fixed with
-   device-pointer translation, validated by falsification bracket on both
-   platforms. Likely genuinely upstream-vLLM (any WSL2 user of the
-   OffloadingConnector, any model).
-2. **Prefix-cache zero-reuse on int4 KV + DFlash2** — a one-flag fix
-   (`--prefix-match-unit 848`) with the two-site contradiction analysis that
-   explains why it was invisible under int8.
-3. **An int4 MQ-3D spec-decode kernel** — 33-line dispatch change + reducer
-   guard; true end-to-end ~3.3× on deep int4 spec decode (22.3 → ~73 tok/s).
-   Held behind six promotion gates (listed in §3); included as a separate,
-   cuttable commit.
-4. **A measurement correction that affects any SSE-based benchmark of
-   speculative decoding** (§1) — it reversed our own initial "speculation
-   loses at depth" conclusion.
-5. **Doctrine**: the two-wing serving design, retention capacity vs.
-   round-robin, MAX_SEQS as designed geometry, and operator notes.
+What it carries:
 
-## 1. The unit inversion — a correction that affects every SSE chunk-rate benchmark
+1. **A fix for the CPU offload tier on WSL2** (`patches/offload-wsl2-devptr.patch`).
+   The OffloadingConnector crashes with an illegal memory access on WSL2. We
+   root caused it, fixed it, and validated the fix on both platforms. This is
+   probably an upstream vLLM bug rather than a repo bug: any WSL2 user of the
+   connector should hit it, with any model.
+2. **A one flag fix for prefix caching going dead** on int4 KV + DFlash2
+   (`--prefix-match-unit 848`), with the analysis of why it dies.
+3. **An int4 attention kernel for speculative decoding**
+   (`patches/spec-decode-int4-kv-mq3d.patch`), opt in via `VLLM_INT4_MQ_3D=1`.
+   About 3.3x end to end on deep int4 spec decode. It defaults off, and section
+   3 lists the tests it still owes before it earns default on.
+4. **A measurement correction** that matters to anyone benchmarking this stack
+   over SSE. It reversed one of our own early conclusions.
+5. **Operating notes**: what actually stays cached at depth, which settings
+   matter under mixed load, and what the engine's startup numbers do and do not
+   tell you.
 
-With speculative decoding on, **SSE chunks are spec steps, not tokens** (~3
-tokens per chunk at n7 acceptance). Any benchmark that counts chunks/s is
-undercounting spec-on throughput ~3× while counting spec-off correctly — a
-systematic bias *against* speculation. Fix: request
-`stream_options.include_usage` and read `usage.completion_tokens`; report
-emitted-tokens-per-step alongside as the receipt. Both boxes reproduced the
-inversion independently. All spec-on rates in this MR are token-true.
+## 1. If you benchmark speculation over SSE, read this first
 
-## 2. The token-true deep map (72.6k-token context, 4090/WSL2)
+With speculation on, each SSE chunk is one speculative step, not one token; at
+n7 a chunk averages about 3 tokens. A benchmark that counts chunks per second
+therefore undercounts spec-on throughput by roughly 3x while counting spec-off
+correctly, so every comparison is biased against speculation. We made exactly
+this mistake, concluded "speculation loses at depth" from it, and retracted.
+The fix: request `stream_options.include_usage` and read
+`usage.completion_tokens`; report emitted tokens per step alongside as the
+sanity check. Both boxes reproduced the effect independently. Every spec-on
+number in this PR is counted in tokens.
 
-| Config | decode tok/s (deep) |
+## 2. Deep context numbers (72.6k token prompt, 4090/WSL2)
+
+| config | decode tok/s (deep) |
 |---|---|
-| int4 KV + MQ-3D kernel, DFlash2 n7 | **70.5–75.2** |
-| long (int8 KV), DFlash2 n7 | 64–68 |
-| huge (KVarN 4/2-bit), DFlash2 n7 | ~60–63 |
+| int4 KV + MQ-3D kernel, DFlash2 n7 | **70.5 to 75.2** |
+| long (int8 KV), DFlash2 n7 | 64 to 68 |
+| huge (KVarN 4/2-bit), DFlash2 n7 | ~60 to 63 |
 | int4 KV, spec off | 35.55 |
 | int4 KV, stock #42 dispatch, DFlash2 n7 | 22.3 |
 
-**Speculation wins ~2× at depth with the right kernel** — the pre-correction
-verdict ("spec loses at 72k") was the unit inversion plus the stock int4
-dispatch, compounded. The stock dispatch genuinely loses (0.63× vs spec-off);
-the kernel turns that into a 2× win.
+With the right kernel and flags, speculation wins by about 2x at depth. Our
+earlier conclusion that it loses was two errors compounding: the chunk counting
+above, plus the stock int4 dispatch, which genuinely does lose (0.63x against
+spec off).
 
 ## 3. The int4 MQ-3D kernel
 
-Stock #42's spec-decode path launches the int4 attention kernel once per query
-position (2D grid); the MQ-3D form dispatches all q positions in one 3D launch
-with a reducer guard. 33 lines. Measured: 8.14 → 25.2–25.4 steps/s at 72.6k
-(×2.74 step rate), true e2e 22.3 → ~73 tok/s (~3.3×). Ships as
-`patches/spec-decode-int4-kv-mq3d.patch` with the dispatch **opt-in**
-(`VLLM_INT4_MQ_3D=1`; default off) because six promotion gates remain open
-before it should become the default: 72k operator/logit oracle · full-length
-exactness · per-position logit comparison · eager+captured+q=9 parity ·
-shallow crossover (shallow shows −16%; wants a seq_len floor) ·
-capture-aware dual-variant switching. Its own commit, cuttable without
-touching the rest.
+Stock #42 launches its spec-verify attention once per query position (a 2D
+grid), but DFlash2's verify is an 8 row multi-query batch, so each step walks
+the whole KV serially: measured 8.14 steps/s at 72.6k depth. Dispatching all
+query rows in one 3D launch with a reducer guard (33 lines) restores split-KV
+for the verify batch: 8.14 to 25.2 steps/s, which is 22.3 to ~73 tok/s end to
+end (~3.3x).
 
-## 4. Prefix-cache zero-reuse on int4 + DFlash2 — the one-flag fix
+It ships opt in (`VLLM_INT4_MQ_3D=1`, default off) because six checks are still
+owed before anyone should trust it as a default: a 72k operator/logit oracle,
+full length exactness, per position logit comparison, eager+captured+q=9
+parity, a shallow crossover floor (shallow currently reads -16%), and capture
+aware dual variant switching. It is its own commit, so it drops cleanly if you
+want the rest without it.
 
-Symptom: int4 KV + DFlash2 gets **zero** prefix-cache hits (every request
-re-prefills; 62s TTFT on a warm 72.6k whale). The 2×2 cross-box isolation:
-int8+DFlash hits, int4−DFlash hits — the interaction is int4 × DFlash2.
+## 4. Prefix cache zero reuse on int4 + DFlash2: the one flag fix
 
-Cause: the kvarn-v2 port's two sites carry contradictory assumptions. The GCD
-computation *excludes* SW groups ("their block is a divisor of the primary by
-construction" — true), yielding hash unit 1696; the SW guard then demands the
-SW block (848) be a *multiple* of that hash unit — 848 % 1696 ≠ 0, guaranteed
-false by the exclusion itself. Invisible under int8 where 864 = 864 satisfies
-both clauses.
+Symptom: with int4 KV and DFlash2 together, the prefix cache never hits.
+Every request re-prefills; a warm 72.6k prompt costs 62 seconds every time.
+The cross box isolation: int8 + DFlash2 hits, int4 without DFlash2 hits,
+therefore the bug is the interaction of the two.
 
-Fix: the port's own escape hatch, **`--prefix-match-unit 848`** (the GCD) —
-every clause then passes by arithmetic (1696 % 848 = 0, 848 % 848 = 0, both
-read clauses). Verified warm-whale TTFT 62s → 4.3s. **Rule: the
-prefix-match unit must equal the SW block, and it is per-(model, kv-dtype,
-draft-length)** — 848 is this model's number, not a constant.
+Cause: two sites in the kvarn v2 port carry assumptions that contradict each
+other. The GCD computation excludes sliding window groups (its comment says
+their block divides the primary by construction, which is true) and lands on
+hash unit 1696. But the SW guard then requires the SW block (848) to be a
+multiple of that hash unit, and 848 % 1696 is never 0: the exclusion
+guarantees the guard fails. Under int8 both values are 864, so the
+contradiction is invisible there.
 
-## 5. Retention — capacity and round-robin are different questions
+Fix: the port's own escape hatch, `--prefix-match-unit 848` (the GCD). Every
+clause then passes by arithmetic (1696 % 848 = 0, 848 % 848 = 0, both read
+clauses). Verified: warm whale TTFT 62s to 4.3s. The rule that generalizes:
+the prefix match unit must equal the SW block, and it is per model, KV dtype,
+and draft length... 848 is this model's number, not a constant.
 
-Measured on the 3090 (int8/long, three distinct contexts, 111,904 naive
-tokens = 82% of a 136,429-token pool):
+## 5. Retention: what actually stays cached
 
-- **Capacity** ("what the pool holds"): recheck the *newest* context only →
-  retained, 2.24s vs 50.35s cold (22×). Capacity ≈ **1.3 contexts**.
-- **Round-robin** ("what the workload sees"): recheck A, B, C in order →
-  **0/3**, every recheck ~1.0× cold. The sweep's own prefills evict the next
-  context before it is asked.
+Some vocabulary we used throughout, so the numbers below read plainly: a
+**whale** is one large prompt (say 72k tokens); **minnows** are the small 4k
+requests competing with it for the same engine.
 
-The tax is mamba-dominated (fixed-size per-seq state pages) plus drafter
-groups. **Measured** (L-bisection with per-length salts, tier off, each
-boundary rung required to reproduce alone in a fresh boot): per-context
-retention cost is **≈2.5–2.9× its token count** at ~51–61k-token contexts
-on the 4090/int4 geometry (pool 300,583), and **≈2.3–2.7×** at ~25–29k on
-the 3090/int8 geometry (pool 136,429). Pre-registered K=3 discriminator
-rungs then rejected **both** simple cost models, one per geometry: pure
-multiplicative (`cost = m·L`) fails on int4 (K=2 caps m at 2.93 while a
-K=3 0/3 at ~31.7k requires m > 3.18 — disjoint), and pure
-additive-constant (`cost = L + F`, the model our own falsified banner
-patch implemented from the engine's spec bytes) fails on int8 (K=2 and
-K=3 demand F in disjoint intervals). An affine shape (`cost = a·L + F`)
-fits every boundary on both boxes — but the feasible region is wide:
-every slope from a = 1.5 to a = 4.0 admits some constant, so **the affine
-is the last model standing, which is a different claim from the affine
-being right**. What would actually bite is not another data point but a
-designed rung where two feasible (a, F) pairs predict opposite outcomes
-(feasible pairs diverge fast at large L) — left as follow-on. This MR
-ships the measured brackets — every boundary rung on both boxes
-reproduced **alone in a fresh boot** before being called a measurement —
-and flags the cost-shape mechanism as open. The engine's own
-banner is **right only at full length** (proved by the needle probe, §7);
-at shorter or cached contexts nothing in the log says the real cost is
-2–3× the token count — which is the operator trap.
+The engine's startup line ("Maximum concurrency for N tokens per request:
+X.XXx") divides the pool by max_model_len. We measured what that number means
+in practice, and the answer depends on the question you ask:
 
-**Product sentence:** with the CPU offload tier (§6), the same round-robin
-pattern goes **0/3 → 3/3** (three 72.6k whales all recheck in 4.2–4.3s on
-the 4090 — tier restores, not GPU-warm hits, and that is the point: the
-GPU pool holds ~one such context warm, and the tier serves the rest at
-interactive latency instead of a 62s recompute). Measured under true
-concurrency: three simultaneous agents, each on its own 72.6k context,
-firing repeatedly — every round completes with **zero recomputes**;
-unqueued tier restores land in 5–7s, the LRU-rotated seat pays ~16s
-restoring under load, against 62s cold. Three deep agents on one 24 GB
-card is a serving pattern this tier makes real.
+- **Capacity** (recheck only the newest context): the newest one is warm.
+  On the 3090, 2.24s against a 50.35s cold prime, a 22x speedup.
+- **Round robin** (recheck A, B, C in order, the pattern a multi user service
+  actually runs): **0 of 3 hit**, because each recheck's own prefill evicts
+  the next context before it is asked.
 
-## 6. The OffloadingConnector fix (the patch in this MR)
+Then we measured the per context cost directly, by finding the largest context
+length where two contexts both stay warm (per length salts, offload tier off,
+and each boundary re-run alone in a fresh boot before we called it a
+measurement): a cached context costs about **2.5 to 2.9x its token count** at
+51k to 61k on the 4090 (int4 geometry, 300,583 token pool), and about
+**2.3 to 2.7x** at 25k to 29k on the 3090 (int8, 136,429 pool). The extra cost
+is the per sequence state: mamba state pages are constant size per sequence,
+therefore they do not shrink with shorter prompts, and the drafter adds its
+own groups.
 
-Full write-up: `docs/wsl2-4090.md` § "CPU offload tier under WSL2". Short
-form: the Triton `swap_blocks` kernel dereferences **host** VAs of the
-`cudaHostRegistered` /dev/shm mmap. Native UVA makes host VA == device VA by
-coincidence; WSL2 maps the region at a different device address and the
-kernel faults. The fix calls `cudaHostGetDevicePointer` after registration,
-carries the delta on the CPU views, and adds it where
-`compute_sub_block_ptrs` builds addresses. Delta is 0 on native — no behavior
-change. All failure branches **raise** (a platform without the device pointer
-refuses to start rather than run silent-unsafe) — which makes a live patched
-engine itself evidence the query ran: the fix is not only safer but more
-falsifiable than a warn-and-continue shape.
+We then tried to pin down the cost model and killed both simple candidates,
+one per geometry, with pre-registered tests: pure multiplicative
+(`cost = m * L`) fails on int4 (the K=2 boundary caps m at 2.93 but a K=3 test
+demands more than 3.18; no m satisfies both), and pure additive
+(`cost = L + F`) fails on int8 (the K=2 and K=3 boundaries demand F in
+disjoint intervals). An affine shape fits every boundary on both boxes, but
+with two free parameters against six one sided constraints that is a shape
+with room to spare, not a finding; this PR ships the measured brackets and
+leaves the cost model open.
 
-Falsification bracket: WSL2 with fix = 3 whales warm, 0 IMAs; fix removed =
-IMA ×3, first prime dies. Native = three arms byte-identical at 52.4 tok/s,
-805 MB moved through the tier live, loader resolves via `CDLL(None)`, rc=0,
-delta=0. **The bracket is trustworthy only for v3.** v1's native arms
-"passed" inert: `CDLL("libcudart.so")` throws on standard pip installs (the
-wheels ship only *versioned* sonames at wheel paths), so v1's happy path
-never executed on native — and discovering that is what exposed v2's
-would-be regression (its raise would have refused most native boxes). v3
-resolves from the process image first and raises on every failure, so a
-live patched engine is itself the execution proof — the evidence behind
-§9's falsifiability claim.
+The practical takeaways:
 
-Production-form follow-on (tracked, not in this MR): typed two-pointer
-separation instead of a delta attribute, transfer records, restored-state
-checksums, lifecycle/teardown coverage.
+- The startup concurrency number is **correct for a single full length
+  request** (section 7 has the measurement) but overstates warm multi context
+  capacity by 2x or more, and nothing in the log says which case you are in.
+- **The offload fix in section 6 changes the round robin story**: with the
+  CPU tier, the same 3-whale round robin goes from 0/3 to 3/3. Not because
+  the GPU holds them (it holds about one), but because eviction becomes a
+  RAM restore instead of a full re-prefill.
 
-## 7. Two wings, and MAX_SEQS as designed geometry
+## 6. The OffloadingConnector fix
 
-- **Spec wing** (single/low concurrency, DFlash2 on): wins ≤C4–C8. long C4 =
-  517 agg (4090).
-- **Batch wing** (spec off, batch geometry): takes over ~C10+. 4090
-  fp8-block-800: 676 agg @ C16. 3090 shipped `fast` @ `GPU_UTIL=0.972`
-  (boots native; WSL2 refuses this setting): ms/pass 23.3 → 28.2 across
-  C1–C16 — a 21% spread over a 16× batch — with **zero preemptions at every
-  level**, where the spec profile took 2 at N=8. *The wings differ in what
-  they are willing to have go wrong, not only in speed.* (The two boxes'
-  batch rows are different profiles — kept as separate rows, never a ratio.)
-- **MAX_SEQS is designed geometry, not a free knob**: graph budget (3090:
-  N=4 aggregate +6.1% just from MS=8→4) *and* worst-case admission bound
-  (huge MS=2 shows 44.7% KV at N=2, yet 2 × 245,760 > the 268,169 pool —
-  and that arithmetic is naive-token, i.e. optimistic, per §5's tax). **The
-  two gauges lie in opposite directions** — kv% understates worst-case
-  admission risk, the concurrency banner overstates multi-context capacity
-  by 2×+ (measured bound, §5; honest at N=1 — see the needle row below) —
-  so an operator reading both sees headroom twice and tunes into a cliff.
-  Size MAX_SEQS to the workload's real prompt distribution, never to a
-  gauge.
-- **Needle-at-max-len (3090)**: a single request climbing to **234,158
-  tokens — 95.3% of max_model_len — completes with exact needle recall**
-  (the last 4.7% untested: the corpus ran out, not the engine). So the
-  banner is honest about *one*, which sharpens the criticism rather than
-  softening it: the banner is not wrong about capacity but about **what
-  capacity means**. `pool / max_model_len` is a true statement about a
-  single live request and a 2×+ overstatement (measured bound, §5) the
-  moment the question is concurrent or cached contexts, where the 9-group
-  page tax applies. Same number, honest in one regime and misleading in the
-  other, with nothing on the line to say which regime you are in.
-- **Politeness knob**: `--max-num-batched-tokens 512` makes minnows live
-  (~5s) under a whale prefill for ~15% whale tax (prefill head-of-line
-  blocking is the mechanism).
-- **Pinned prefixes**: pin one whale prefix per box and it holds.
+Full writeup: docs/wsl2-4090.md, the offload section. The short version:
 
-## 8. Operator notes / gotcha ledger
+The Triton `swap_blocks` kernel dereferences **host** virtual addresses of the
+`cudaHostRegistered` /dev/shm region. On native Linux, UVA makes host VA equal
+device VA, so this works; but that is a coincidence of the platform, not a
+contract of the API. WSL2 registers successfully and maps the region at a
+**different** device address, therefore the kernel faults (illegal memory
+access) on the first real eviction.
 
-- The 8 GB `/dev/shm` offload region **outlives the process** (confirmed
-  empirically on both boxes) and holds RAM while the box idles — clean at
-  shutdown as well as startup; on a small-RAM box the stranded region is the
+The fix: after registration, ask `cudaHostGetDevicePointer` for the device
+address, carry the delta on the CPU views, and add it where
+`compute_sub_block_ptrs` builds pointers. The delta is 0 on native Linux, so
+no behavior change there. Every failure branch raises: a platform where the
+device pointer is unavailable refuses to start instead of running with
+addresses that fault later.
+
+Validation, both platforms:
+
+| arm | WSL2 / 4090 | native / 3090 |
+|---|---|---|
+| with fix | 3x 72.6k whales primed, all recheck warm in 4.2 to 4.3s, 0 IMAs | 52.4 tok/s, tokens byte identical to baseline, **805 MB** moved through the tier live |
+| fix removed | the IMA returns (count 3), first prime dies | returns to baseline exactly |
+| loader | resolves in-process, delta prints and translates | `CDLL(None)`, rc=0, delta=0 |
+
+One honesty note that section 9 leans on: the first version of this fix
+"passed" its native arms while inert, because a bare `CDLL("libcudart.so")`
+throws on standard pip installs (the wheels ship only versioned sonames), so
+its happy path never executed. v3 resolves from the process image first and
+raises on every failure, therefore a live patched engine is itself proof the
+device pointer query ran and succeeded.
+
+Follow-on hardening, tracked but not in this PR: typed two pointer separation
+instead of a delta attribute, transfer records, restored state checksums, and
+lifecycle/teardown coverage.
+
+## 7. Concurrency: two serving modes, and MAX_SEQS
+
+- **Speculation wins at low concurrency, batch mode wins past ~C10.** Long
+  profile C4 on the 4090: 517 tok/s aggregate. Batch mode on the 3090 at
+  `GPU_UTIL=0.972` (boots on a headless native box; WSL2 refuses that
+  setting): ms per forward pass goes 23.3 to 28.2 across C1 to C16, a 21%
+  spread over a 16x batch, with **zero preemptions at every level**. The spec
+  profile preempted twice at N=8 on the same box, so the two modes do not
+  just differ in speed: they differ in what goes wrong under pressure.
+- **MAX_SEQS is part of the profile's design, not a free knob.** On the 3090,
+  running the long profile at its designed MAX_SEQS=4 instead of 8 was worth
+  +6.1% aggregate at N=4, purely from not over provisioning slots. And on
+  huge, MAX_SEQS=2 shows 44.7% KV used at N=2, which looks like headroom;
+  but 2 x 245,760 is more than the 268,169 pool, so two full length requests
+  can never both fit. MAX_SEQS there is a worst case admission bound,
+  deliberately overcommitted for realistic prompt sizes. The kv% gauge
+  understates that risk, the concurrency banner overstates capacity
+  (section 5), therefore neither gauge is safe to tune MAX_SEQS against:
+  size it to the prompt lengths your workload actually sends.
+- **The banner is honest at N=1, measured.** A single request on huge climbed
+  to 234,158 tokens (95.3% of max_model_len) and completed with exact needle
+  recall at every rung. The last 4.7% is untested because the corpus ran out,
+  not the engine.
+- **Prefill blocks small requests, and one flag fixes it.** A 72.6k prefill
+  takes ~65 seconds, and while it runs, small requests starve (about 1 tok/s).
+  `--max-num-batched-tokens 512` caps how much prefill each scheduler pass
+  takes, therefore decode steps interleave and a 4k request answers in ~5s
+  during the big prefill. The cost: the big prefill runs about 15% slower.
+- Pin one whale prefix per box and it holds warm across turns.
+
+## 8. Operator notes
+
+- The 8 GB `/dev/shm` offload region **outlives the process** (confirmed on
+  both boxes; one teardown kill left it resident). shm is RAM backed, so the
+  stranded file holds those gigabytes until removed. Clean stale regions at
+  shutdown as well as startup; on a small RAM box the stranded region is the
   next boot's OOM.
-- Docker: `--ipc host` required — the 64 MB default shm makes the region's
-  `madvise(MADV_POPULATE_WRITE)` fail with EFAULT at boot.
-- `alternative.sh` silently ignores `SPEC=off`; a no-nvcc image silently
-  runs spec-off. Check the boot banner, not the launch command.
-- `GPU_UTIL=0.972` never fits under WSL2 (compositor + WDDM overhead);
-  fine on headless native. fp8 MAX_LEN geometry ≠ int4's numbers.
-- cudart loading: see §6's loader note.
-- Two independent `sed` failures in one week (a silent no-op edit; an
-  alternation filter under non-`-E` sed that printed nothing while the run
-  was fine): **instruments persist raw output (`--json` always); the
-  presentation layer is allowed to fail.**
+- Docker needs `--ipc host` for the offload tier: the 64 MB default shm makes
+  the region's `madvise(MADV_POPULATE_WRITE)` fail with EFAULT at boot.
+- `single-user/alternative.sh` hardcodes `--speculative-config` and ignores
+  `SPEC=off`, so an A/B against it silently runs two spec-on arms. The tell:
+  the emitted per step receipt read 2.29 on an arm that must read 1.00 with
+  speculation off. An unrecognized `SPEC` should refuse, not proceed.
+- `GPU_UTIL=0.972` never fits under WSL2 (compositor and WDDM overhead); it
+  is fine on headless native. fp8 MAX_LEN geometry does not transfer to int4.
+- `verify.sh` verifies patch application, not runtime behavior; we were bitten
+  by the difference twice.
 
-## 9. Methodology
+## 9. How we worked
 
-Pre-registered predictions before each arm (two held across the campaign;
-six mechanism stories died on instruments built to kill them). One rule
-this campaign paid for four times, in four different ways: **a retention
-measurement is only valid when nothing else can produce a fast recheck.**
-A tier restore, a shared prefix between ladder rungs, and pool residue
-from a prior rung all read as "retained" through a latency threshold — a
-latency threshold is not a mechanism discriminator. Corollaries: retention
-numbers are valid only with the offload tier off (stated as precondition,
-not assumption); ladder rungs must share no prefix (a descending ladder
-with fixed salts is contaminated at exactly the rung being hunted, while
-the same code read ascending is safe); and the boundary rung must
-reproduce **in isolation** — a fresh boot at that length alone — before
-the number is real. The model rejections in §5 rested on two paired
-halves, and both are load-bearing: **over-determination is the only thing
-that can kill a model** (two boundaries fitting two one-parameter models
-is an exactly-determined fit that cannot lose), and **pre-registered
-opposite predictions on a single rung** are what let one rung reject
-anything at all — over-determination without pre-registration would have
-let either reading survive. The
-falsification bracket as the standard of "fixed": reproduce the failure,
-apply the fix, watch it pass, remove the fix, watch it fail again. And the
-campaign's capstone, paid for twice: **a pass from an unexecuted branch is
-indistinguishable from a pass — only the execution count tells you which you
-have.** (v1 of the offload fix "validated" on four arms whose happy path
-never ran; v3 was redesigned so every failure branch raises and a live
-engine is itself the proof of execution.) The same discipline killed one of
-our own contributions before it could ship: a banner patch printing
-model-derived warm-context capacity passed its internal-consistency check,
-then failed its pre-registered tier-off falsification (predicted 2/2,
-measured 0/2) — it is parked on an experiment branch as mechanism data, not
-merged, because a wrong honesty line is worse than none. Corrections
-throughout the docs are struck in place, not cleaned — the record keeps its
-own history legible.
+Every arm ran with predictions registered before the result came back, and the
+standard for "fixed" was the full bracket: reproduce the failure, apply the
+fix, watch it pass, remove the fix, watch it fail again. Six mechanism stories
+died on instruments built to kill them, and several of the deaths were our own
+published claims, retracted within hours.
+
+Three rules we paid for and now keep:
+
+- **A pass from a branch that never executed is indistinguishable from a
+  pass.** Only the execution count tells you which you have (the v1 loader
+  story in section 6).
+- **A retention measurement is only valid when nothing else can produce a
+  fast recheck.** A tier restore, a shared prefix between test rungs, and
+  pool residue from a prior rung all read as "retained" through a latency
+  threshold. Corollaries: retention numbers are only valid with the offload
+  tier off; test rungs must share no prefix; and a boundary rung must
+  reproduce alone in a fresh boot before the number is real.
+- **Over-determination is the only thing that can kill a model, and
+  pre-registration is what makes the kill honest.** Two boundaries fitting
+  two one parameter models is an exactly determined fit that cannot lose;
+  a second boundary at a different K rejects one model outright, but only
+  because both predictions were written down first.
+
+The same discipline killed one of our own contributions before it shipped: a
+startup banner patch that printed model derived warm context capacity passed
+its internal consistency check, then failed its pre-registered tier-off test
+(predicted 2/2, measured 0/2). It is parked on an experiment branch as
+mechanism data, unmerged, because a wrong honesty line is worse than none.
+Corrections throughout the docs are struck in place rather than cleaned, so
+the record keeps its own history readable.

--- a/docs/MR-DRAFT.md
+++ b/docs/MR-DRAFT.md
@@ -1,0 +1,191 @@
+# MR draft — speculative decoding at depth, the CPU tier, and two fixes
+
+> **DRAFT — not filed.** This is the assembled body for the single upstream MR
+> covering both boxes (RTX 4090 / WSL2 / Windows 11 · RTX 3090 / native
+> Ubuntu). Michael files it. One measurement slot is still open (§7, the
+> needle-at-max-len probe, running on the 3090). Every number below traces to
+> the bench record; the load-bearing claims are measured on both boxes.
+
+## Summary
+
+This MR carries two fixes, one kernel, one measurement correction, and the
+operating doctrine that fell out of measuring them:
+
+1. **OffloadingConnector fix for non-UVA platforms** (`patches/offload-wsl2-devptr.patch`)
+   — the CPU offload tier crashes with an illegal memory access on WSL2;
+   root-caused to host-VA dereference in the Triton swap kernel, fixed with
+   device-pointer translation, validated by falsification bracket on both
+   platforms. Likely genuinely upstream-vLLM (any WSL2 user of the
+   OffloadingConnector, any model).
+2. **Prefix-cache zero-reuse on int4 KV + DFlash2** — a one-flag fix
+   (`--prefix-match-unit 848`) with the two-site contradiction analysis that
+   explains why it was invisible under int8.
+3. **An int4 MQ-3D spec-decode kernel** — 33-line dispatch change + reducer
+   guard; true end-to-end ~3.3× on deep int4 spec decode (22.3 → ~73 tok/s).
+   Held behind six promotion gates (listed in §3); included as a separate,
+   cuttable commit.
+4. **A measurement correction that affects any SSE-based benchmark of
+   speculative decoding** (§1) — it reversed our own initial "speculation
+   loses at depth" conclusion.
+5. **Doctrine**: the two-wing serving design, retention capacity vs.
+   round-robin, MAX_SEQS as designed geometry, and operator notes.
+
+## 1. The unit inversion — a correction that affects every SSE chunk-rate benchmark
+
+With speculative decoding on, **SSE chunks are spec steps, not tokens** (~3
+tokens per chunk at n7 acceptance). Any benchmark that counts chunks/s is
+undercounting spec-on throughput ~3× while counting spec-off correctly — a
+systematic bias *against* speculation. Fix: request
+`stream_options.include_usage` and read `usage.completion_tokens`; report
+emitted-tokens-per-step alongside as the receipt. Both boxes reproduced the
+inversion independently. All spec-on rates in this MR are token-true.
+
+## 2. The token-true deep map (72.6k-token context, 4090/WSL2)
+
+| Config | decode tok/s (deep) |
+|---|---|
+| int4 KV + MQ-3D kernel, DFlash2 n7 | **70.5–75.2** |
+| long (int8 KV), DFlash2 n7 | 64–68 |
+| huge (KVarN 4/2-bit), DFlash2 n7 | ~60–63 |
+| int4 KV, spec off | 35.55 |
+| int4 KV, stock #42 dispatch, DFlash2 n7 | 22.3 |
+
+**Speculation wins ~2× at depth with the right kernel** — the pre-correction
+verdict ("spec loses at 72k") was the unit inversion plus the stock int4
+dispatch, compounded. The stock dispatch genuinely loses (0.63× vs spec-off);
+the kernel turns that into a 2× win.
+
+## 3. The int4 MQ-3D kernel
+
+Stock #42's spec-decode path launches the int4 attention kernel once per query
+position (2D grid); the MQ-3D form dispatches all q positions in one 3D launch
+with a reducer guard. 33 lines. Measured: 8.14 → 25.2–25.4 steps/s at 72.6k
+(×2.74 step rate), true e2e 22.3 → ~73 tok/s (~3.3×). **Held behind six
+promotion gates** before it should merge: 72k operator/logit oracle ·
+full-length exactness · per-position logit comparison · eager+captured+q=9
+parity · shallow crossover (shallow shows −16%; wants a seq_len floor) ·
+capture-aware dual-variant switching. Included as its own commit so it can be
+cut without touching the rest.
+
+## 4. Prefix-cache zero-reuse on int4 + DFlash2 — the one-flag fix
+
+Symptom: int4 KV + DFlash2 gets **zero** prefix-cache hits (every request
+re-prefills; 62s TTFT on a warm 72.6k whale). The 2×2 cross-box isolation:
+int8+DFlash hits, int4−DFlash hits — the interaction is int4 × DFlash2.
+
+Cause: the kvarn-v2 port's two sites carry contradictory assumptions. The GCD
+computation *excludes* SW groups ("their block is a divisor of the primary by
+construction" — true), yielding hash unit 1696; the SW guard then demands the
+SW block (848) be a *multiple* of that hash unit — 848 % 1696 ≠ 0, guaranteed
+false by the exclusion itself. Invisible under int8 where 864 = 864 satisfies
+both clauses.
+
+Fix: the port's own escape hatch, **`--prefix-match-unit 848`** (the GCD) —
+every clause then passes by arithmetic (1696 % 848 = 0, 848 % 848 = 0, both
+read clauses). Verified warm-whale TTFT 62s → 4.3s. **Rule: the
+prefix-match unit must equal the SW block, and it is per-(model, kv-dtype,
+draft-length)** — 848 is this model's number, not a constant.
+
+## 5. Retention — capacity and round-robin are different questions
+
+Measured on the 3090 (int8/long, three distinct contexts, 111,904 naive
+tokens = 82% of a 136,429-token pool):
+
+- **Capacity** ("what the pool holds"): recheck the *newest* context only →
+  retained, 2.24s vs 50.35s cold (22×). Capacity ≈ **1.3 contexts**.
+- **Round-robin** ("what the workload sees"): recheck A, B, C in order →
+  **0/3**, every recheck ~1.0× cold. The sweep's own prefills evict the next
+  context before it is asked.
+
+The tax is mamba-dominated (fixed-size per-seq state pages, ≈2× at ~37k
+contexts) plus drafter groups (to ~2.7× under spec). Consequence for the
+engine's own banner: **"Maximum concurrency" overestimates ~2.68×** because it
+divides pool by max_len and ignores the group pages.
+
+**Product sentence:** with the CPU offload tier (§6), the same round-robin
+pattern goes **0/3 → 3/3** (three 72.6k whales all recheck warm at 4.2–4.3s
+on the 4090). The tier doesn't merely raise capacity; it converts the serving
+pattern operators actually run from zero reuse to full reuse.
+
+## 6. The OffloadingConnector fix (the patch in this MR)
+
+Full write-up: `docs/wsl2-4090.md` § "CPU offload tier under WSL2". Short
+form: the Triton `swap_blocks` kernel dereferences **host** VAs of the
+`cudaHostRegistered` /dev/shm mmap. Native UVA makes host VA == device VA by
+coincidence; WSL2 maps the region at a different device address and the
+kernel faults. The fix calls `cudaHostGetDevicePointer` after registration,
+carries the delta on the CPU views, and adds it where
+`compute_sub_block_ptrs` builds addresses. Delta is 0 on native — no behavior
+change. All failure branches **raise** (a platform without the device pointer
+refuses to start rather than run silent-unsafe) — which makes a live patched
+engine itself evidence the query ran: the fix is not only safer but more
+falsifiable than a warn-and-continue shape.
+
+Falsification bracket: WSL2 with fix = 3 whales warm, 0 IMAs; fix removed =
+IMA ×3, first prime dies. Native = three arms byte-identical at 52.4 tok/s,
+805 MB moved through the tier live, loader resolves via `CDLL(None)`, rc=0,
+delta=0. Loader note: pip wheels ship only *versioned* cudart sonames at
+wheel paths, so `CDLL("libcudart.so")` fails on most native installs —
+resolve from the process image first.
+
+Production-form follow-on (tracked, not in this MR): typed two-pointer
+separation instead of a delta attribute, transfer records, restored-state
+checksums, lifecycle/teardown coverage.
+
+## 7. Two wings, and MAX_SEQS as designed geometry
+
+- **Spec wing** (single/low concurrency, DFlash2 on): wins ≤C4–C8. long C4 =
+  517 agg (4090).
+- **Batch wing** (spec off, batch geometry): takes over ~C10+. 4090
+  fp8-block-800: 676 agg @ C16. 3090 shipped `fast` @ `GPU_UTIL=0.972`
+  (boots native; WSL2 refuses this setting): ms/pass 23.3 → 28.2 across
+  C1–C16 — a 21% spread over a 16× batch — with **zero preemptions at every
+  level**, where the spec profile took 2 at N=8. *The wings differ in what
+  they are willing to have go wrong, not only in speed.* (The two boxes'
+  batch rows are different profiles — kept as separate rows, never a ratio.)
+- **MAX_SEQS is designed geometry, not a free knob**: graph budget (3090:
+  N=4 aggregate +6.1% just from MS=8→4) *and* worst-case admission bound
+  (huge MS=2 shows 44.7% KV at N=2, yet 2 × 245,760 > the 268,169 pool —
+  and that arithmetic is naive-token, i.e. optimistic, per §5's tax). **The
+  two gauges lie in opposite directions** — kv% understates worst-case
+  admission risk, the concurrency banner overstates capacity ~2.68× — so an
+  operator reading both sees headroom twice and tunes into a cliff. Size
+  MAX_SEQS to the workload's real prompt distribution, never to a gauge.
+- **[PENDING — needle-at-max-len probe, 3090]**: does ONE full 245,760-token
+  request complete on `huge`? If not, the banner is wrong about *one*, not
+  merely optimistic about concurrency.
+- **Politeness knob**: `--max-num-batched-tokens 512` makes minnows live
+  (~5s) under a whale prefill for ~15% whale tax (prefill head-of-line
+  blocking is the mechanism).
+- **Pinned prefixes**: pin one whale prefix per box and it holds.
+
+## 8. Operator notes / gotcha ledger
+
+- The 8 GB `/dev/shm` offload region **outlives the process** (confirmed
+  empirically on both boxes) and holds RAM while the box idles — clean at
+  shutdown as well as startup; on a small-RAM box the stranded region is the
+  next boot's OOM.
+- Docker: `--ipc host` required — the 64 MB default shm makes the region's
+  `madvise(MADV_POPULATE_WRITE)` fail with EFAULT at boot.
+- `alternative.sh` silently ignores `SPEC=off`; a no-nvcc image silently
+  runs spec-off. Check the boot banner, not the launch command.
+- `GPU_UTIL=0.972` never fits under WSL2 (compositor + WDDM overhead);
+  fine on headless native. fp8 MAX_LEN geometry ≠ int4's numbers.
+- cudart loading: see §6's loader note.
+- Two independent `sed` failures in one week (a silent no-op edit; an
+  alternation filter under non-`-E` sed that printed nothing while the run
+  was fine): **instruments persist raw output (`--json` always); the
+  presentation layer is allowed to fail.**
+
+## 9. Methodology
+
+Pre-registered predictions before each arm (two held across the campaign;
+six mechanism stories died on instruments built to kill them). The
+falsification bracket as the standard of "fixed": reproduce the failure,
+apply the fix, watch it pass, remove the fix, watch it fail again. And the
+campaign's capstone, paid for twice: **a pass from an unexecuted branch is
+indistinguishable from a pass — only the execution count tells you which you
+have.** (v1 of the offload fix "validated" on four arms whose happy path
+never ran; v3 was redesigned so every failure branch raises and a live
+engine is itself the proof of execution.) Corrections throughout the docs
+are struck in place, not cleaned — the record keeps its own history legible.

--- a/docs/MR-DRAFT.md
+++ b/docs/MR-DRAFT.md
@@ -100,18 +100,30 @@ tokens = 82% of a 136,429-token pool):
   **0/3**, every recheck ~1.0× cold. The sweep's own prefills evict the next
   context before it is asked.
 
-The tax is mamba-dominated (fixed-size per-seq state pages, ≈2× at ~37k
-contexts) plus drafter groups (to ~2.7× under spec). Consequence for the
-engine's own banner: **"Maximum concurrency" overestimates multi-context
-capacity ~2.68×** because it divides pool by max_len and ignores the group
-pages. (The 2.68× is measured on the 4090; the 3090 corroborates it by
-independent derivation from its own boot-log arithmetic against the measured
-~1.3-context capacity — corroboration, not a second measurement.)
+The tax is mamba-dominated (fixed-size per-seq state pages) plus drafter
+groups. Measured bounds: on the 4090 (int4 geometry, 300,583-token pool),
+two 72.6k contexts do **not** both stay warm (K=2 no-tier round-robin =
+0/2), so real per-context cost exceeds 150k tokens at 72.6k — a multiplier
+above 2.07× at that depth. Consequence for the engine's own banner: its
+number is **right only at full length** (proved by the needle probe, §7).
+At shorter or cached contexts the real cost per context is substantially
+larger than its token count — and a naive constant-plus-linear model
+computed from the engine's own spec bytes still *under*counts the measured
+cost (we falsified our own corrective banner patch against this data; the
+gap mechanism — drafter group pages, per-group block rounding, or
+prefix-retention granularity — is an open question this MR flags rather
+than answers).
 
 **Product sentence:** with the CPU offload tier (§6), the same round-robin
-pattern goes **0/3 → 3/3** (three 72.6k whales all recheck warm at 4.2–4.3s
-on the 4090). The tier doesn't merely raise capacity; it converts the serving
-pattern operators actually run from zero reuse to full reuse.
+pattern goes **0/3 → 3/3** (three 72.6k whales all recheck in 4.2–4.3s on
+the 4090 — tier restores, not GPU-warm hits, and that is the point: the
+GPU pool holds ~one such context warm, and the tier serves the rest at
+interactive latency instead of a 62s recompute). Measured under true
+concurrency: three simultaneous agents, each on its own 72.6k context,
+firing repeatedly — every round completes with **zero recomputes**;
+unqueued tier restores land in 5–7s, the LRU-rotated seat pays ~16s
+restoring under load, against 62s cold. Three deep agents on one 24 GB
+card is a serving pattern this tier makes real.
 
 ## 6. The OffloadingConnector fix (the patch in this MR)
 
@@ -160,19 +172,20 @@ checksums, lifecycle/teardown coverage.
   and that arithmetic is naive-token, i.e. optimistic, per §5's tax). **The
   two gauges lie in opposite directions** — kv% understates worst-case
   admission risk, the concurrency banner overstates multi-context capacity
-  ~2.68× (honest at N=1; see the needle row below) — so an operator reading
-  both sees headroom twice and tunes into a cliff. Size MAX_SEQS to the
-  workload's real prompt distribution, never to a gauge.
+  by 2×+ (measured bound, §5; honest at N=1 — see the needle row below) —
+  so an operator reading both sees headroom twice and tunes into a cliff.
+  Size MAX_SEQS to the workload's real prompt distribution, never to a
+  gauge.
 - **Needle-at-max-len (3090)**: a single request climbing to **234,158
   tokens — 95.3% of max_model_len — completes with exact needle recall**
   (the last 4.7% untested: the corpus ran out, not the engine). So the
   banner is honest about *one*, which sharpens the criticism rather than
   softening it: the banner is not wrong about capacity but about **what
   capacity means**. `pool / max_model_len` is a true statement about a
-  single live request and a ~2.68× overstatement the moment the question is
-  concurrent or cached contexts, where the 9-group page tax applies. Same
-  number, honest in one regime and misleading in the other, with nothing on
-  the line to say which regime you are in.
+  single live request and a 2×+ overstatement (measured bound, §5) the
+  moment the question is concurrent or cached contexts, where the 9-group
+  page tax applies. Same number, honest in one regime and misleading in the
+  other, with nothing on the line to say which regime you are in.
 - **Politeness knob**: `--max-num-batched-tokens 512` makes minnows live
   (~5s) under a whale prefill for ~15% whale tax (prefill head-of-line
   blocking is the mechanism).
@@ -206,5 +219,11 @@ campaign's capstone, paid for twice: **a pass from an unexecuted branch is
 indistinguishable from a pass — only the execution count tells you which you
 have.** (v1 of the offload fix "validated" on four arms whose happy path
 never ran; v3 was redesigned so every failure branch raises and a live
-engine is itself the proof of execution.) Corrections throughout the docs
-are struck in place, not cleaned — the record keeps its own history legible.
+engine is itself the proof of execution.) The same discipline killed one of
+our own contributions before it could ship: a banner patch printing
+model-derived warm-context capacity passed its internal-consistency check,
+then failed its pre-registered tier-off falsification (predicted 2/2,
+measured 0/2) — it is parked on an experiment branch as mechanism data, not
+merged, because a wrong honesty line is worse than none. Corrections
+throughout the docs are struck in place, not cleaned — the record keeps its
+own history legible.

--- a/docs/MR-DRAFT.md
+++ b/docs/MR-DRAFT.md
@@ -111,11 +111,16 @@ multiplicative (`cost = m·L`) fails on int4 (K=2 caps m at 2.93 while a
 K=3 0/3 at ~31.7k requires m > 3.18 — disjoint), and pure
 additive-constant (`cost = L + F`, the model our own falsified banner
 patch implemented from the engine's spec bytes) fails on int8 (K=2 and
-K=3 demand F in disjoint intervals). An affine shape (slope ≈2.5
-pool-tokens per context token plus a small dtype-dependent constant) fits
-every boundary on both boxes, but that is a two-parameter fit against six
-inequalities — a candidate, not a finding. This MR ships the measured
-brackets and flags the cost-shape mechanism as open. The engine's own
+K=3 demand F in disjoint intervals). An affine shape (`cost = a·L + F`)
+fits every boundary on both boxes — but the feasible region is wide:
+every slope from a = 1.5 to a = 4.0 admits some constant, so **the affine
+is the last model standing, which is a different claim from the affine
+being right**. What would actually bite is not another data point but a
+designed rung where two feasible (a, F) pairs predict opposite outcomes
+(feasible pairs diverge fast at large L) — left as follow-on. This MR
+ships the measured brackets — every boundary rung on both boxes
+reproduced **alone in a fresh boot** before being called a measurement —
+and flags the cost-shape mechanism as open. The engine's own
 banner is **right only at full length** (proved by the needle probe, §7);
 at shorter or cached contexts nothing in the log says the real cost is
 2–3× the token count — which is the operator trap.
@@ -229,7 +234,13 @@ not assumption); ladder rungs must share no prefix (a descending ladder
 with fixed salts is contaminated at exactly the rung being hunted, while
 the same code read ascending is safe); and the boundary rung must
 reproduce **in isolation** — a fresh boot at that length alone — before
-the number is real. The
+the number is real. The model rejections in §5 rested on two paired
+halves, and both are load-bearing: **over-determination is the only thing
+that can kill a model** (two boundaries fitting two one-parameter models
+is an exactly-determined fit that cannot lose), and **pre-registered
+opposite predictions on a single rung** are what let one rung reject
+anything at all — over-determination without pre-registration would have
+let either reading survive. The
 falsification bracket as the standard of "fixed": reproduce the failure,
 apply the fix, watch it pass, remove the fix, watch it fail again. And the
 campaign's capstone, paid for twice: **a pass from an unexecuted branch is

--- a/docs/MR-DRAFT.md
+++ b/docs/MR-DRAFT.md
@@ -212,7 +212,18 @@ checksums, lifecycle/teardown coverage.
 ## 9. Methodology
 
 Pre-registered predictions before each arm (two held across the campaign;
-six mechanism stories died on instruments built to kill them). The
+six mechanism stories died on instruments built to kill them). One rule
+this campaign paid for four times, in four different ways: **a retention
+measurement is only valid when nothing else can produce a fast recheck.**
+A tier restore, a shared prefix between ladder rungs, and pool residue
+from a prior rung all read as "retained" through a latency threshold — a
+latency threshold is not a mechanism discriminator. Corollaries: retention
+numbers are valid only with the offload tier off (stated as precondition,
+not assumption); ladder rungs must share no prefix (a descending ladder
+with fixed salts is contaminated at exactly the rung being hunted, while
+the same code read ascending is safe); and the boundary rung must
+reproduce **in isolation** — a fresh boot at that length alone — before
+the number is real. The
 falsification bracket as the standard of "fixed": reproduce the failure,
 apply the fix, watch it pass, remove the fix, watch it fail again. And the
 campaign's capstone, paid for twice: **a pass from an unexecuted branch is

--- a/docs/MR-DRAFT.md
+++ b/docs/MR-DRAFT.md
@@ -101,18 +101,24 @@ tokens = 82% of a 136,429-token pool):
   context before it is asked.
 
 The tax is mamba-dominated (fixed-size per-seq state pages) plus drafter
-groups. Measured bounds: on the 4090 (int4 geometry, 300,583-token pool),
-two 72.6k contexts do **not** both stay warm (K=2 no-tier round-robin =
-0/2), so real per-context cost exceeds 150k tokens at 72.6k — a multiplier
-above 2.07× at that depth. Consequence for the engine's own banner: its
-number is **right only at full length** (proved by the needle probe, §7).
-At shorter or cached contexts the real cost per context is substantially
-larger than its token count — and a naive constant-plus-linear model
-computed from the engine's own spec bytes still *under*counts the measured
-cost (we falsified our own corrective banner patch against this data; the
-gap mechanism — drafter group pages, per-group block rounding, or
-prefix-retention granularity — is an open question this MR flags rather
-than answers).
+groups. **Measured** (L-bisection with per-length salts, tier off, each
+boundary rung required to reproduce alone in a fresh boot): per-context
+retention cost is **≈2.5–2.9× its token count** at ~51–61k-token contexts
+on the 4090/int4 geometry (pool 300,583), and **≈2.3–2.7×** at ~25–29k on
+the 3090/int8 geometry (pool 136,429). Pre-registered K=3 discriminator
+rungs then rejected **both** simple cost models, one per geometry: pure
+multiplicative (`cost = m·L`) fails on int4 (K=2 caps m at 2.93 while a
+K=3 0/3 at ~31.7k requires m > 3.18 — disjoint), and pure
+additive-constant (`cost = L + F`, the model our own falsified banner
+patch implemented from the engine's spec bytes) fails on int8 (K=2 and
+K=3 demand F in disjoint intervals). An affine shape (slope ≈2.5
+pool-tokens per context token plus a small dtype-dependent constant) fits
+every boundary on both boxes, but that is a two-parameter fit against six
+inequalities — a candidate, not a finding. This MR ships the measured
+brackets and flags the cost-shape mechanism as open. The engine's own
+banner is **right only at full length** (proved by the needle probe, §7);
+at shorter or cached contexts nothing in the log says the real cost is
+2–3× the token count — which is the operator trap.
 
 **Product sentence:** with the CPU offload tier (§6), the same round-robin
 pattern goes **0/3 → 3/3** (three 72.6k whales all recheck in 4.2–4.3s on

--- a/docs/MR-DRAFT.md
+++ b/docs/MR-DRAFT.md
@@ -61,12 +61,14 @@ the kernel turns that into a 2× win.
 Stock #42's spec-decode path launches the int4 attention kernel once per query
 position (2D grid); the MQ-3D form dispatches all q positions in one 3D launch
 with a reducer guard. 33 lines. Measured: 8.14 → 25.2–25.4 steps/s at 72.6k
-(×2.74 step rate), true e2e 22.3 → ~73 tok/s (~3.3×). **Held behind six
-promotion gates** before it should merge: 72k operator/logit oracle ·
-full-length exactness · per-position logit comparison · eager+captured+q=9
-parity · shallow crossover (shallow shows −16%; wants a seq_len floor) ·
-capture-aware dual-variant switching. Included as its own commit so it can be
-cut without touching the rest.
+(×2.74 step rate), true e2e 22.3 → ~73 tok/s (~3.3×). Ships as
+`patches/spec-decode-int4-kv-mq3d.patch` with the dispatch **opt-in**
+(`VLLM_INT4_MQ_3D=1`; default off) because six promotion gates remain open
+before it should become the default: 72k operator/logit oracle · full-length
+exactness · per-position logit comparison · eager+captured+q=9 parity ·
+shallow crossover (shallow shows −16%; wants a seq_len floor) ·
+capture-aware dual-variant switching. Its own commit, cuttable without
+touching the rest.
 
 ## 4. Prefix-cache zero-reuse on int4 + DFlash2 — the one-flag fix
 

--- a/docs/MR-DRAFT.md
+++ b/docs/MR-DRAFT.md
@@ -2,9 +2,10 @@
 
 > **DRAFT — not filed.** This is the assembled body for the single upstream MR
 > covering both boxes (RTX 4090 / WSL2 / Windows 11 · RTX 3090 / native
-> Ubuntu). Michael files it. One measurement slot is still open (§7, the
-> needle-at-max-len probe, running on the 3090). Every number below traces to
-> the bench record; the load-bearing claims are measured on both boxes.
+> Ubuntu). Michael files it. Every planned measurement on both boxes is in;
+> every number below traces to the bench record and the 3090 seat has
+> reviewed its own rows (no misquotes found); the load-bearing claims are
+> measured on both boxes.
 
 ## Summary
 
@@ -99,8 +100,11 @@ tokens = 82% of a 136,429-token pool):
 
 The tax is mamba-dominated (fixed-size per-seq state pages, ≈2× at ~37k
 contexts) plus drafter groups (to ~2.7× under spec). Consequence for the
-engine's own banner: **"Maximum concurrency" overestimates ~2.68×** because it
-divides pool by max_len and ignores the group pages.
+engine's own banner: **"Maximum concurrency" overestimates multi-context
+capacity ~2.68×** because it divides pool by max_len and ignores the group
+pages. (The 2.68× is measured on the 4090; the 3090 corroborates it by
+independent derivation from its own boot-log arithmetic against the measured
+~1.3-context capacity — corroboration, not a second measurement.)
 
 **Product sentence:** with the CPU offload tier (§6), the same round-robin
 pattern goes **0/3 → 3/3** (three 72.6k whales all recheck warm at 4.2–4.3s
@@ -124,9 +128,14 @@ falsifiable than a warn-and-continue shape.
 Falsification bracket: WSL2 with fix = 3 whales warm, 0 IMAs; fix removed =
 IMA ×3, first prime dies. Native = three arms byte-identical at 52.4 tok/s,
 805 MB moved through the tier live, loader resolves via `CDLL(None)`, rc=0,
-delta=0. Loader note: pip wheels ship only *versioned* cudart sonames at
-wheel paths, so `CDLL("libcudart.so")` fails on most native installs —
-resolve from the process image first.
+delta=0. **The bracket is trustworthy only for v3.** v1's native arms
+"passed" inert: `CDLL("libcudart.so")` throws on standard pip installs (the
+wheels ship only *versioned* sonames at wheel paths), so v1's happy path
+never executed on native — and discovering that is what exposed v2's
+would-be regression (its raise would have refused most native boxes). v3
+resolves from the process image first and raises on every failure, so a
+live patched engine is itself the execution proof — the evidence behind
+§9's falsifiability claim.
 
 Production-form follow-on (tracked, not in this MR): typed two-pointer
 separation instead of a delta attribute, transfer records, restored-state
@@ -148,12 +157,20 @@ checksums, lifecycle/teardown coverage.
   (huge MS=2 shows 44.7% KV at N=2, yet 2 × 245,760 > the 268,169 pool —
   and that arithmetic is naive-token, i.e. optimistic, per §5's tax). **The
   two gauges lie in opposite directions** — kv% understates worst-case
-  admission risk, the concurrency banner overstates capacity ~2.68× — so an
-  operator reading both sees headroom twice and tunes into a cliff. Size
-  MAX_SEQS to the workload's real prompt distribution, never to a gauge.
-- **[PENDING — needle-at-max-len probe, 3090]**: does ONE full 245,760-token
-  request complete on `huge`? If not, the banner is wrong about *one*, not
-  merely optimistic about concurrency.
+  admission risk, the concurrency banner overstates multi-context capacity
+  ~2.68× (honest at N=1; see the needle row below) — so an operator reading
+  both sees headroom twice and tunes into a cliff. Size MAX_SEQS to the
+  workload's real prompt distribution, never to a gauge.
+- **Needle-at-max-len (3090)**: a single request climbing to **234,158
+  tokens — 95.3% of max_model_len — completes with exact needle recall**
+  (the last 4.7% untested: the corpus ran out, not the engine). So the
+  banner is honest about *one*, which sharpens the criticism rather than
+  softening it: the banner is not wrong about capacity but about **what
+  capacity means**. `pool / max_model_len` is a true statement about a
+  single live request and a ~2.68× overstatement the moment the question is
+  concurrent or cached contexts, where the 9-group page tax applies. Same
+  number, honest in one regime and misleading in the other, with nothing on
+  the line to say which regime you are in.
 - **Politeness knob**: `--max-num-batched-tokens 512` makes minnows live
   (~5s) under a whale prefill for ~15% whale tax (prefill head-of-line
   blocking is the mechanism).

--- a/docs/python-314.md
+++ b/docs/python-314.md
@@ -1,0 +1,74 @@
+# Python 3.14, natively
+
+*Contributed from a reproduction on an RTX 3090, Ubuntu 26.04, August 2026. The short
+version: **nothing in this repo needs changing for 3.14.** One system package does.*
+
+[← back to the main README](../README.md)
+
+The README specifies Python 3.12, and the container freezes it there. That is a safe
+default rather than a hard requirement — vLLM 0.27.1 publishes an **abi3 wheel** (tagged
+`cp38`, `requires_python <3.15,>=3.10`) and torch 2.13 ships real `cp314` wheels, so
+`pip install vllm==0.27.1` resolves and imports cleanly on 3.14.
+
+Every patch in `patches/` applies unmodified. `verify.sh --no-server` passes. The
+single-user benchmark reproduces the README's cohort table (numbers below).
+
+## What actually blocks it
+
+**`python3.14-dev`.** Triton JIT-compiles a small C launcher at runtime and needs the
+Python development headers. Without them the server dies during model-architecture
+inspection with a traceback whose useful line is buried:
+
+```
+/tmp/tmpXXXXXX/cuda_utils.c:9:10: fatal error: Python.h: No such file or directory
+```
+
+which vLLM then re-raises as the much less helpful:
+
+```
+Model architectures ['Qwen3_5ForConditionalGeneration'] failed to be inspected.
+```
+
+Fix, matching your interpreter version exactly:
+
+```bash
+sudo apt-get install -y python3.14-dev     # or python3.13-dev, etc.
+```
+
+`gcc` must also be present; Triton shells out to it.
+
+## Three things that cost us time and are not version-specific
+
+1. **The patches are SEQUENTIALLY DEPENDENT.** Applied individually, three of fifteen fail
+   (`dflash2-lookup-drafting`, `spec-decode-int8-kv`, `vision-tower-cpu-offload`) because
+   they build on hunks an earlier patch introduces. Applied in the README's loop order, all
+   fifteen land. A dry-run over the set will look like an incompatibility and is not one.
+
+2. **`patch -d` targets the `vllm` PACKAGE directory, not `site-packages`.** The README is
+   correct; it is an easy misread. Pointing one level too high fails all fifteen, which
+   looks exactly like "this vLLM is wrong."
+
+3. **`bench/run_benchmarks.sh` needs `vllm[bench]`** (pandas) for the custom-dataset
+   cohorts. The `random` dataset path works without it, so a partial install looks like a
+   working one — the cohort logs contain `ModuleNotFoundError: No module named 'pandas'`
+   while the harness still prints its `ROW` lines, with every field empty.
+   And the bench client authenticates with **`OPENAI_API_KEY`**, not `VLLM_API_KEY`; with
+   only the latter set it receives silent 401s and reports `0.00` in every field rather
+   than failing.
+
+## Install, start to finish
+
+```bash
+sudo apt-get install -y python3.14-dev gcc
+python3 -m venv venv
+venv/bin/pip install 'vllm[bench]==0.27.1' huggingface_hub hf_transfer ninja \
+  flashinfer-python flashinfer-cubin==0.6.13
+# model + requantization exactly as the README
+VP=$(venv/bin/python -c 'import vllm,os;print(os.path.dirname(vllm.__file__))')
+for p in patches/*.patch; do patch -p1 -d "$VP" < "$p"; done   # order matters
+bash verify.sh --no-server
+```
+
+## Reproduction
+
+See [reproductions/threadchip-3090.md](reproductions/threadchip-3090.md).

--- a/docs/python-314.md
+++ b/docs/python-314.md
@@ -6,7 +6,7 @@ version: **nothing in this repo needs changing for 3.14.** One system package do
 [← back to the main README](../README.md)
 
 The README specifies Python 3.12, and the container freezes it there. That is a safe
-default rather than a hard requirement — vLLM 0.27.1 publishes an **abi3 wheel** (tagged
+default rather than a hard requirement: vLLM 0.27.1 publishes an **abi3 wheel** (tagged
 `cp38`, `requires_python <3.15,>=3.10`) and torch 2.13 ships real `cp314` wheels, so
 `pip install vllm==0.27.1` resolves and imports cleanly on 3.14.
 
@@ -15,7 +15,7 @@ single-user benchmark reproduces the README's cohort table (numbers below).
 
 ## What actually blocks it
 
-**`python3.14-dev`.** Triton JIT-compiles a small C launcher at runtime and needs the
+**`python3.14-dev`.** Triton JIT-compiles a small C launcher at runtime, so it needs the
 Python development headers. Without them the server dies during model-architecture
 inspection with a traceback whose useful line is buried:
 
@@ -42,7 +42,7 @@ sudo apt-get install -y python3.14-dev     # or python3.13-dev, etc.
 1. **The patches are SEQUENTIALLY DEPENDENT.** Applied individually, three of fifteen fail
    (`dflash2-lookup-drafting`, `spec-decode-int8-kv`, `vision-tower-cpu-offload`) because
    they build on hunks an earlier patch introduces. Applied in the README's loop order, all
-   fifteen land. A dry-run over the set will look like an incompatibility and is not one.
+   fifteen land. A dry-run over the set will look like an incompatibility but is not one.
 
 2. **`patch -d` targets the `vllm` PACKAGE directory, not `site-packages`.** The README is
    correct; it is an easy misread. Pointing one level too high fails all fifteen, which
@@ -50,7 +50,7 @@ sudo apt-get install -y python3.14-dev     # or python3.13-dev, etc.
 
 3. **`bench/run_benchmarks.sh` needs `vllm[bench]`** (pandas) for the custom-dataset
    cohorts. The `random` dataset path works without it, so a partial install looks like a
-   working one — the cohort logs contain `ModuleNotFoundError: No module named 'pandas'`
+   working one: the cohort logs contain `ModuleNotFoundError: No module named 'pandas'`
    while the harness still prints its `ROW` lines, with every field empty.
    And the bench client authenticates with **`OPENAI_API_KEY`**, not `VLLM_API_KEY`; with
    only the latter set it receives silent 401s and reports `0.00` in every field rather
@@ -71,4 +71,4 @@ bash verify.sh --no-server
 
 ## Reproduction
 
-See [reproductions/threadchip-3090.md](reproductions/threadchip-3090.md).
+See [reproductions/native-3090.md](reproductions/native-3090.md).

--- a/docs/reproductions/native-3090.md
+++ b/docs/reproductions/native-3090.md
@@ -15,7 +15,7 @@ applied. Every run below discards a warmup pass, per the README's own instructio
 | model | `dbirks/Qwen3.8-27B-W4A16-AutoRound` + repo requantization + fast variant + DFlash2 drafter |
 | KVarN | installed (`kvarn/install.sh`) |
 
-## `bench/run_benchmarks.sh single`, greedy — vs the README
+## `bench/run_benchmarks.sh single`, greedy, vs the README
 
 | cohort | ours e2e | ours decode | README |
 |---|---:|---:|---:|
@@ -30,7 +30,7 @@ Within a few percent throughout. **The README's table reproduces on Python 3.14.
 
 | profile | KV dtype | max_model_len | pool | perplexity¹ |
 |---|---|---:|---:|---:|
-| `CTX=fast` | bf16 | 65,536 | 68,605–72,992² | 3.1174 |
+| `CTX=fast` | bf16 | 65,536 | 68,605-72,992² | 3.1174 |
 | `CTX=long` | int8 per-token-head | 131,072 | 136,429 | 3.1100 |
 | `CTX=huge` | KVarN 4/2-bit | 245,760 | 268,169 | 3.1107 |
 
@@ -56,8 +56,8 @@ cohort so no row is measuring cache warmth instead of concurrency.
 2×.** fermion's first reading of this had the opposite sign and was retracted: their
 deep-decode probe counted SSE chunks, and that stack emits **one chunk per speculative step**,
 so every spec-on number was low by the emitted/step factor (~3×). Token-true, at 72k: int4
-with the wide-verify kernel **70–75 tok/s**, `long` **64–68**, against spec-off **35.5**.
-Acceptance at depth is .286/.290 across the two KV dtypes — identical, so the decay is
+with the wide-verify kernel **70-75 tok/s**, `long` **64-68**, against spec-off **35.5**.
+Acceptance at depth is .286/.290 across the two KV dtypes: identical, so the decay is
 model-and-depth rather than dtype. **These deep rows are therefore speculator and profile
 jointly**, and there is no spec-off column here to separate them.
 
@@ -65,7 +65,7 @@ jointly**, and there is no spec-off column here to separate them.
 chunk count is a **step** count. Spec-off is immune at one token per step, which is exactly
 why the wrong world looks self-consistent. Everything in this document takes its token counts
 from `usage.completion_tokens` or the server's `generation_tokens_total` counter, never from
-delta counting — `bench/conc_ladder.py` uses SSE deltas only for first/last timestamps.
+delta counting; `bench/conc_ladder.py` uses SSE deltas only for first/last timestamps.
 
 `CTX=huge` costs roughly 10% shallow and 8% deep against `long`, for 1.9× the window. At
 depth the larger pools hold up where `fast` does not.
@@ -84,7 +84,7 @@ The README predicts *"5.9 s afterwards"* for a 112k document. Reproduced exactly
 
 ## KV quality at 4/2 bits
 
-Perplexity is a weak instrument here — it scores the model's fit to text it is *looking at*,
+Perplexity is a weak instrument here: it scores the model's fit to text it is *looking at*,
 over a short window, which is not where a quantised cache fails. Needle-in-a-haystack on
 `CTX=huge` (KVarN 4/2-bit), one distinctive fact planted at varying depth in a long
 document, exact-match recall:
@@ -98,24 +98,24 @@ document, exact-match recall:
 
 **Caveat, stated because the table would otherwise imply more than it shows:** the bf16
 profile cannot exceed 65,536 tokens, so only the first rung has a like-for-like control.
-This demonstrates that KVarN recalls correctly at 218k — not that it equals bf16 there.
+This demonstrates that KVarN recalls correctly at 218k, not that it equals bf16 there.
 
 ## Prompt shape dominates, and it explains a reported number
 
-A community report of ~208 tok/s did not match our first prose measurement (107.2), and the
+A community report of ~208 tok/s did not match our first prose measurement (107.2), but the
 author later published the prompt and the distinction: **200 was a peak, the average on that
-prompt was ~160, and it was "very simple, code heavy output" — "Please write a Tetris clone
-that can run in a browser."** Prose, he noted, runs 100–120.
+prompt was ~160, and it was "very simple, code heavy output": "Please write a Tetris clone
+that can run in a browser."** Prose, he noted, runs 100-120.
 
 Running that exact prompt here, same configuration, three consecutive runs within 0.2%:
 
 | prompt | ours | reported |
 |---|---:|---:|
 | *"Please write a Tetris clone that can run in a browser."* | **188.3** | ~160 avg, 200 peak |
-| reflective prose essay | **113.1** | 100–120 |
+| reflective prose essay | **113.1** | 100-120 |
 
 Both land inside or above the reported band. **The discrepancy was never hardware or
-configuration — it was that code generation and prose are different workloads.** `LOOKUP`
+configuration: it was that code generation and prose are different workloads.** `LOOKUP`
 drafting predicts repetitive structure well (braces, indentation, boilerplate), so long runs
 clear per verify step; prose branches more and accepts less.
 
@@ -134,7 +134,7 @@ of each other. Reproduction-shaped prompts do climb, consistent with `LOOKUP` dr
 | quote a passage back verbatim | 125.5 |
 | repeat a passage with a substitution | 156.6 |
 
-The original report says "peaked at around 208", and a peak is not a median; the prompt was
+The original report says "peaked at around 208", but a peak is not a median; the prompt was
 not published. Recorded as unreproduced rather than disputed.
 
 ---
@@ -142,7 +142,7 @@ not published. Recorded as unreproduced rather than disputed.
 *Added August 2026, second pass. Everything below shares the stack above; where it does not,
 the row says so.*
 
-## Concurrency ladder — and the 3090/4090 gap widens with load
+## Concurrency ladder: the 3090/4090 gap widens with load
 
 `bench/conc_ladder.py --n 1,2,4,8 --out 256 --reps 2`, `CTX=long`, `MAX_SEQS=8`, shipped
 `KV_MEM` pin. The 4090 column is fermion's run of the identical command under WSL2
@@ -155,35 +155,35 @@ the row says so.*
 | 4 | 46.6 | 79.0 | 1.70× | **316** | **517** | 73.5 | 71.1 | 0 / 0 |
 | 8 | 30.3 | 57.2 | 1.89× | 230\* | 351\* | 98.2 | 98.2 | 2 / 2 |
 
-\* Tail measurement — no instant at which all 8 streams were decoding.
+\* Tail measurement: no instant at which all 8 streams were decoding.
 
 Two things fall out, and the second is the one worth carrying away:
 
 - **The concurrency ceiling is pool geometry, not the card.** N=8 goes tail-mode on *both*
-  boxes at **kv 98.2% with 2 preemptions each** — same occupancy to the decimal, same failure
+  boxes at **kv 98.2% with 2 preemptions each**: same occupancy to the decimal, same failure
   mode, same count. A 4090 does not buy N=8 in long mode; it buys the same wall, reached
   faster. And **N=8 is strictly dominated by N=4 in aggregate on both cards** (230 vs 316
-  here, 351 vs 517 there) — not a tradeoff, a loss.
+  here, 351 vs 517 there): not a tradeoff, a loss.
 - **The 4090's per-stream advantage widens with N: +16% at N=1 → +89% at N=8.** This is
   consistent with, and extends, the README's own explanation of its +1.9% 4090 row
   ([#32](https://github.com/syv-ai/qwen38-27b-rtx3090/issues/32)): *batch-1 decode is
   bandwidth-bound, the extra compute has nothing to bite on.* Raise N and the forward pass
-  goes compute-bound, and sm_89 pulls away. **Sizing a card from a single-stream benchmark
+  goes compute-bound, so sm_89 pulls away. **Sizing a card from a single-stream benchmark
   under-buys for concurrency by roughly 5× the error you think you are making.**
 
 **What this ladder cannot see, and it is the binding constraint on mixed load.** Every stream
-here carries a uniform ~4k prompt, so every prefill is small and comparable — the ladder
+here carries a uniform ~4k prompt, so every prefill is small and comparable: the ladder
 measures *decode* concurrency and is structurally blind to **prefill head-of-line blocking**.
 fermion measured the case it misses: one 72.6k "whale" against 4k "minnows", where the deep
 prefill monopolises the engine for its full ~65 s, admitted minnows ration to ~1 tok/s, and
-the rest queue behind the entire prefill (TTFT 63–82 s). Cached whale, same scenario: 72.2 s
+the rest queue behind the entire prefill (TTFT 63-82 s). Cached whale, same scenario: 72.2 s
 → 13.5 s wall. **So "N=4 is the sweet spot, N=8 is strictly dominated" is scoped to uniform
-short-prompt load** — under mixed depth the constraint is prefill admission, not decode
-concurrency, and the ladder's advice does not transfer.
+short-prompt load**: under mixed depth the constraint is prefill admission, not decode
+concurrency, so the ladder's advice does not transfer.
 
 *Instrument caveats, both found the hard way:* `kv%` is documented as **peak** occupancy
 sampled every 250 ms, and our N=4 run lasts 1.70× longer than fermion's on the same output
-budget — so it gets 1.70× the draws at catching the same transient. **A peak-of-poll compared
+budget, so it gets 1.70× the draws at catching the same transient. **A peak-of-poll compared
 across runs of different duration is structurally biased upward on the slower machine.**
 Compare `preempt` and tail-mode onset instead: discrete, duration-invariant, and they matched
 exactly. Separately, `conc_ladder.py:245` puts `int(time.time())` inside every prompt salt, so
@@ -191,8 +191,8 @@ token counts differ per box, per run, per rep by design.
 
 ## `VLLM_DFLASH2_LOOKUP`, and how to measure an env toggle at all
 
-Every env-toggle A/B on this stack is a **cross-boot** comparison — the toggle needs a
-restart — so it is only readable against a measured boot-to-boot floor. Ours, on this build
+Every env-toggle A/B on this stack is a **cross-boot** comparison (the toggle needs a
+restart), so it is only readable against a measured boot-to-boot floor. Ours, on this build
 (`fa11c73`, pre-[#38](https://github.com/syv-ai/qwen38-27b-rtx3090/issues/38)), warmed,
 median of 2 passes per boot, env read back from `/proc/<pid>/environ` rather than trusted from
 the shell:
@@ -202,22 +202,22 @@ the shell:
 | `LOOKUP=1` (default) | 3 | 142.85 · 142.89 · 142.78 → **142.84** | 185.53 · 185.41 · 185.50 → **185.48** |
 | `LOOKUP=0` | 2 | 157.64 · 157.54 → **157.59** | 185.63 · 185.57 → **185.60** |
 | boot floor (worst spread) | | **0.070%** | **0.065%** |
-| effect | | **+10.33% — 147× the floor, stands** | +0.06% — 1× the floor, **unresolved** |
+| effect | | **+10.33% (147× the floor), stands** | +0.06% (1× the floor), **unresolved** |
 
 *Audited after the fact, because the harness timed whole requests including prefill:* re-ran
-streamed with TTFT split out, and the effect is the same three ways — whole-window unstreamed
+streamed with TTFT split out, and the effect is the same three ways: whole-window unstreamed
 **+10.33%**, whole-window streamed **+9.92%**, **decode-only +9.96%**. The arms were clean for
 the dull reason: ~200-token prompts against a working prefix cache leave no prefill worth
 contaminating.
 
 **On novel generation the lookup lane is net overhead on prose here, and invisible on code.**
 Its value is context reproduction, exactly as the `DFLASH_TOKENS=15` documentation says.
-Code is *inside our floor* and we report it as unresolved rather than as zero — fermion
+Code is *inside our floor*, so we report it as unresolved rather than as zero: fermion
 measures a real +7.7% there, and our silence is not evidence against it.
 
 **The boot floor is a property of what state the boot inherited, not of the stack.** Ours is
 0.07% across plain restarts that reuse the venv and `torch.compile` cache. Fermion measured
-**8.7%** across a boot that followed an *image rebuild* with cold JIT caches — and a
+**8.7%** across a boot that followed an *image rebuild* with cold JIT caches; a
 "regression" found that way was retracted once warm boots were compared. The README's
 "first run reads low" warning operates at **boot** granularity; one warmup generation does not
 warm a boot.
@@ -225,10 +225,10 @@ warm a boot.
 *Falsifier for everything in this section:* single RTX 3090 at 250 W, 453 MiB driver-reserved,
 nothing else resident, native Linux with no container, `llama-chip` stopped for the duration
 and verified healthy afterward. Prompts are two fixed strings (one prose, one code), not the
-harness cohorts — comparable to each other, loosely comparable to anything else.
+harness cohorts: comparable to each other, loosely comparable to anything else.
 
 
-## int4 KV (#42) — the 256k window serves on a 3090, and recall holds at 218k
+## int4 KV (#42): the 256k window serves on a 3090, and recall holds at 218k
 
 `single-user/alternative.sh`, `MAX_LEN=256000`, `SPEC=off`, nothing else changed.
 
@@ -239,7 +239,7 @@ harness cohorts — comparable to each other, loosely comparable to anything els
 | VRAM | 22,612 MiB |
 | attention block size the engine chose | **1696** |
 
-Needle planted at depth and asked back — one distinctive literal, four positions:
+Needle planted at depth and asked back (one distinctive literal, four positions):
 
 | prompt tokens | depth | recall | wall |
 |---:|---:|:---:|---:|
@@ -254,16 +254,16 @@ not worse than the alternative already trusted here.**
 **Read this narrowly.** A needle is a *recall* test, not a *quality* test: a distinctive
 literal is close to the easiest thing a degraded KV can still retrieve. Four depths, n=1
 each, one needle string, spec off. It licenses *"int4 does not lose the plot at 218k"* and
-**not** *"int4 is lossless at 218k"* — the second wants a teacher-forced comparison against
+**not** *"int4 is lossless at 218k"*; the second wants a teacher-forced comparison against
 bf16 at depth, which nobody has run.
 
 *`SPEC=off` is not incidental:* fermion measured spec-on 25.2 against spec-off 35.5 tok/s at
-72k depth on this profile — **speculation is a 1.4× slowdown there**, because acceptance
+72k depth on this profile: **speculation is a 1.4× slowdown there**, because acceptance
 around .30 across 7 draft tokens cannot beat plain q=1 decode.
 
 ### The prefix-match unit is per-(model, kv-dtype, draft-length), not per-card
 
-This 3090 reports `Setting attention block size to 1696 tokens` under int4 — **identical to
+This 3090 reports `Setting attention block size to 1696 tokens` under int4, **identical to
 fermion's 4090.** The card enters only through how much pool fits. The axis that does move it
 is the draft length: at `DFLASH_TOKENS=3` the same stack reports 1616. So **a user changing
 `DFLASH_TOKENS` silently changes the only valid `--prefix-match-unit` underneath themselves**,

--- a/docs/reproductions/threadchip-3090.md
+++ b/docs/reproductions/threadchip-3090.md
@@ -52,13 +52,20 @@ cohort so no row is measuring cache warmth instead of concurrency.
 | huge | shallow | 134.1 | 220.9 | 157.6 | 232.2 |
 | huge | deep (44k) | 43.6 | 50.1 | 53.3 | 52.8 |
 
-**Scope note: every row above is speculation-ON, and at depth that is not the same as
-speculation earning something.** fermion measured spec-on ≈ spec-off at 72k on this model —
-35.6 vs ~35.5 under KVarN, and 25.2 vs 35.5 under int4 where speculation is an outright 1.4×
-*slowdown*. Acceptance at depth is .286/.290 across the two KV dtypes, identical, so the
-decay is model-and-depth rather than dtype. **These deep rows therefore measure the KV
-profile, not the speculator** — there is no spec-off column here and a reader should not infer
-one.
+**Scope note: every row above is speculation-ON, and at depth speculation is worth roughly
+2×.** fermion's first reading of this had the opposite sign and was retracted: their
+deep-decode probe counted SSE chunks, and that stack emits **one chunk per speculative step**,
+so every spec-on number was low by the emitted/step factor (~3×). Token-true, at 72k: int4
+with the wide-verify kernel **70–75 tok/s**, `long` **64–68**, against spec-off **35.5**.
+Acceptance at depth is .286/.290 across the two KV dtypes — identical, so the decay is
+model-and-depth rather than dtype. **These deep rows are therefore speculator and profile
+jointly**, and there is no spec-off column here to separate them.
+
+*The counting hazard is worth stating for anyone reproducing this:* under speculation, a
+chunk count is a **step** count. Spec-off is immune at one token per step, which is exactly
+why the wrong world looks self-consistent. Everything in this document takes its token counts
+from `usage.completion_tokens` or the server's `generation_tokens_total` counter, never from
+delta counting — `bench/conc_ladder.py` uses SSE deltas only for first/last timestamps.
 
 `CTX=huge` costs roughly 10% shallow and 8% deep against `long`, for 1.9× the window. At
 depth the larger pools hold up where `fast` does not.

--- a/docs/reproductions/threadchip-3090.md
+++ b/docs/reproductions/threadchip-3090.md
@@ -52,6 +52,14 @@ cohort so no row is measuring cache warmth instead of concurrency.
 | huge | shallow | 134.1 | 220.9 | 157.6 | 232.2 |
 | huge | deep (44k) | 43.6 | 50.1 | 53.3 | 52.8 |
 
+**Scope note: every row above is speculation-ON, and at depth that is not the same as
+speculation earning something.** fermion measured spec-on ≈ spec-off at 72k on this model —
+35.6 vs ~35.5 under KVarN, and 25.2 vs 35.5 under int4 where speculation is an outright 1.4×
+*slowdown*. Acceptance at depth is .286/.290 across the two KV dtypes, identical, so the
+decay is model-and-depth rather than dtype. **These deep rows therefore measure the KV
+profile, not the speculator** — there is no spec-off column here and a reader should not infer
+one.
+
 `CTX=huge` costs roughly 10% shallow and 8% deep against `long`, for 1.9× the window. At
 depth the larger pools hold up where `fast` does not.
 

--- a/docs/reproductions/threadchip-3090.md
+++ b/docs/reproductions/threadchip-3090.md
@@ -1,0 +1,102 @@
+# Reproduction: RTX 3090, native Python 3.14, Ubuntu 26.04
+
+*August 2026. Native venv, no container. `verify.sh --no-server` clean, all fifteen patches
+applied. Every run below discards a warmup pass, per the README's own instruction.*
+
+[← back to Python 3.14](../python-314.md) · [← main README](../../README.md)
+
+## Hardware and stack
+
+| | |
+|---|---|
+| GPU | RTX 3090, 24 GiB, driver 610.43.02, 250 W |
+| OS / Python | Ubuntu 26.04, Python **3.14.4** (system), `python3.14-dev` installed |
+| vLLM | 0.27.1 + all fifteen `patches/`, torch 2.13.0+cu130, Triton 3.7.1 |
+| model | `dbirks/Qwen3.8-27B-W4A16-AutoRound` + repo requantization + fast variant + DFlash2 drafter |
+| KVarN | installed (`kvarn/install.sh`) |
+
+## `bench/run_benchmarks.sh single`, greedy — vs the README
+
+| cohort | ours e2e | ours decode | README |
+|---|---:|---:|---:|
+| C1 | **122.46** | 125.9 | 121.8 |
+| C2 | 203.13 | 231.7 | 195.5 |
+| C4 | 270.91 | 320.3 | 278.9 |
+| C8 | 372.62 | 466.5 | 389.9 |
+
+Within a few percent throughout. **The README's table reproduces on Python 3.14.**
+
+## Context profiles as measured
+
+| profile | KV dtype | max_model_len | pool | perplexity¹ |
+|---|---|---:|---:|---:|
+| `CTX=fast` | bf16 | 65,536 | 68,605–72,992² | 3.1174 |
+| `CTX=long` | int8 per-token-head | 131,072 | 136,429 | 3.1100 |
+| `CTX=huge` | KVarN 4/2-bit | 245,760 | 268,169 | 3.1107 |
+
+¹ Teacher-forced, identical 12,000-character passage, echo+logprobs. Only the KV dtype
+varies. **All three within 0.24%.**
+² Varies with `SPEC`/`DFLASH_TOKENS`; both values observed.
+
+## Aggregate tok/s, context × concurrency
+
+`SPEC=dflash2 DFLASH_TOKENS=7 PREFIX_CACHE=1`, 256-token answers, prefix warmed before each
+cohort so no row is measuring cache warmth instead of concurrency.
+
+| profile | depth | C1 | C2 | C4 | C8 |
+|---|---|---:|---:|---:|---:|
+| fast | shallow | 137.3 | 239.5 | **321.3** | 300.6 |
+| fast | deep (44k) | 66.8 | 99.7 | 19.2 | 33.4 |
+| long | shallow | 121.1 | 230.0 | 304.8 | 311.0 |
+| long | deep (44k) | 47.2 | 63.7 | 69.5 | 70.8 |
+| huge | shallow | 134.1 | 220.9 | 157.6 | 232.2 |
+| huge | deep (44k) | 43.6 | 50.1 | 53.3 | 52.8 |
+
+`CTX=huge` costs roughly 10% shallow and 8% deep against `long`, for 1.9× the window. At
+depth the larger pools hold up where `fast` does not.
+
+## Prefix cache
+
+Same 96,370-token document, three consecutive turns, `PREFIX_CACHE=1`:
+
+```
+turn 1:  232.9 s   ← pays the prefill
+turn 2:    5.9 s
+turn 3:    6.0 s
+```
+
+The README predicts *"5.9 s afterwards"* for a 112k document. Reproduced exactly.
+
+## KV quality at 4/2 bits
+
+Perplexity is a weak instrument here — it scores the model's fit to text it is *looking at*,
+over a short window, which is not where a quantised cache fails. Needle-in-a-haystack on
+`CTX=huge` (KVarN 4/2-bit), one distinctive fact planted at varying depth in a long
+document, exact-match recall:
+
+| prompt tokens | needle at | recall |
+|---:|---:|---|
+| 29,653 | 25% | HIT |
+| 96,368 | 50% | HIT |
+| 168,542 | 75% | HIT |
+| **218,085** | 50% | **HIT** |
+
+**Caveat, stated because the table would otherwise imply more than it shows:** the bf16
+profile cannot exceed 65,536 tokens, so only the first rung has a like-for-like control.
+This demonstrates that KVarN recalls correctly at 218k — not that it equals bf16 there.
+
+## Not reproduced
+
+A community report of **~208 accepted tok/s** on a 3090 at `CTX=long` with a basic prompt
+did not reproduce here: **107.2 tok/s median**, same posted configuration
+(`SPEC=dflash2 DFLASH_TOKENS=7 PREFIX_CACHE=1 CTX=long`), four consecutive runs within 0.2%
+of each other. Reproduction-shaped prompts do climb, consistent with `LOOKUP` drafting:
+
+| task | tok/s |
+|---|---:|
+| free generation | 102.7 |
+| quote a passage back verbatim | 125.5 |
+| repeat a passage with a substitution | 156.6 |
+
+The original report says "peaked at around 208", and a peak is not a median; the prompt was
+not published. Recorded as unreproduced rather than disputed.

--- a/docs/reproductions/threadchip-3090.md
+++ b/docs/reproductions/threadchip-3090.md
@@ -179,6 +179,12 @@ the shell:
 | boot floor (worst spread) | | **0.070%** | **0.065%** |
 | effect | | **+10.33% — 147× the floor, stands** | +0.06% — 1× the floor, **unresolved** |
 
+*Audited after the fact, because the harness timed whole requests including prefill:* re-ran
+streamed with TTFT split out, and the effect is the same three ways — whole-window unstreamed
+**+10.33%**, whole-window streamed **+9.92%**, **decode-only +9.96%**. The arms were clean for
+the dull reason: ~200-token prompts against a working prefix cache leave no prefill worth
+contaminating.
+
 **On novel generation the lookup lane is net overhead on prose here, and invisible on code.**
 Its value is context reproduction, exactly as the `DFLASH_TOKENS=15` documentation says.
 Code is *inside our floor* and we report it as unresolved rather than as zero — fermion
@@ -195,3 +201,46 @@ warm a boot.
 nothing else resident, native Linux with no container, `llama-chip` stopped for the duration
 and verified healthy afterward. Prompts are two fixed strings (one prose, one code), not the
 harness cohorts — comparable to each other, loosely comparable to anything else.
+
+
+## int4 KV (#42) — the 256k window serves on a 3090, and recall holds at 218k
+
+`single-user/alternative.sh`, `MAX_LEN=256000`, `SPEC=off`, nothing else changed.
+
+| | |
+|---|---|
+| GPU KV cache size | **266,520 tokens** |
+| max_model_len served | 256,000 |
+| VRAM | 22,612 MiB |
+| attention block size the engine chose | **1696** |
+
+Needle planted at depth and asked back — one distinctive literal, four positions:
+
+| prompt tokens | depth | recall | wall |
+|---:|---:|:---:|---:|
+| 29,653 | 25% | **HIT** | 36 s |
+| 96,368 | 50% | **HIT** | 215 s |
+| 168,542 | 75% | **HIT** | 563 s |
+| **218,085** | 50% | **HIT** | 893 s |
+
+218,085 is the same depth at which KVarN 4/2-bit recalls exactly on this box, so **int4 is
+not worse than the alternative already trusted here.**
+
+**Read this narrowly.** A needle is a *recall* test, not a *quality* test: a distinctive
+literal is close to the easiest thing a degraded KV can still retrieve. Four depths, n=1
+each, one needle string, spec off. It licenses *"int4 does not lose the plot at 218k"* and
+**not** *"int4 is lossless at 218k"* — the second wants a teacher-forced comparison against
+bf16 at depth, which nobody has run.
+
+*`SPEC=off` is not incidental:* fermion measured spec-on 25.2 against spec-off 35.5 tok/s at
+72k depth on this profile — **speculation is a 1.4× slowdown there**, because acceptance
+around .30 across 7 draft tokens cannot beat plain q=1 decode.
+
+### The prefix-match unit is per-(model, kv-dtype, draft-length), not per-card
+
+This 3090 reports `Setting attention block size to 1696 tokens` under int4 — **identical to
+fermion's 4090.** The card enters only through how much pool fits. The axis that does move it
+is the draft length: at `DFLASH_TOKENS=3` the same stack reports 1616. So **a user changing
+`DFLASH_TOKENS` silently changes the only valid `--prefix-match-unit` underneath themselves**,
+and any value has to be read from the boot log rather than inherited from another machine or
+another profile.

--- a/docs/reproductions/threadchip-3090.md
+++ b/docs/reproductions/threadchip-3090.md
@@ -85,7 +85,28 @@ document, exact-match recall:
 profile cannot exceed 65,536 tokens, so only the first rung has a like-for-like control.
 This demonstrates that KVarN recalls correctly at 218k — not that it equals bf16 there.
 
-## Not reproduced
+## Prompt shape dominates, and it explains a reported number
+
+A community report of ~208 tok/s did not match our first prose measurement (107.2), and the
+author later published the prompt and the distinction: **200 was a peak, the average on that
+prompt was ~160, and it was "very simple, code heavy output" — "Please write a Tetris clone
+that can run in a browser."** Prose, he noted, runs 100–120.
+
+Running that exact prompt here, same configuration, three consecutive runs within 0.2%:
+
+| prompt | ours | reported |
+|---|---:|---:|
+| *"Please write a Tetris clone that can run in a browser."* | **188.3** | ~160 avg, 200 peak |
+| reflective prose essay | **113.1** | 100–120 |
+
+Both land inside or above the reported band. **The discrepancy was never hardware or
+configuration — it was that code generation and prose are different workloads.** `LOOKUP`
+drafting predicts repetitive structure well (braces, indentation, boilerplate), so long runs
+clear per verify step; prose branches more and accepts less.
+
+**A tok/s figure for this stack is meaningless without the prompt that produced it.**
+
+## Earlier, before the prompt was known
 
 A community report of **~208 accepted tok/s** on a 3090 at `CTX=long` with a basic prompt
 did not reproduce here: **107.2 tok/s median**, same posted configuration

--- a/docs/reproductions/threadchip-3090.md
+++ b/docs/reproductions/threadchip-3090.md
@@ -156,6 +156,16 @@ Two things fall out, and the second is the one worth carrying away:
   goes compute-bound, and sm_89 pulls away. **Sizing a card from a single-stream benchmark
   under-buys for concurrency by roughly 5× the error you think you are making.**
 
+**What this ladder cannot see, and it is the binding constraint on mixed load.** Every stream
+here carries a uniform ~4k prompt, so every prefill is small and comparable — the ladder
+measures *decode* concurrency and is structurally blind to **prefill head-of-line blocking**.
+fermion measured the case it misses: one 72.6k "whale" against 4k "minnows", where the deep
+prefill monopolises the engine for its full ~65 s, admitted minnows ration to ~1 tok/s, and
+the rest queue behind the entire prefill (TTFT 63–82 s). Cached whale, same scenario: 72.2 s
+→ 13.5 s wall. **So "N=4 is the sweet spot, N=8 is strictly dominated" is scoped to uniform
+short-prompt load** — under mixed depth the constraint is prefill admission, not decode
+concurrency, and the ladder's advice does not transfer.
+
 *Instrument caveats, both found the hard way:* `kv%` is documented as **peak** occupancy
 sampled every 250 ms, and our N=4 run lasts 1.70× longer than fermion's on the same output
 budget — so it gets 1.70× the draws at catching the same transient. **A peak-of-poll compared

--- a/docs/reproductions/threadchip-3090.md
+++ b/docs/reproductions/threadchip-3090.md
@@ -121,3 +121,77 @@ of each other. Reproduction-shaped prompts do climb, consistent with `LOOKUP` dr
 
 The original report says "peaked at around 208", and a peak is not a median; the prompt was
 not published. Recorded as unreproduced rather than disputed.
+
+---
+
+*Added August 2026, second pass. Everything below shares the stack above; where it does not,
+the row says so.*
+
+## Concurrency ladder — and the 3090/4090 gap widens with load
+
+`bench/conc_ladder.py --n 1,2,4,8 --out 256 --reps 2`, `CTX=long`, `MAX_SEQS=8`, shipped
+`KV_MEM` pin. The 4090 column is fermion's run of the identical command under WSL2
+([wsl2-4090.md](../wsl2-4090.md)).
+
+| N | 3090 /stream | 4090 /stream | ratio | 3090 agg | 4090 agg | kv% 3090 | kv% 4090 | preempt |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 129.1 | 149.7 | 1.16× | 128 | — | 19.7 | — | 0 / 0 |
+| 2 | 91.8 | 119.8 | 1.31× | 236 | 278 | 38.3 | — | 0 / 0 |
+| 4 | 46.6 | 79.0 | 1.70× | **316** | **517** | 73.5 | 71.1 | 0 / 0 |
+| 8 | 30.3 | 57.2 | 1.89× | 230\* | 351\* | 98.2 | 98.2 | 2 / 2 |
+
+\* Tail measurement — no instant at which all 8 streams were decoding.
+
+Two things fall out, and the second is the one worth carrying away:
+
+- **The concurrency ceiling is pool geometry, not the card.** N=8 goes tail-mode on *both*
+  boxes at **kv 98.2% with 2 preemptions each** — same occupancy to the decimal, same failure
+  mode, same count. A 4090 does not buy N=8 in long mode; it buys the same wall, reached
+  faster. And **N=8 is strictly dominated by N=4 in aggregate on both cards** (230 vs 316
+  here, 351 vs 517 there) — not a tradeoff, a loss.
+- **The 4090's per-stream advantage widens with N: +16% at N=1 → +89% at N=8.** This is
+  consistent with, and extends, the README's own explanation of its +1.9% 4090 row
+  ([#32](https://github.com/syv-ai/qwen38-27b-rtx3090/issues/32)): *batch-1 decode is
+  bandwidth-bound, the extra compute has nothing to bite on.* Raise N and the forward pass
+  goes compute-bound, and sm_89 pulls away. **Sizing a card from a single-stream benchmark
+  under-buys for concurrency by roughly 5× the error you think you are making.**
+
+*Instrument caveats, both found the hard way:* `kv%` is documented as **peak** occupancy
+sampled every 250 ms, and our N=4 run lasts 1.70× longer than fermion's on the same output
+budget — so it gets 1.70× the draws at catching the same transient. **A peak-of-poll compared
+across runs of different duration is structurally biased upward on the slower machine.**
+Compare `preempt` and tail-mode onset instead: discrete, duration-invariant, and they matched
+exactly. Separately, `conc_ladder.py:245` puts `int(time.time())` inside every prompt salt, so
+token counts differ per box, per run, per rep by design.
+
+## `VLLM_DFLASH2_LOOKUP`, and how to measure an env toggle at all
+
+Every env-toggle A/B on this stack is a **cross-boot** comparison — the toggle needs a
+restart — so it is only readable against a measured boot-to-boot floor. Ours, on this build
+(`fa11c73`, pre-[#38](https://github.com/syv-ai/qwen38-27b-rtx3090/issues/38)), warmed,
+median of 2 passes per boot, env read back from `/proc/<pid>/environ` rather than trusted from
+the shell:
+
+| | boots | prose | code |
+|---|---:|---|---|
+| `LOOKUP=1` (default) | 3 | 142.85 · 142.89 · 142.78 → **142.84** | 185.53 · 185.41 · 185.50 → **185.48** |
+| `LOOKUP=0` | 2 | 157.64 · 157.54 → **157.59** | 185.63 · 185.57 → **185.60** |
+| boot floor (worst spread) | | **0.070%** | **0.065%** |
+| effect | | **+10.33% — 147× the floor, stands** | +0.06% — 1× the floor, **unresolved** |
+
+**On novel generation the lookup lane is net overhead on prose here, and invisible on code.**
+Its value is context reproduction, exactly as the `DFLASH_TOKENS=15` documentation says.
+Code is *inside our floor* and we report it as unresolved rather than as zero — fermion
+measures a real +7.7% there, and our silence is not evidence against it.
+
+**The boot floor is a property of what state the boot inherited, not of the stack.** Ours is
+0.07% across plain restarts that reuse the venv and `torch.compile` cache. Fermion measured
+**8.7%** across a boot that followed an *image rebuild* with cold JIT caches — and a
+"regression" found that way was retracted once warm boots were compared. The README's
+"first run reads low" warning operates at **boot** granularity; one warmup generation does not
+warm a boot.
+
+*Falsifier for everything in this section:* single RTX 3090 at 250 W, 453 MiB driver-reserved,
+nothing else resident, native Linux with no container, `llama-chip` stopped for the duration
+and verified healthy afterward. Prompts are two fixed strings (one prose, one code), not the
+harness cohorts — comparable to each other, loosely comparable to anything else.

--- a/docs/ubuntu-3090.md
+++ b/docs/ubuntu-3090.md
@@ -1,0 +1,130 @@
+# RTX 3090 on native Ubuntu — campaign notes
+
+The native half of the two-box campaign behind PR #46. Companion to
+[wsl2-4090.md](wsl2-4090.md) (the WSL2/4090 half) and to
+[reproductions/threadchip-3090.md](reproductions/threadchip-3090.md) (the earlier
+full reproduction on this box — hardware table, README-parity benches, needle
+recall, the prompt-shape finding). Numbers below are the 3090 seat's five
+run-books (2026-08-28), relayed cross-box with artifact hashes; the seat
+reviewed every row as it entered the MR draft.
+
+Stack: Ubuntu 26.04, system Python 3.14.4, native venv (no container), RTX 3090
+@ 250 W, vLLM 0.27.1 + the full patch stack. See the reproduction doc for the
+detailed table.
+
+## Offload fix validation (the native control arm)
+
+The [OffloadingConnector WSL2 fix](wsl2-4090.md#cpu-offload-tier-under-wsl2--the-offloadingconnector-fix-2026-08-28)
+must be a no-op on native Linux, and "no-op" was validated as three arms, not
+assumed:
+
+| arm | decode | token sha | engine |
+|---|---:|---|---|
+| baseline (no fix) | 52.4 tok/s | `6ffe0154…` | alive |
+| fix applied | 52.4 tok/s | `6ffe0154…` byte-identical | alive |
+| fix removed | 52.4 tok/s | `6ffe0154…` byte-identical | alive |
+
+Execution was confirmed, not inferred: the loader resolves at tier 0
+(`CDLL(None)`), the live `cudaHostGetDevicePointer` call returns rc=0 delta=0,
+and the CPU tier moved **805 MB** during the arm (`kv_offload_store_bytes`), so
+the patched function ran live with translated pointers and changed nothing.
+The v1 lesson from this box: v1's arms had "passed" **inert** — a bare
+`CDLL("libcudart.so")` throws on standard pip installs, so its happy path never
+executed; v3 raises on every failure branch, making a live engine itself the
+proof the query ran.
+
+Also found in the same logs: **#33's drafter handling is active here** — nine
+EAGLE/MTP draft attention groups detected at runtime (an earlier
+"deliberately skipped" read came from patch-application state, not runtime;
+`verify.sh` checks the former).
+
+## Retention: the trio, the bisection, and the model kill
+
+Same pool, same contexts, opposite answers by design (int8/long, pool 136,429,
+tier off):
+
+```
+ROUND-ROBIN  (recheck A,B,C in order)   0/3 — every recheck ~1.0x cold
+CAPACITY     (recheck newest only)      RETAINED — 2.24s vs 50.35s cold (22x)
+```
+
+The round-robin sweep evicts each context via the next recheck's own prefill —
+0/3 was never a capacity measurement. The L-bisection (per-length salts,
+measured `prompt_tokens` per rung, boundary rungs re-run **alone in fresh
+boots** — both reproduce to the decimal):
+
+| L (tok) | K=2 result |
+|---:|---|
+| 34,124 | 0/2 |
+| 29,340 | 0/2 |
+| **24,865** | **2/2** (2.5s / 2.2s vs 44s cold) |
+
+Per-context retention cost ≈ **2.3–2.7× its token count** at ~25–29k. The
+pre-registered K=3 discriminator (12,142 tok, fresh solo boot) returned
+**3/3** — which kills the additive cost model on this geometry by an emptiness
+argument (K=2 demands F ∈ (38,874, 43,350]; K=3 demands F ≤ 33,334; no such F).
+The 4090 ran the mirror rung and got the mirror result (0/3, killing the
+multiplicative model there): **no one-parameter cost model survives both
+boxes**; see the MR's §5 for the affine candidate and why it is a fit, not a
+finding.
+
+## Designed-config ladder — MAX_SEQS is geometry, not a knob
+
+CTX=long, identical instrument, only MAX_SEQS differs:
+
+| N | MS=8 agg | MS=4 agg | preempts |
+|---:|---:|---:|---:|
+| 1 | 128.0 | 127.8 | 0 |
+| 2 | 236.0 | 241.6 | 0 |
+| 4 | 316.0 | **335.4 (+6.1%)** | 0 |
+
+Not over-provisioning slots is worth +6.1% at the design point, and the
+designed configs take zero preemptions where the uniform sweep took two.
+CTX=huge at its designed MS=2 shows 44.7% KV at N=2 — but 2 × 245,760 >
+the 268,169 pool, so MAX_SEQS there is a **worst-case admission bound**
+deliberately overcommitted for realistic prompts, not a throughput setting.
+The kv% gauge understates that risk while the concurrency banner overstates
+multi-context capacity; neither is safe to tune against.
+
+## Batch wing at GPU_UTIL=0.972 — the arm only a headless box can run
+
+CTX=fast, MAX_SEQS=64, SPEC=off, pool 86,353 (0.972 boots and serves here;
+WSL2 refuses it):
+
+| N | per-stream | agg | ms/pass | preempts | kv% | TTFT ms |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 130.7 | 131.7 | 23.3 | 0 | 14.3 | 3,172 |
+| 2 | 97.8 | 238.8 | 26.0 | 0 | 26.5 | 5,722 |
+| 4 | 53.8 | 332.4 | 37.9 | 0 | 56.1 | 9,794 |
+| 8 | 34.7 | 187.1* | 25.7 | 0 | 98.7 | 16,899 |
+| 16 | 23.6 | 282.3* | 28.2 | 0 | 96.9 | 31,981 |
+
+(*tail measurement.) ms/pass spreads 21% over a 16× batch, with **zero
+preemptions at every level** — where the spec profile took two at N=8. The
+wings differ in what they are willing to have go wrong, not only in speed.
+(Not comparable to the 4090's fp8-geometry batch rows — different profile;
+separate rows, never a ratio.)
+
+## Needle at max length — the banner is honest about one
+
+CTX=huge, single request, climbing: 159,262 / 194,121 / 217,221 / **234,158**
+tokens — every level completes with exact needle recall, the last at 95.3% of
+max_model_len in 355.2s. The final 4.7% is untested because the corpus ran
+out, not the engine. So the "Maximum concurrency 1.09x" banner is **true for
+one live request** — and misleading only for concurrent or cached contexts,
+where the retention tax above applies and nothing on the line says so.
+
+## Operator notes from this box
+
+- The 8 GB `/dev/shm/vllm_offload_*.mmap` **survived a teardown kill** and
+  held that RAM until removed by hand — clean stale regions at shutdown as
+  well as startup.
+- `verify.sh` verifies patch application, not runtime behavior — the nine
+  draft groups above were the proof.
+- Instrument ledger entries paid for here: basic `sed` has no alternation
+  without `-E` (a display filter printed nothing while the run was fine —
+  instruments persist `--json`); a hardcoded K=2 label printed "3/2" with the
+  count right and the label wrong; a descending-L ladder with fixed salts is
+  contaminated at exactly the boundary rung (smaller contexts are prefixes of
+  larger ones — salt per rung); estimates place rungs, only measured
+  `prompt_tokens` place conclusions.

--- a/docs/ubuntu-3090.md
+++ b/docs/ubuntu-3090.md
@@ -1,9 +1,9 @@
-# RTX 3090 on native Ubuntu — campaign notes
+# RTX 3090 on native Ubuntu: campaign notes
 
 The native half of the two-box campaign behind PR #46. Companion to
 [wsl2-4090.md](wsl2-4090.md) (the WSL2/4090 half) and to
-[reproductions/threadchip-3090.md](reproductions/threadchip-3090.md) (the earlier
-full reproduction on this box — hardware table, README-parity benches, needle
+[reproductions/native-3090.md](reproductions/native-3090.md) (the earlier
+full reproduction on this box: hardware table, README-parity benches, needle
 recall, the prompt-shape finding). Numbers below are the 3090 seat's five
 run-books (2026-08-28), relayed cross-box with artifact hashes; the seat
 reviewed every row as it entered the MR draft.
@@ -28,12 +28,12 @@ Execution was confirmed, not inferred: the loader resolves at tier 0
 (`CDLL(None)`), the live `cudaHostGetDevicePointer` call returns rc=0 delta=0,
 and the CPU tier moved **805 MB** during the arm (`kv_offload_store_bytes`), so
 the patched function ran live with translated pointers and changed nothing.
-The v1 lesson from this box: v1's arms had "passed" **inert** — a bare
+The v1 lesson from this box: v1's arms had "passed" **inert**; a bare
 `CDLL("libcudart.so")` throws on standard pip installs, so its happy path never
 executed; v3 raises on every failure branch, making a live engine itself the
 proof the query ran.
 
-Also found in the same logs: **#33's drafter handling is active here** — nine
+Also found in the same logs: **#33's drafter handling is active here**: nine
 EAGLE/MTP draft attention groups detected at runtime (an earlier
 "deliberately skipped" read came from patch-application state, not runtime;
 `verify.sh` checks the former).
@@ -48,10 +48,10 @@ ROUND-ROBIN  (recheck A,B,C in order)   0/3 — every recheck ~1.0x cold
 CAPACITY     (recheck newest only)      RETAINED — 2.24s vs 50.35s cold (22x)
 ```
 
-The round-robin sweep evicts each context via the next recheck's own prefill —
+The round-robin sweep evicts each context via the next recheck's own prefill;
 0/3 was never a capacity measurement. The L-bisection (per-length salts,
 measured `prompt_tokens` per rung, boundary rungs re-run **alone in fresh
-boots** — both reproduce to the decimal):
+boots**; both reproduce to the decimal):
 
 | L (tok) | K=2 result | isolated re-run |
 |---:|---|---|
@@ -65,16 +65,16 @@ sides: pool residue from the rung above could in principle manufacture the
 eviction at 29,340, and if the true 0/2 boundary were higher, `F` would be
 smaller and additive would survive.
 
-Per-context retention cost ≈ **2.3–2.7× its token count** at ~25–29k. The
+Per-context retention cost ≈ **2.3-2.7× its token count** at ~25-29k. The
 pre-registered K=3 discriminator (12,142 tok, fresh solo boot) returned
-**3/3** — which kills the additive cost model on this geometry by an emptiness
+**3/3**, which kills the additive cost model on this geometry by an emptiness
 argument (K=2 demands F ∈ (38,874, 43,350]; K=3 demands F ≤ 33,334; no such F).
 The 4090 ran the mirror rung and got the mirror result (0/3, killing the
 multiplicative model there): **no one-parameter cost model survives both
 boxes**; see the MR's §5 for the affine candidate and why it is a fit, not a
 finding.
 
-## Designed-config ladder — MAX_SEQS is geometry, not a knob
+## Designed-config ladder: MAX_SEQS is geometry, not a knob
 
 CTX=long, identical instrument, only MAX_SEQS differs:
 
@@ -91,18 +91,18 @@ designed configs take zero preemptions where the uniform sweep took two.
 Every stream here carries a uniform ~4k prompt, so every prefill is small and
 comparable: `conc_ladder.py` measures *decode* concurrency and is structurally
 blind to **prefill head-of-line blocking**. The 4090 measured the case it
-misses — one 72.6k whale against 4k minnows, where the deep prefill monopolises
+misses: one 72.6k whale against 4k minnows, where the deep prefill monopolises
 the engine for its full ~65 s and admitted minnows ration to ~1 tok/s. So
 everything in this section is scoped to **uniform short-prompt load**; under
 mixed depth the binding constraint is prefill admission and none of this advice
 transfers.
-CTX=huge at its designed MS=2 shows 44.7% KV at N=2 — but 2 × 245,760 >
+CTX=huge at its designed MS=2 shows 44.7% KV at N=2, but 2 × 245,760 >
 the 268,169 pool, so MAX_SEQS there is a **worst-case admission bound**
 deliberately overcommitted for realistic prompts, not a throughput setting.
 The kv% gauge understates that risk while the concurrency banner overstates
 multi-context capacity; neither is safe to tune against.
 
-## Batch wing at GPU_UTIL=0.972 — the arm only a headless box can run
+## Batch wing at GPU_UTIL=0.972: the arm only a headless box can run
 
 CTX=fast, MAX_SEQS=64, SPEC=off, pool 86,353 (0.972 boots and serves here;
 WSL2 refuses it):
@@ -116,39 +116,39 @@ WSL2 refuses it):
 | 16 | 23.6 | 282.3* | 28.2 | 0 | 96.9 | 31,981 |
 
 (*tail measurement.) ms/pass spreads 21% over a 16× batch, with **zero
-preemptions at every level** — where the spec profile took two at N=8. The
+preemptions at every level**, where the spec profile took two at N=8. The
 wings differ in what they are willing to have go wrong, not only in speed.
-(Not comparable to the 4090's fp8-geometry batch rows — different profile;
+(Not comparable to the 4090's fp8-geometry batch rows: different profile;
 separate rows, never a ratio.)
 
-## Needle at max length — the banner is honest about one
+## Needle at max length: the banner is honest about one
 
 CTX=huge, single request, climbing: 159,262 / 194,121 / 217,221 / **234,158**
-tokens — every level completes with exact needle recall, the last at 95.3% of
+tokens; every level completes with exact needle recall, the last at 95.3% of
 max_model_len in 355.2s. The final 4.7% is untested because the corpus ran
 out, not the engine. So the "Maximum concurrency 1.09x" banner is **true for
-one live request** — and misleading only for concurrent or cached contexts,
+one live request**, but misleading only for concurrent or cached contexts,
 where the retention tax above applies and nothing on the line says so.
 
 ## Operator notes from this box
 
 - The 8 GB `/dev/shm/vllm_offload_*.mmap` **survived a teardown kill** and
-  held that RAM until removed by hand — clean stale regions at shutdown as
+  held that RAM until removed by hand: clean stale regions at shutdown as
   well as startup.
-- `verify.sh` verifies patch application, not runtime behavior — the nine
+- `verify.sh` verifies patch application, not runtime behavior; the nine
   draft groups above were the proof.
 - **`single-user/alternative.sh` silently ignores `SPEC`.** Line 71 hardcodes
   `--speculative-config` with no guard, so `SPEC=off` still serves n7. Two arms
   labelled spec-on and spec-off came back *bit-identical*, and the tell was the
   **emitted/step receipt: 2.29 on an arm that must be 1.00 if speculation were
   off.** Anyone A/B-ing speculation on the int4 profile gets two spec-on arms and
-  concludes speculation does nothing — one inference from a conclusion this PR
+  concludes speculation does nothing: one inference from a conclusion this PR
   had already retracted once by a different road. An unrecognised `SPEC` should
   refuse, not proceed.
 - Instrument ledger entries paid for here: basic `sed` has no alternation
-  without `-E` (a display filter printed nothing while the run was fine —
+  without `-E` (a display filter printed nothing while the run was fine, so
   instruments persist `--json`); a hardcoded K=2 label printed "3/2" with the
   count right and the label wrong; a descending-L ladder with fixed salts is
   contaminated at exactly the boundary rung (smaller contexts are prefixes of
-  larger ones — salt per rung); estimates place rungs, only measured
+  larger ones: salt per rung); estimates place rungs, only measured
   `prompt_tokens` place conclusions.

--- a/docs/ubuntu-3090.md
+++ b/docs/ubuntu-3090.md
@@ -53,11 +53,17 @@ The round-robin sweep evicts each context via the next recheck's own prefill —
 measured `prompt_tokens` per rung, boundary rungs re-run **alone in fresh
 boots** — both reproduce to the decimal):
 
-| L (tok) | K=2 result |
-|---:|---|
-| 34,124 | 0/2 |
-| 29,340 | 0/2 |
-| **24,865** | **2/2** (2.5s / 2.2s vs 44s cold) |
+| L (tok) | K=2 result | isolated re-run |
+|---:|---|---|
+| 34,124 | 0/2 | — |
+| 29,340 | 0/2 | **29,344 → 0/2**, 35.7s / 37.1s |
+| **24,865** | **2/2** (2.5s / 2.2s vs 44s cold) | **24,869 → 2/2**, 2.5s / 2.2s |
+
+Both boundary rungs were re-run **alone in fresh boots** and reproduce to the
+decimal. That matters because the emptiness argument below leans on *both*
+sides: pool residue from the rung above could in principle manufacture the
+eviction at 29,340, and if the true 0/2 boundary were higher, `F` would be
+smaller and additive would survive.
 
 Per-context retention cost ≈ **2.3–2.7× its token count** at ~25–29k. The
 pre-registered K=3 discriminator (12,142 tok, fresh solo boot) returned
@@ -80,6 +86,16 @@ CTX=long, identical instrument, only MAX_SEQS differs:
 
 Not over-provisioning slots is worth +6.1% at the design point, and the
 designed configs take zero preemptions where the uniform sweep took two.
+
+**Scope, because this ladder cannot see the constraint that binds mixed load.**
+Every stream here carries a uniform ~4k prompt, so every prefill is small and
+comparable: `conc_ladder.py` measures *decode* concurrency and is structurally
+blind to **prefill head-of-line blocking**. The 4090 measured the case it
+misses — one 72.6k whale against 4k minnows, where the deep prefill monopolises
+the engine for its full ~65 s and admitted minnows ration to ~1 tok/s. So
+everything in this section is scoped to **uniform short-prompt load**; under
+mixed depth the binding constraint is prefill admission and none of this advice
+transfers.
 CTX=huge at its designed MS=2 shows 44.7% KV at N=2 — but 2 × 245,760 >
 the 268,169 pool, so MAX_SEQS there is a **worst-case admission bound**
 deliberately overcommitted for realistic prompts, not a throughput setting.
@@ -121,6 +137,14 @@ where the retention tax above applies and nothing on the line says so.
   well as startup.
 - `verify.sh` verifies patch application, not runtime behavior — the nine
   draft groups above were the proof.
+- **`single-user/alternative.sh` silently ignores `SPEC`.** Line 71 hardcodes
+  `--speculative-config` with no guard, so `SPEC=off` still serves n7. Two arms
+  labelled spec-on and spec-off came back *bit-identical*, and the tell was the
+  **emitted/step receipt: 2.29 on an arm that must be 1.00 if speculation were
+  off.** Anyone A/B-ing speculation on the int4 profile gets two spec-on arms and
+  concludes speculation does nothing — one inference from a conclusion this PR
+  had already retracted once by a different road. An unrecognised `SPEC` should
+  refuse, not proceed.
 - Instrument ledger entries paid for here: basic `sed` has no alternation
   without `-E` (a display filter printed nothing while the run was fine —
   instruments persist `--json`); a hardcoded K=2 label printed "3/2" with the

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -176,6 +176,38 @@ card.** With recall clean, the MQ split-KV kernel (3.1× deep decode) and
 `--prefix-match-unit` in hand, the remaining objections to #42 at depth are
 performance items with known fixes, not correctness ones.
 
+## ⚠ INSTRUMENT INVERSION (2026-08-28) — read before any deep spec-on number below
+
+Every deep **spec-on** "decode tok/s" below measured by the streaming probe
+before 2026-08-28 late is **VOID: it counted SSE chunks, and under
+speculative decoding on this stack one SSE chunk carries one STEP's tokens**
+(~3 at depth). Spec-off numbers (1 token/step) and everything counter-based
+(ladder aggregates, acceptance, TTFT, exactness) were always true. Proof:
+a saved deep generation tokenizes to 455 tokens against 149 counted chunks
+(3.05× = that run's emitted/step 3.06). Token-true re-measurement
+(usage.completion_tokens, identity-checked steps×emitted/step≈tokens):
+
+| deep 72.6k decode-only, TRUE tok/s | | |
+|---|---:|---|
+| **int4 + MQ split-KV kernel** | **70.5–75.2** | the fastest deep config on the box |
+| long (int8) | 64.0–67.7 | |
+| huge (KVarN) | 59.9–62.7 | old "35.6" void (unknown instrument) |
+| any profile, spec-off | ~35.5 | |
+| int4 stock dispatch | 22.3 | |
+
+**Inverted verdicts:** speculation at depth WINS ~2× (never was break-even —
+the q=8 step costs 43ms vs q=1's 28ms, +54% for ~3× tokens); ~~run deep int4
+work spec-off~~ → **spec-on is the deep mode**; the MQ kernel's true e2e is
+~3.3×; the deep crown moves to int4+kernel (held behind its promotion gates —
+this measurement is not the default-flip gate). The shallow spec-on figures
+(102–138 class) from the same probe are also step-contaminated and the
+shallow crossover awaits token-true re-measurement. The mixed-load and
+politeness sections' *decode* columns are step rates (~×3 for tokens);
+their TTFT/starvation findings are timing-based and stand. Lesson kept:
+**know what one unit of the thing you are counting actually is** — chunks,
+steps, tokens, requests, and windows were five different quantities in this
+document's history.
+
 ## The whole ladder, one table (2026-08-27, single 4090 unless noted)
 
 | profile | KV format | window | pool (tok) | shallow prose | deep 72.6k decode | windows @72.6k | notes |

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -380,6 +380,36 @@ cold 4.94s → warm 0.64s (7.7×). Restart on failure. Until root-caused, no
 sized pair check. (Third instance in one day of a test tuned to a constant
 it didn't read — the constant is never portable and always in the boot log.)
 
+## Batch mode on the 4090 (2026-08-28) — the other wing
+
+First boot of the repo's `batch` profile here (fp8 KV, no speculation, engine
+block 800, pool 175,515 @150k, `GPU_UTIL=0.93` — **0.972 never fits under
+WSL2's reserve on a desktop-attached card**; the MAX_LEN defaults are
+fp8-geometry-specific, don't carry int4 numbers over). Token-true ladder,
+distinct 4k prompts:
+
+| N | 1 | 2 | 4 | 8 | 16 |
+|---|---:|---:|---:|---:|---:|
+| decode agg | 55 | 101 | 195 | 384 | **676** |
+| per-stream | 54.5 | 49.7 | 42.4 | 33.8 | 23.3 |
+| ms/pass | 18.3 | 19.8 | 20.5 | 20.9 | 23.7 |
+
+Textbook batch scaling: tokens/pass ≡ N, ms/pass essentially flat C1→C16,
+zero preemptions (the profile's 64-way graph budget is pre-sized — no
+piecewise trap). **Doctrine: the spec wing (single+DFlash) wins up to
+~C4–C8 (long C4 = 517 agg); batch takes over around C10 and scales to 64**
+(README: ~1,094 at C64 on a 3090). At C1 batch costs 2.7× vs spec — spec IS
+the single-user profile.
+
+**Retention under batch — prediction falsified, informatively:** with NO
+drafter groups, 3 contexts at 85% naive utilization still fully evicted. The
+retention tax's center of mass is the **mamba state** (equal-sized mamba
+pages per attention block, by construction ≈ 2× per cached context), with
+the drafter adding the rest of spec-mode's ~2.7×. Universal for this hybrid
+model: **cached seats ≈ pool ÷ (2–2.7 × context) on every profile** — one
+warm deep whale per box; a CPU offload tier (the in-tree #33 patch /
+LMCache, noted for investigation) is the only door to more.
+
 ## TP=2 (2×4090) under WSL2 (2026-08-27)
 
 Boots clean (PYNCCL; no NCCL env tweaks needed). **Capacity play, not a speed play

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -303,6 +303,25 @@ head-of-line blocking, not decode concurrency** — and the fix is the prefix
 cache: with the whale's prefix warm, the same scenario collapses 72s → 13.5s
 and every stream's first token lands inside ~11s. Pin your whales' prefixes.
 
+## The politeness knob: `--max-num-batched-tokens` under mixed load (2026-08-28)
+
+Same cold-whale C4 mix as above, CTX=long, sweeping the per-pass token budget:
+
+| budget | whale TTFT | minnow TTFT | minnow decode during whale prefill | wall |
+|---|---:|---|---|---:|
+| 2048 (default) | 62.6s | 63–70s (queued) | 22–40 only after | 72.2s |
+| 1024 | 69.6s | **4.2–7.2s** | 6.8–14.3 | 73.0s |
+| 512 | 72.2s | **4.5–7.6s** | **14.2–21.8** | 75.4s |
+
+At 2048 a whale chunk fills the whole budget and minnow prefills queue behind
+the entire whale; at ≤1024 the scheduler interleaves and minnows are live in
+~5s. Whale decode is unaffected (25.4 everywhere). **Mixed serving: budget
+512 + pinned whale prefixes (with the cache, the whale itself starts in ~5s
+— see the cached-whale row above); dedicated single-user depth: keep 2048.**
+Caveat for the boot ritual below: smaller budgets slow ALL prefill, so the
+warm-pair ratio compresses (7.7× at 2048 → ~2.8× at 512); the ½ threshold
+still held.
+
 ## Cache-dead boots (observed 2026-08-27/28) — add a warm-pair check to the boot ritual
 
 One CTX=long boot served correctly but **never produced a prefix-cache hit**

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -241,10 +241,21 @@ ladders too, so treat C1 ordering as unconfirmed; the C2–C4 gaps (1.5–2×)
 exceed any observed boot wobble. kv% is harness-internal (block-granularity),
 comparable within a run only.
 
-**Practical read: long for single-user shallow, huge for single-user depth,
+~~**Practical read: long for single-user shallow, huge for single-user depth,
 int4 for concurrency (C2–C4) and prefill-latency-sensitive serving** — best
-aggregate, best e2e, flattest scaling. Ladder JSONs kept with the bench
-record.
+aggregate, best e2e, flattest scaling.~~ **CONTAMINATED — correction in
+progress (caught by Michael: "I thought we were pulling ~500 at C4?").** The
+long/huge rows above were measured with a forced `MAX_SEQS=8` that overflows
+their CUDA-graph reservations (start_qwen.sh sizes capture for its own
+defaults — long=4, huge=2 — and documents the overflow mode: "bigger batches
+run piecewise instead of captured: slower, alive"). long at its DESIGNED
+MAX_SEQS=4 does ~517–533 decode-agg at C4 (two prior measurements), not 208.
+int4's row is genuine (its launcher captures 64 natively — flat ms/pass).
+Designed-config reruns for long/huge are running; the corrected table
+replaces this section when they land. Standing lesson: **a concurrency
+number is only comparable at the graph-capture config it was captured
+under** — MAX_SEQS is not a free knob, it is a graph-budget choice.
+Ladder JSONs kept with the bench record.
 
 ## TP=2 (2×4090) under WSL2 (2026-08-27)
 

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -69,3 +69,28 @@ Consequences, which outlive the mistake:
   one server session and remain the best-sourced claim.
 - The instrument list gains an item: **the warm-state of the serving process** —
   which boot, how many requests old, cache volume state.
+
+## Chain mode + #42 int4-KV, tested (2026-08-27, boot-floor-aware)
+
+**Boot floor, corrected by mechanism:** rebuild-reset caches produced the ~8.7%
+"floor" retracted above; plain restarts inherit the cache volume and measure a floor
+of **~0.1%** here (copy cell: 221.6 / 221.6 across boots). The floor is a property of
+what state the boot inherited, not of the stack.
+
+**`VLLM_DFLASH2_CHAIN=1`** (2 boots/arm, ~0.1% floors): copy **221.6 → 268.0
+(+21%)** — triple the README's +7% on this card — prose 140.4 → 136.75 (**−2.5%**,
+small but real). A per-workload flag: on for reproduction jobs, off for novel
+generation.
+
+**#42 int4-KV profile (`alternative.sh`, GPU_UTIL=0.93 per its own WSL2 note):**
+window/pool **256,000 tokens on one card**, 22.0GB, serves clean. Shallow prose
+118.0 (≈12% under bf16 — near the claimed cost). **But at 72.6k depth, cached-prefix
+decode collapses to 3.6 tok/s** — ~10× under KVarN's 35.6 at the same depth, with
+healthy acceptance (~30% — ~3.1 tok/step): the cliff is **step time (~860ms)**, i.e.
+the verify attention over a long int4 cache. The repo's int8 long mode needed a
+dedicated split-KV verify kernel for exactly this (its notes price unsplit Triton
+attention at 7.4ms/layer at 128k); int4 has no analogous kernel yet. **Verdict: #42
+is a capacity profile whose deep decode is not yet usable interactively; it does not
+obsolete `CTX=huge`/KVarN.** Quality-at-depth remains unmeasured here on purpose —
+Austen needles are memorization-contaminated (PPL 1.06), and the proper
+needle-recall harness run is queued on the 3090.

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -89,8 +89,23 @@ decode collapses to 3.6 tok/s** — ~10× under KVarN's 35.6 at the same depth, 
 healthy acceptance (~30% — ~3.1 tok/step): the cliff is **step time (~860ms)**, i.e.
 the verify attention over a long int4 cache. The repo's int8 long mode needed a
 dedicated split-KV verify kernel for exactly this (its notes price unsplit Triton
-attention at 7.4ms/layer at 128k); int4 has no analogous kernel yet. **Verdict: #42
-is a capacity profile whose deep decode is not yet usable interactively; it does not
-obsolete `CTX=huge`/KVarN.** Quality-at-depth remains unmeasured here on purpose —
+attention at 7.4ms/layer at 128k); int4 has no analogous kernel yet.
+
+**Mechanism CONFIRMED by the discriminating arm** (proposed by the 3090 seat: same
+profile, same depth, speculation off — single-token decode is single-query
+attention, so if the multi-query verify path is the cause, the cliff disappears):
+
+| int4 @ 72.6k depth | decode tok/s |
+|---|---:|
+| SPEC=dflash2 (n7) | 3.6 |
+| **speculation off** | **29.0** |
+
+The cliff is the verify path, resolved at n=1 against a ~0.1% restart floor. Two
+corollaries: with speculation, deep int4 is currently an **8× slowdown**, not a
+speedup — and raw int4 at depth (29.0) is within ~20% of KVarN-with-speculation
+(35.6), so **one kernel** (the int4 analogue of `spec-decode-int8-kv`) plausibly
+makes #42 fully competitive at triple the window. **Verdict: #42 is a capacity
+profile one kernel short of usable deep decode; it does not obsolete
+`CTX=huge`/KVarN today.** Quality-at-depth remains unmeasured here on purpose —
 Austen needles are memorization-contaminated (PPL 1.06), and the proper
 needle-recall harness run is queued on the 3090.

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -50,9 +50,22 @@ Same standing config, warmed second-pass medians, CTX=long:
 | c954724 | 1 (default) | 130.6 | 170.0 |
 | c954724 | **0** | **140.6** | **194.6** |
 
-Two findings: the #38 chain rework costs the **default `LOOKUP=1` lane ~5.5%** on
-non-reproduction prompts (global paths are unregressed — lookup-off *beats* the old
-build), and on novel-generation workloads the lookup lane is net overhead either
-way — its value is context reproduction, per the `DFLASH_TOKENS=15` docs. Standing
-config on this box is now `LOOKUP=0`, flipped on per-workload for verbatim-
-reproduction tasks.
+**RETRACTED (same day): the "#38 costs ~5.5%" row above was a COLD-BOOT
+artifact, not a regression.** The c954724 `LOOKUP=1` numbers came from the first
+boot after the image rebuild — empty torch.compile/JIT caches — and the README's
+"first run reads low" warning operates at *boot* granularity: a warmed **third**
+boot of the identical config measured **140.4 / 184.8** (vs 130.6/170.0 on boot
+one — **+8.7% boot-to-boot on the same build and flags**). Warm-boot old-vs-new is
+138.0/180.6 → 140.4/184.8: **no regression**; the pickup is clean.
+
+Consequences, which outlive the mistake:
+- **Boot-to-boot variance on this stack is ~8-9%** — larger than most effects
+  worth arguing about. Any A/B whose arms require a server restart (every env-var
+  toggle) is a *cross-boot* comparison and needs boot-median protocol (≥2 boots
+  per arm) or effects >2× the boot floor to be claimed at all.
+- The `LOOKUP=0` vs `LOOKUP=1` deltas on this card are therefore **unresolved**
+  (prose 140.6 vs 140.4 — identical; code 194.6 vs 184.8 — inside two boot
+  floors). Upstream's own README numbers (+7% copy, flat prose) were taken within
+  one server session and remain the best-sourced claim.
+- The instrument list gains an item: **the warm-state of the serving process** —
+  which boot, how many requests old, cache volume state.

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -176,6 +176,36 @@ card.** With recall clean, the MQ split-KV kernel (3.1× deep decode) and
 `--prefix-match-unit` in hand, the remaining objections to #42 at depth are
 performance items with known fixes, not correctness ones.
 
+## The whole ladder, one table (2026-08-27, single 4090 unless noted)
+
+| profile | KV format | window | pool (tok) | shallow prose | deep 72.6k decode | windows @72.6k | notes |
+|---|---|---:|---:|---:|---:|---:|---|
+| fast | bf16 | 65,536 | 68,605 | 134.7 | — (window < 72.6k) | — | code 144.5, easy 295.8 |
+| long | int8 | 131,072 | 136,429 | **138.0** | *unmeasured* | 1.9 | code 180.6; the daily driver |
+| huge | KVarN 4/2-bit | 245,760 | 268,169 | 122.9 | **35.6** | 3.7 | on the reference decay curve (32.0 @ 112k) |
+| int4 (#42) | int4 per-token-head | **256,000** | 266k–302k† | 118.0 | **35.55** spec-off · 25.23 spec-on+MQ-kernel · 8.14 spec-on stock | 3.7–4.2 | recall 4/4 to 218k (3090); needs `--prefix-match-unit 848`; only boots at n=7 |
+
+† Pool numbers are **boot-state-scoped** (this card measured 253,965 and
+301,974 under identical config, hours apart — free-VRAM drift); the 3090
+reports 266,520 at MAX_LEN=256000, the patch header 314,915. Quote a pool with
+its boot. Full-window concurrency is ~1.0–1.2× everywhere — these are
+single-user profiles; "windows @72.6k" is the honest concurrency-depth column.
+
+Deep prefill is the shared pain, not a differentiator: huge ~1,080 tok/s,
+int4 ~1,170 tok/s at 72.6k (~60–70s first call). Deep-cached calls need a
+verified cache: huge's 35.6 sits on the reference decay curve (independent
+corroboration); int4's requires the prefix-match-unit flag; long's is
+threadchip-verified (0→60.4% hit rate).
+
+**Reading of the tradeoffs:** with kvarn installed (both our boxes), **huge
+remains the depth default** — equal deep decode (35.6 vs 35.55), slightly
+better shallow, no flag, no n-brittleness. int4's case is (a) **stock-vLLM
+machinery** — it needs no kvarn install, only 3 small patches, which makes it
+the *portable* 256k profile and the upstream-relevant one; (b) +4% window /
+up to +13% pool; (c) it's where the MQ split-KV kernel and any future
+int8-IMMA prefill work land. Run int4 spec-off at depth (25.2 spec-on <
+35.5 spec-off even with the kernel — acceptance ~.30 × n7 loses to q=1).
+
 ## TP=2 (2×4090) under WSL2 (2026-08-27)
 
 Boots clean (PYNCCL; no NCCL env tweaks needed). **Capacity play, not a speed play

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -139,14 +139,16 @@ every divisibility clause pass with no geometry change and zero pool cost.
 Verified on this card: per-group hits converge at 71,232/72,591 tokens
 (98.1%), **TTFT 62.0s → 4.1s on the warm repeat**, warm generation
 byte-identical to cold, decode rate and acceptance unchanged. Two caveats
-under active audit: (1) ~~pool unchanged (253,965)~~ **RETRACTED — flag-boots
-report 301,974 tokens vs 253,965 without the flag (+19%, consistent across
-boots). A hash-granularity flag should not resize the pool; until the
-accounting path is traced and the larger pool proven physically realizable,
-treat the advertised capacity under this flag as unverified.** (2) The
-byte-identical result is partially confounded by the drafter's suffix-lookup
-history (request order alone can change greedy output on this stack); a
-lookup-disabled re-verification is in flight. The value is per-card AND
+were raised and both resolved same-day: (1) ~~pool unchanged (253,965)~~ — an
+apparent +19% pool difference under the flag (301,974 vs 253,965) was traced
+to boot-time free-VRAM drift, not the flag: a same-hour no-flag control boot
+also reports 301,974. The flag does not touch capacity; quote any pool number
+together with its boot's GPU state. (2) The byte-identical warm-vs-cold result
+was confounded by the drafter's suffix-lookup history (request order alone can
+change greedy output on this stack); re-verified with the lookup lane disabled
+(`LOOKUP=0`): warm TTFT 4.12s, per-group hits converge at 71,232, and the warm
+generation remains byte-identical to cold — reuse reproduces the cold
+computation exactly. The value is per-card AND
 per-profile: the unit must EQUAL the sliding-window group's block size
 exactly (848 here — finer divisors get zero reuse from the guard's alignment
 clause), and that block size moves with model, KV dtype, and DFLASH_TOKENS

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -408,7 +408,8 @@ pages per attention block, by construction ≈ 2× per cached context), with
 the drafter adding the rest of spec-mode's ~2.7×. Universal for this hybrid
 model: **cached seats ≈ pool ÷ (2–2.7 × context) on every profile** — one
 warm deep whale per box; a CPU offload tier (the in-tree #33 patch /
-LMCache, noted for investigation) is the only door to more.
+LMCache, noted for investigation) is the only door to more. *(That door is
+now open — see the offload section below.)*
 
 ## TP=2 (2×4090) under WSL2 (2026-08-27)
 
@@ -421,3 +422,57 @@ single card's 517. The PCIe all-reduce under WSL2 inverts #40's native-3090 resu
 The #40-era `start_qwen.sh` TP calibration (auto-skip of the single-card KV_MEM
 pin) worked exactly as documented. One caveat: the desktop compositor's ~1.7GB on
 the second card means `GPU_UTIL=0.90` there, not 0.93.
+
+## CPU offload tier under WSL2 — the OffloadingConnector fix (2026-08-28)
+
+The in-tree #33 OffloadingConnector (CPU tier over a pinned `/dev/shm` mmap)
+crashed WSL2 with an illegal memory access on the first real eviction, after a
+misdirection cascade that blamed two innocent async bystanders (the mamba-state
+copy, then the block zeroer — `CUDA_LAUNCH_BLOCKING` serializes **kernels**, not
+async copies, so the fault surfaced on whatever synchronized next).
+
+**Root cause:** the Triton `swap_blocks` kernel dereferences raw **host** virtual
+addresses of the `cudaHostRegistered` region. Under native-Linux UVA the host VA
+happens to equal the device VA, so it works — by coincidence, not contract. WSL2
+registers successfully but maps the region at a **different device address**, so
+the kernel faults. Registration succeeding was mistaken for device-address
+equivalence; `cudaHostGetDevicePointer` — the API's own answer for exactly this
+case — was never called.
+
+**The fix** (`patches/offload-wsl2-devptr.patch`, applied in the stack): after
+registration, ask for the device pointer, carry the delta on each CPU view, and
+add it where `compute_sub_block_ptrs` builds addresses. Delta is 0 on native
+Linux — no behavior change. Every failure branch **raises** rather than warning:
+a platform where the device pointer is unavailable refuses to start instead of
+proceeding into silent-unsafe zero-copy. That makes the fix more falsifiable
+than a warn-and-continue shape — a live engine with the patch applied is itself
+evidence the query ran and succeeded.
+
+**Loader gotcha** (cost one review round): standard pip installs ship only
+*versioned* cudart sonames at absolute wheel paths, so `CDLL("libcudart.so")`
+throws on most native boxes. The patch resolves from the process image first
+(`CDLL(None)` — torch has already dlopen'd cudart), then system sonames, then a
+glob over the torch wheel's `nvidia/*/lib/`.
+
+**Falsification bracket, both platforms:**
+
+| Arm | WSL2 / 4090 | Native / 3090 |
+|---|---|---|
+| With fix | 3×72.6k whales primed, all recheck **warm 4.2–4.3s**, 0 IMAs | 52.4 tok/s, token sha byte-identical to baseline, **805 MB** moved through the tier live |
+| Fix removed | IMA returns (count 3), first prime dies | returns to baseline exactly |
+| Loader | resolves tier 1 (also carries unversioned soname) | resolves tier 0 (`CDLL(None)`), rc=0, **delta=0** |
+
+On WSL2 the delta line prints (`delta=-133564122513408 … translating kernel
+addresses`); on native it must be **absent** — both observed. First time the CPU
+tier carried state on either box: ~590k page-tokens held beyond the 252k GPU
+pool; a 72.6k whale primes in ~62s and rechecks warm in 4.3s.
+
+**Operator notes:** the 8 GB `/dev/shm` backing file **outlives the process** —
+an unclean exit strands it, so clean stale regions at startup (`start_qwen.sh`
+does). Docker needs `--ipc host`: the 64 MB default shm makes the region's
+`madvise(MADV_POPULATE_WRITE)` fail with EFAULT at boot.
+
+Status: validated on both boxes for correctness and round-trip. The
+production-form hardening (typed two-pointer separation instead of a delta
+attribute, transfer records, restored-state checksums) is tracked as follow-on
+work.

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -108,21 +108,34 @@ and end-to-end deep decode did not move — verify was ~5% of the step, and the
 spec-off arm removes the drafter as well as the verify, so it could never
 attribute the difference (the 3090 seat retracted the test's design themselves).
 Then the premise died: **the "3.6 tok/s deep decode" was never a decode rate.**
-Under this profile the engine reports **0% prefix-cache hits** (identical 72k
-prompt, `enable_prefix_caching=True`), so every "cached" deep request re-ran the
-full 72k prefill (~62s at ~1,170 tok/s through the eager int4 chunked-prefill
-path) inside a total-window measurement. Streamed with TTFT split out, true
-**deep decode-only is ~25 tok/s** (spec-on, n7, acceptance ~.30, ~3.1
-emitted/step ≈ 123 ms/step). The 29.0 spec-off arm is under the same audit on
-the 3090. **Corrected verdict: #42's real deep-use blockers are (1) zero
-prefix-cache reuse in this config — every long-context request pays the full
-prefill, and (2) the slow int4 chunked prefill itself; deep *decode* is within
-~30% of KVarN's 35.6, not 10× under it.** The split-KV verify kernel is real and
-now matters (predicted +25-30% of the true 123ms step; measurement in flight)
-but is held pending acceptance/exactness gates. It still does not obsolete
-`CTX=huge`/KVarN today. Quality-at-depth remains unmeasured here on purpose —
-Austen needles are memorization-contaminated (PPL 1.06), and the proper
-needle-recall harness run is queued on the 3090.
+Under this profile the engine gets **zero prefix-cache reuse** (identical 72k
+prompt, `enable_prefix_caching=True`, three requests = three full ~62s
+prefills, request-level TTFT), so every "cached" deep request re-ran the full
+72k prefill (~1,170 tok/s through the eager int4 chunked-prefill path) inside a
+total-window measurement. Streamed with TTFT split out, the true numbers at
+72.6k depth on this card:
+
+| int4 @ 72.6k, decode-only | tok/s | accept | emitted/step | step ms |
+|---|---:|---:|---:|---:|
+| speculation off | **35.55** | — | 1 | 28 |
+| SPEC=dflash2 n7, stock dispatch | 8.14 | .248 | 2.74 | 336 |
+| SPEC=dflash2 n7 + MQ split-KV kernel | 25.23 | .302 | 3.11 | 123 |
+
+**Corrected verdict:** #42's real deep-use blockers are (1) **zero prefix-cache
+reuse under int4 × DFlash2** — isolated by ablation: int8+DFlash2 reuses fine
+(3090), int4 *without* DFlash2 reuses fine (TTFT 62.1s → 3.9s on repeat); only
+the combination never hits — and (2) the slow int4 chunked prefill itself
+(~1,170 tok/s at depth). Deep *decode* was never 10× under KVarN. Speculation
+at this depth is a net slowdown even with the experimental MQ split-KV kernel
+(acceptance ~.30 × n7 loses to single-query decode): **run deep int4 work
+spec-off** (35.5, matching KVarN-with-spec's 35.6). The MQ kernel (2.73× step ×
+1.14 emitted = 3.10× over stock spec-on) is held unshipped pending operator
+oracles at depth, a full-length exactness pass, and a shallow-context crossover
+(shallow shows −16%; the dispatch needs a seq_len floor and a capture-aware
+variant switch). It still does not obsolete `CTX=huge`/KVarN today.
+Quality-at-depth remains unmeasured here on purpose — Austen needles are
+memorization-contaminated (PPL 1.06), and the proper needle-recall harness run
+is queued on the 3090.
 
 ## TP=2 (2×4090) under WSL2 (2026-08-27)
 

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -283,6 +283,38 @@ Standing lesson: **MAX_SEQS is a graph-budget choice, not a free knob — a
 concurrency number is only comparable at the capture config it was captured
 under.** Ladder JSONs (both passes) kept with the bench record.
 
+## big.LITTLE mixed load: one whale + minnows (2026-08-28, CTX=long, MAX_SEQS=4)
+
+The uniform ladder above can't see the real serving hazard. Mix one 72.6k
+"whale" (salted → real prefill) with salted 4k "minnows", launched together:
+
+| scenario | whale TTFT | minnow TTFT (min/med/max) | minnow decode | wall |
+|---|---:|---|---|---:|
+| C2: whale+1, cold | 65.6s | 2.8s | **1.2 tok/s** (starved) | 69s |
+| C4: whale+3, cold | 62.6s | 63.5/68.2/70.2s | 22–40 (after waiting) | 72s |
+| C8: whale+7, cold | 68.6s | 2.2/**75.9**/81.6s | 0.9/14.5/36.3 | 83s |
+| **C4: whale+3, whale CACHED** | **4.9s** | **5.5/6.9/11.2s** | 15–35 (immediate) | **13.5s** |
+
+**A deep prefill monopolizes the engine for its full ~65s** — chunked prefill
+either rations an admitted minnow to ~1 tok/s (each pass = a 2,020-token whale
+chunk + one minnow token) or queues minnows behind the entire prefill. Decode
+coexistence afterward is fine. So the serving constraint is **prefill
+head-of-line blocking, not decode concurrency** — and the fix is the prefix
+cache: with the whale's prefix warm, the same scenario collapses 72s → 13.5s
+and every stream's first token lands inside ~11s. Pin your whales' prefixes.
+
+## Cache-dead boots (observed 2026-08-27/28) — add a warm-pair check to the boot ritual
+
+One CTX=long boot served correctly but **never produced a prefix-cache hit**
+(0.0% across 32 windows; three identical-prompt pairs all re-prefilled ~62s),
+with verifiably healthy 864/864 block geometry. A config-identical restart hit
+normally (warm TTFT 3.5s; per-group trace converging at 71,712). Cause
+unknown — the dead boot was recycled before deep inspection; treat as a real,
+rare, nondeterministic boot state. **Detection is cheap: after any boot, send
+a ~2k-token prompt twice and require the second TTFT < half the first (~10s
+total).** Restart on failure. Until root-caused, no "deep-cached" number
+should be trusted from a boot that hasn't passed the pair check.
+
 ## TP=2 (2×4090) under WSL2 (2026-08-27)
 
 Boots clean (PYNCCL; no NCCL env tweaks needed). **Capacity play, not a speed play

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -138,11 +138,20 @@ default never resolves it; the explicit flag (=gcd of the block sizes) makes
 every divisibility clause pass with no geometry change and zero pool cost.
 Verified on this card: per-group hits converge at 71,232/72,591 tokens
 (98.1%), **TTFT 62.0s → 4.1s on the warm repeat**, warm generation
-byte-identical to cold, decode rate and acceptance unchanged, pool unchanged
-(253,965). The int8 profile never needs the flag (its geometry lands 864/864,
-so the guard cannot fire). The value is per-card: it is the gcd of the
-engine-chosen group block sizes printed at boot ("Setting attention block
-size to N tokens" and its half for the SW group under int4). Deep *decode* was never 10× under KVarN. Speculation
+byte-identical to cold, decode rate and acceptance unchanged. Two caveats
+under active audit: (1) ~~pool unchanged (253,965)~~ **RETRACTED — flag-boots
+report 301,974 tokens vs 253,965 without the flag (+19%, consistent across
+boots). A hash-granularity flag should not resize the pool; until the
+accounting path is traced and the larger pool proven physically realizable,
+treat the advertised capacity under this flag as unverified.** (2) The
+byte-identical result is partially confounded by the drafter's suffix-lookup
+history (request order alone can change greedy output on this stack); a
+lookup-disabled re-verification is in flight. The value is per-card AND
+per-profile: the unit must EQUAL the sliding-window group's block size
+exactly (848 here — finer divisors get zero reuse from the guard's alignment
+clause), and that block size moves with model, KV dtype, and DFLASH_TOKENS
+(n=3 chooses 1616/808). The int8 profile never needs the flag (its geometry
+lands 864/864, so the guard cannot fire). Deep *decode* was never 10× under KVarN. Speculation
 at this depth is a net slowdown even with the experimental MQ split-KV kernel
 (acceptance ~.30 × n7 loses to single-query decode): **run deep int4 work
 spec-off** (35.5, matching KVarN-with-spec's 35.6). The MQ kernel (2.73× step ×

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -84,29 +84,43 @@ generation.
 
 **#42 int4-KV profile (`alternative.sh`, GPU_UTIL=0.93 per its own WSL2 note):**
 window/pool **256,000 tokens on one card**, 22.0GB, serves clean. Shallow prose
-118.0 (≈12% under bf16 — near the claimed cost). **But at 72.6k depth, cached-prefix
+118.0 (≈12% under bf16 — near the claimed cost). ~~**But at 72.6k depth, cached-prefix
 decode collapses to 3.6 tok/s** — ~10× under KVarN's 35.6 at the same depth, with
 healthy acceptance (~30% — ~3.1 tok/step): the cliff is **step time (~860ms)**, i.e.
 the verify attention over a long int4 cache. The repo's int8 long mode needed a
 dedicated split-KV verify kernel for exactly this (its notes price unsplit Triton
-attention at 7.4ms/layer at 128k); int4 has no analogous kernel yet.
+attention at 7.4ms/layer at 128k); int4 has no analogous kernel yet.~~
 
-**Mechanism CONFIRMED by the discriminating arm** (proposed by the 3090 seat: same
+~~**Mechanism CONFIRMED by the discriminating arm** (proposed by the 3090 seat: same
 profile, same depth, speculation off — single-token decode is single-query
-attention, so if the multi-query verify path is the cause, the cliff disappears):
+attention, so if the multi-query verify path is the cause, the cliff disappears):~~
 
 | int4 @ 72.6k depth | decode tok/s |
 |---|---:|
-| SPEC=dflash2 (n7) | 3.6 |
-| **speculation off** | **29.0** |
+| SPEC=dflash2 (n7) | ~~3.6~~ |
+| **speculation off** | ~~**29.0**~~ |
 
-The cliff is the verify path, resolved at n=1 against a ~0.1% restart floor. Two
-corollaries: with speculation, deep int4 is currently an **8× slowdown**, not a
-speedup — and raw int4 at depth (29.0) is within ~20% of KVarN-with-speculation
-(35.6), so **one kernel** (the int4 analogue of `spec-decode-int8-kv`) plausibly
-makes #42 fully competitive at triple the window. **Verdict: #42 is a capacity
-profile one kernel short of usable deep decode; it does not obsolete
-`CTX=huge`/KVarN today.** Quality-at-depth remains unmeasured here on purpose —
+~~The cliff is the verify path, resolved at n=1 against a ~0.1% restart floor.~~
+
+**STRUCK 2026-08-27 (same night, twice).** First the attribution died: we built
+the missing split-KV verify kernel (6× in isolation, 43.5→7.2 ms/step at 72.6k)
+and end-to-end deep decode did not move — verify was ~5% of the step, and the
+spec-off arm removes the drafter as well as the verify, so it could never
+attribute the difference (the 3090 seat retracted the test's design themselves).
+Then the premise died: **the "3.6 tok/s deep decode" was never a decode rate.**
+Under this profile the engine reports **0% prefix-cache hits** (identical 72k
+prompt, `enable_prefix_caching=True`), so every "cached" deep request re-ran the
+full 72k prefill (~62s at ~1,170 tok/s through the eager int4 chunked-prefill
+path) inside a total-window measurement. Streamed with TTFT split out, true
+**deep decode-only is ~25 tok/s** (spec-on, n7, acceptance ~.30, ~3.1
+emitted/step ≈ 123 ms/step). The 29.0 spec-off arm is under the same audit on
+the 3090. **Corrected verdict: #42's real deep-use blockers are (1) zero
+prefix-cache reuse in this config — every long-context request pays the full
+prefill, and (2) the slow int4 chunked prefill itself; deep *decode* is within
+~30% of KVarN's 35.6, not 10× under it.** The split-KV verify kernel is real and
+now matters (predicted +25-30% of the true 123ms step; measurement in flight)
+but is held pending acceptance/exactness gates. It still does not obsolete
+`CTX=huge`/KVarN today. Quality-at-depth remains unmeasured here on purpose —
 Austen needles are memorization-contaminated (PPL 1.06), and the proper
 needle-recall harness run is queued on the 3090.
 

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -218,6 +218,34 @@ up to +13% pool; (c) it's where the MQ split-KV kernel and any future
 int8-IMMA prefill work land. Run int4 spec-off at depth (25.2 spec-on <
 35.5 spec-off even with the kernel — acceptance ~.30 × n7 loses to q=1).
 
+## Three-way concurrency ladder (2026-08-27, all MAX_SEQS=8, ~4k prompts, out=256, reps=2)
+
+Same hour, same harness (`bench/conc_ladder.py`), sequential boots, each phase
+branded by its boot's pool line (long 136,429 / huge 268,169 / int4 250,486).
+
+| N | long per-stream/agg | huge per-stream/agg | int4 per-stream/agg |
+|---|---|---|---|
+| 1 | 107.0 / 106 | 134.9 / 133 | 129.0 / 127 |
+| 2 | 69.0 / 151 | 116.1 / 249 | 120.1 / **259** |
+| 4 | 41.8 / 208 | 62.5 / 330 | 81.5 / **452** |
+| 8 | 35.1 / 190* | 46.2 / **303*** | 54.4 / 242* |
+
+C1 TTFT: long 1.8s · int4 2.7s · huge 5.5s (17.9s at C8 — the KVarN prefill
+tax, which drops huge's end-to-end aggregate to 34–66, worst of the three;
+int4's e2e is best from C2 up at 99–121). \*C8 rows are tail measurements —
+no instant had all 8 decoding; long preempted twice at 98% kv, int4 hit 99%.
+ms/pass: int4 flattest (25.9→31.6 — healthy batching), long steepest
+(34.5→70.9). **Caveats:** this long boot ran 29% under its own earlier
+documented C1 (107 vs 149.7, identical config) — the boot floor applies to
+ladders too, so treat C1 ordering as unconfirmed; the C2–C4 gaps (1.5–2×)
+exceed any observed boot wobble. kv% is harness-internal (block-granularity),
+comparable within a run only.
+
+**Practical read: long for single-user shallow, huge for single-user depth,
+int4 for concurrency (C2–C4) and prefill-latency-sensitive serving** — best
+aggregate, best e2e, flattest scaling. Ladder JSONs kept with the bench
+record.
+
 ## TP=2 (2×4090) under WSL2 (2026-08-27)
 
 Boots clean (PYNCCL; no NCCL env tweaks needed). **Capacity play, not a speed play

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -310,10 +310,24 @@ One CTX=long boot served correctly but **never produced a prefix-cache hit**
 with verifiably healthy 864/864 block geometry. A config-identical restart hit
 normally (warm TTFT 3.5s; per-group trace converging at 71,712). Cause
 unknown — the dead boot was recycled before deep inspection; treat as a real,
-rare, nondeterministic boot state. **Detection is cheap: after any boot, send
-a ~2k-token prompt twice and require the second TTFT < half the first (~10s
-total).** Restart on failure. Until root-caused, no "deep-cached" number
-should be trusted from a boot that hasn't passed the pair check.
+rare, nondeterministic boot state. ~~Detection is cheap: send a ~2k-token
+prompt twice and require the second TTFT < half the first.~~ **CORRECTED
+(3090 seat caught it failing on its first healthy boot): a fixed-size probe
+is structurally blind when it spans ≤1 block — reuse is (blocks−1)×B, so 2k
+tokens at B=1696 (int4) reuses NOTHING and a healthy boot reads dead; at
+B=864 it's one reusable block, a coin flip. Size the probe from the block
+size the engine chose, out of its own boot log:**
+
+```bash
+BLK=$(grep -ohE 'Setting attention block size to [0-9]+ tokens' server.log | grep -oE '[0-9]+' | tail -1)
+NTOK=$((BLK * 10))   # 9 reusable blocks ≈ 90% — unmistakable either way
+```
+
+Verified both boxes: 3090 int8 cold 7.58s → warm 0.99s (7.7×); 4090 int8
+cold 4.94s → warm 0.64s (7.7×). Restart on failure. Until root-caused, no
+"deep-cached" number should be trusted from a boot that hasn't passed the
+sized pair check. (Third instance in one day of a test tuned to a constant
+it didn't read — the constant is never portable and always in the boot log.)
 
 ## TP=2 (2×4090) under WSL2 (2026-08-27)
 

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -479,3 +479,17 @@ Status: validated on both boxes for correctness and round-trip. The
 production-form hardening (typed two-pointer separation instead of a delta
 attribute, transfer records, restored-state checksums) is tracked as follow-on
 work.
+
+**Three agents, measured (2026-08-28):** with the tier armed, three
+simultaneous agents each on its own 72.6k context fire repeatedly with
+**zero recomputes** — unqueued tier restores in 5–7s, the LRU-rotated seat
+~16s restoring under load, against 62s cold. Those 4–7s rechecks are tier
+restores, *not* GPU-warm hits: the tier-off control (K=2 round-robin at
+72.6k = **0/2**, K=3 = 0/3 on a 300,583-token pool) shows the GPU holds
+about one such context warm — real per-context cost exceeds 150k tokens at
+72.6k depth, a >2.07× multiplier. A corrective banner line computed from
+the engine's own spec bytes (constant mamba + linear attention) predicted
+2/2 and was falsified by that same control — it is parked on the
+`banner-capacity-experiment` branch, unmerged, while the gap mechanism
+(drafter group pages · per-group block rounding · prefix-retention
+granularity at the 848 hash unit) stays open.

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -249,12 +249,14 @@ CUDA-graph reservations (start_qwen.sh sizes capture for its own defaults —
 long=4, huge=2 — and documents the overflow mode: "bigger batches run
 piecewise instead of captured: slower, alive"). Rerun at designed configs:
 
+Cells: decode-aggregate (per-stream) / TTFT.
+
 | N | long (MAX_SEQS=4) | huge (MAX_SEQS=2) | int4 (MAX_SEQS=8) |
 |---|---|---|---|
-| 1 | 143 (145.6/stream) | 134 (135.3) | 127 (129.0) |
-| 2 | 281 (121.8) | 227 (105.2) | 259 (120.1) |
-| 4 | **517** (82.5) | 228* (101.4) | 452 (81.5) |
-| 8 | **470*** (75.5) | 191* (80.8) | 242* (54.4) |
+| 1 | 143 (145.6) / 1.9s | 134 (135.3) / 3.3s | 127 (129.0) / 2.7s |
+| 2 | 281 (121.8) / 2.6s | 227 (105.2) / 6.3s | 259 (120.1) / 2.9s |
+| 4 | **517** (82.5) / 4.2s | 228* (101.4) / 10.9s | 452 (81.5) / 4.7s |
+| 8 | **470*** (75.5) / 8.2s | 191* (80.8) / 19.7s | 242* (54.4) / 8.5s |
 
 \* not steady state — no instant had all N decoding. The CAUSE differs per
 profile and the `run`/kv% columns in the JSONs separate them: huge C4/C8 =

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -109,3 +109,15 @@ profile one kernel short of usable deep decode; it does not obsolete
 `CTX=huge`/KVarN today.** Quality-at-depth remains unmeasured here on purpose —
 Austen needles are memorization-contaminated (PPL 1.06), and the proper
 needle-recall harness run is queued on the 3090.
+
+## TP=2 (2×4090) under WSL2 (2026-08-27)
+
+Boots clean (PYNCCL; no NCCL env tweaks needed). **Capacity play, not a speed play
+on this platform**: KV pool **593,574 tokens** at CTX=long (4.53× concurrency at
+131k — four full windows resident at once), but C1 decode drops 22–33% (prose
+107.3, code 121.6 vs 138.0/180.6 single-card) and N=4 aggregate falls to 358 vs the
+single card's 517. The PCIe all-reduce under WSL2 inverts #40's native-3090 result
+(+16–35%) — recorded as a **platform-dependence datapoint**, not an explanation.
+The #40-era `start_qwen.sh` TP calibration (auto-skip of the single-card KV_MEM
+pin) worked exactly as documented. One caveat: the desktop compositor's ~1.7GB on
+the second card means `GPU_UTIL=0.90` there, not 0.93.

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -181,7 +181,7 @@ performance items with known fixes, not correctness ones.
 | profile | KV format | window | pool (tok) | shallow prose | deep 72.6k decode | windows @72.6k | notes |
 |---|---|---:|---:|---:|---:|---:|---|
 | fast | bf16 | 65,536 | 68,605 | 134.7 | — (window < 72.6k) | — | code 144.5, easy 295.8 |
-| long | int8 | 131,072 | 136,429 | **138.0** | *unmeasured* | 1.9 | code 180.6; the daily driver |
+| long | int8 | 131,072 | 136,429 | **138.0** | 25.3 (spec-on) | 1.9 | code 180.6; the daily driver |
 | huge | KVarN 4/2-bit | 245,760 | 268,169 | 122.9 | **35.6** | 3.7 | on the reference decay curve (32.0 @ 112k) |
 | int4 (#42) | int4 per-token-head | **256,000** | 266k–302k† | 118.0 | **35.55** spec-off · 25.23 spec-on+MQ-kernel · 8.14 spec-on stock | 3.7–4.2 | recall 4/4 to 218k (3090); needs `--prefix-match-unit 848`; only boots at n=7 |
 
@@ -197,9 +197,21 @@ verified cache: huge's 35.6 sits on the reference decay curve (independent
 corroboration); int4's requires the prefix-match-unit flag; long's is
 threadchip-verified (0→60.4% hit rate).
 
+**Long at depth, measured 2026-08-27 (the last empty cell):** 25.31 / 25.33
+tok/s across two runs (spec-on n7, acceptance .22–.24, cache verified: warm
+TTFT 1.31s, engine hit rate 49.4%). So at 72.6k the daily driver is the
+SLOWEST of the three — statistically identical to int4 spec-on+kernel (25.2)
+and 29% behind huge (35.6). The consistent physics: deep verify steps are
+KV-bandwidth-bound, and huge's 4/2-bit cache reads roughly half the bytes of
+int8 per step. Long spec-off at depth remains unmeasured (same physics
+predicts ~35). One measurement scar worth its line: **the chat template is
+part of the prefix** — a request with `enable_thinking` toggled renders a
+different prompt prefix and misses the cache entirely (61s re-prefill,
+observed); pin template kwargs when benchmarking cached depth.
+
 **Reading of the tradeoffs:** with kvarn installed (both our boxes), **huge
-remains the depth default** — equal deep decode (35.6 vs 35.55), slightly
-better shallow, no flag, no n-brittleness. int4's case is (a) **stock-vLLM
+is the depth default, now confirmed against the daily driver** — fastest deep
+decode (35.6), slightly better shallow than int4, no flag, no n-brittleness. int4's case is (a) **stock-vLLM
 machinery** — it needs no kvarn install, only 3 small patches, which makes it
 the *portable* 256k profile and the upstream-relevant one; (b) +4% window /
 up to +13% pool; (c) it's where the MQ split-KV kernel and any future

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -161,9 +161,20 @@ spec-off** (35.5, matching KVarN-with-spec's 35.6). The MQ kernel (2.73× step �
 oracles at depth, a full-length exactness pass, and a shallow-context crossover
 (shallow shows −16%; the dispatch needs a seq_len floor and a capture-aware
 variant switch). It still does not obsolete `CTX=huge`/KVarN today.
-Quality-at-depth remains unmeasured here on purpose — Austen needles are
+~~Quality-at-depth remains unmeasured here on purpose — Austen needles are
 memorization-contaminated (PPL 1.06), and the proper needle-recall harness run
-is queued on the 3090.
+is queued on the 3090.~~ **Measured (3090 seat, 2026-08-27): 4/4 exact needle
+recall under int4 KV at 29,653 / 96,368 / 168,542 / 218,085 prompt tokens
+(spec-off, MAX_LEN=256000, pool 266,520, 22,612 MiB) — the same 218k depth
+where KVarN 4/2-bit recalls exactly on that box. Scope stated precisely: a
+needle is a RECALL test, not a quality test — a distinctive literal string is
+near the easiest thing a degraded cache can still retrieve. This licenses
+"int4 does not lose the plot at 218k," not "int4 is lossless at 218k"; the
+latter needs a perplexity or teacher-forced comparison at depth against bf16,
+which has not been run on either box. Four depths, n=1 each, one needle, one
+card.** With recall clean, the MQ split-KV kernel (3.1× deep decode) and
+`--prefix-match-unit` in hand, the remaining objections to #42 at depth are
+performance items with known fixes, not correctness ones.
 
 ## TP=2 (2×4090) under WSL2 (2026-08-27)
 

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -242,20 +242,32 @@ exceed any observed boot wobble. kv% is harness-internal (block-granularity),
 comparable within a run only.
 
 ~~**Practical read: long for single-user shallow, huge for single-user depth,
-int4 for concurrency (C2–C4) and prefill-latency-sensitive serving** — best
-aggregate, best e2e, flattest scaling.~~ **CONTAMINATED — correction in
-progress (caught by Michael: "I thought we were pulling ~500 at C4?").** The
-long/huge rows above were measured with a forced `MAX_SEQS=8` that overflows
-their CUDA-graph reservations (start_qwen.sh sizes capture for its own
-defaults — long=4, huge=2 — and documents the overflow mode: "bigger batches
-run piecewise instead of captured: slower, alive"). long at its DESIGNED
-MAX_SEQS=4 does ~517–533 decode-agg at C4 (two prior measurements), not 208.
-int4's row is genuine (its launcher captures 64 natively — flat ms/pass).
-Designed-config reruns for long/huge are running; the corrected table
-replaces this section when they land. Standing lesson: **a concurrency
-number is only comparable at the graph-capture config it was captured
-under** — MAX_SEQS is not a free knob, it is a graph-budget choice.
-Ladder JSONs kept with the bench record.
+int4 for concurrency (C2–C4).**~~ **CONTAMINATED AND CORRECTED same evening
+(caught by Michael: "I thought we were pulling ~500 at C4?").** The long/huge
+rows above were measured with a forced `MAX_SEQS=8` that overflows their
+CUDA-graph reservations (start_qwen.sh sizes capture for its own defaults —
+long=4, huge=2 — and documents the overflow mode: "bigger batches run
+piecewise instead of captured: slower, alive"). Rerun at designed configs:
+
+| N | long (MAX_SEQS=4) | huge (MAX_SEQS=2) | int4 (MAX_SEQS=8) |
+|---|---|---|---|
+| 1 | 143 (145.6/stream) | 134 (135.3) | 127 (129.0) |
+| 2 | 281 (121.8) | 227 (105.2) | 259 (120.1) |
+| 4 | **517** (82.5) | 228* (101.4) | 452 (81.5) |
+| 8 | **470*** (75.5) | 191* (80.8) | 242* (54.4) |
+
+\* beyond a profile's resident cap: queue-rotation, not steady state (huge
+runs 2 resident — C4/C8 queue with TTFT to 19.7s; long rotates 4 slots).
+long's C4 now three-times confirmed (517 here, 517 documented, 533 on the
+standing stack). ms/pass at designed configs: long flat 23.8→27.8 (captured).
+
+**Corrected read: long is the concurrency king outright** — best aggregate at
+every N, zero preemptions, even its over-cap C8 (470) beats the field. int4
+is second and keeps two distinctions: only profile admitting >4 resident, and
+the 256k window (long caps at 131k). huge is a 1-2 user depth instrument.
+Standing lesson: **MAX_SEQS is a graph-budget choice, not a free knob — a
+concurrency number is only comparable at the capture config it was captured
+under.** Ladder JSONs (both passes) kept with the bench record.
 
 ## TP=2 (2×4090) under WSL2 (2026-08-27)
 

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -1,5 +1,9 @@
 # RTX 4090 under Windows 11 / WSL2 (Docker) — reproduction notes
 
+*The WSL2 half of the two-box campaign; the native half is
+[ubuntu-3090.md](ubuntu-3090.md), with the earlier full 3090 reproduction in
+[reproductions/threadchip-3090.md](reproductions/threadchip-3090.md).*
+
 The docker path reproduces on a 4090 under Docker Desktop's WSL2 backend with **zero
 repo changes** — `.env` plus `VLLM_WSL2_ENABLE_PIN_MEMORY=1`, exactly as
 `docs/docker.md` prescribes. All numbers below: client-measured wall-clock (256-token

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -256,10 +256,22 @@ piecewise instead of captured: slower, alive"). Rerun at designed configs:
 | 4 | **517** (82.5) | 228* (101.4) | 452 (81.5) |
 | 8 | **470*** (75.5) | 191* (80.8) | 242* (54.4) |
 
-\* beyond a profile's resident cap: queue-rotation, not steady state (huge
-runs 2 resident — C4/C8 queue with TTFT to 19.7s; long rotates 4 slots).
-long's C4 now three-times confirmed (517 here, 517 documented, 533 on the
-standing stack). ms/pass at designed configs: long flat 23.8→27.8 (captured).
+\* not steady state — no instant had all N decoding. The CAUSE differs per
+profile and the `run`/kv% columns in the JSONs separate them: huge C4/C8 =
+**admission cap** (MAX_SEQS=2; run=2, kv% 44.7 — pool half empty; extra
+streams queue, TTFT 10.9s→19.7s, throughput pinned at ≈C2 by construction);
+long C8 = the same cap at 4; int4 C8 = genuine **pool pressure** (kv% 99.4).
+
+Reading the two throughput columns: they measure different windows and
+legitimately disagree in both directions. Per-stream is a stream's own
+first-to-last-token average, dragged down by the phase where its decode
+interleaves with other streams' chunked prefills; decode-aggregate opens only
+after EVERY stream has its first token (all prefills done) and reads the
+server counter during pure joint decode. Long C4: joint decode is 517
+(~129/stream) while lifetime per-stream averages 82.5 — aggregate is server
+capacity, per-stream is user experience. long's C4 now three-times confirmed
+(517 here, 517 documented, 533 on the standing stack). ms/pass at designed
+configs: long flat 23.8→27.8 (captured).
 
 **Corrected read: long is the concurrency king outright** — best aggregate at
 every N, zero preemptions, even its over-cap C8 (470) beats the field. int4

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -125,7 +125,24 @@ total-window measurement. Streamed with TTFT split out, the true numbers at
 reuse under int4 × DFlash2** — isolated by ablation: int8+DFlash2 reuses fine
 (3090), int4 *without* DFlash2 reuses fine (TTFT 62.1s → 3.9s on repeat); only
 the combination never hits — and (2) the slow int4 chunked prefill itself
-(~1,170 tok/s at depth). Deep *decode* was never 10× under KVarN. Speculation
+(~1,170 tok/s at depth).
+
+**Blocker (1) is WORKED AROUND with one flag: `--prefix-match-unit 848`**
+(pass via `EXTRA_ARGS` to `alternative.sh`). Root cause: the patch stack's
+sliding-window prefix-cache guard (`port(kvarn-v2)`, issue #18) returns a
+permanent clean miss when the drafter's SW block size (848 under int4's
+halved-page geometry) is not a multiple of the hash unit (1696) — and the
+hybrid coordinator's min turns that one group's miss into zero reuse
+model-wide. The stack's own GCD hash-unit logic excludes SW groups, so the
+default never resolves it; the explicit flag (=gcd of the block sizes) makes
+every divisibility clause pass with no geometry change and zero pool cost.
+Verified on this card: per-group hits converge at 71,232/72,591 tokens
+(98.1%), **TTFT 62.0s → 4.1s on the warm repeat**, warm generation
+byte-identical to cold, decode rate and acceptance unchanged, pool unchanged
+(253,965). The int8 profile never needs the flag (its geometry lands 864/864,
+so the guard cannot fire). The value is per-card: it is the gcd of the
+engine-chosen group block sizes printed at boot ("Setting attention block
+size to N tokens" and its half for the SW group under int4). Deep *decode* was never 10× under KVarN. Speculation
 at this depth is a net slowdown even with the experimental MQ split-KV kernel
 (acceptance ~.30 × n7 loses to single-query decode): **run deep int4 work
 spec-off** (35.5, matching KVarN-with-spec's 35.6). The MQ kernel (2.73× step ×

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -468,9 +468,12 @@ tier carried state on either box: ~590k page-tokens held beyond the 252k GPU
 pool; a 72.6k whale primes in ~62s and rechecks warm in 4.3s.
 
 **Operator notes:** the 8 GB `/dev/shm` backing file **outlives the process** —
-an unclean exit strands it, so clean stale regions at startup (`start_qwen.sh`
-does). Docker needs `--ipc host`: the 64 MB default shm makes the region's
-`madvise(MADV_POPULATE_WRITE)` fail with EFAULT at boot.
+confirmed empirically on the 3090 (still resident after a teardown kill), and
+because shm is RAM-backed the stranded file **holds those gigabytes for as long
+as the box sits idle**. Cleaning at startup (`start_qwen.sh` does) recovers it
+for the next run, but on a small-RAM box the held memory is the next boot's
+OOM — clean at shutdown too. Docker needs `--ipc host`: the 64 MB default shm
+makes the region's `madvise(MADV_POPULATE_WRITE)` fail with EFAULT at boot.
 
 Status: validated on both boxes for correctness and round-trip. The
 production-form hardening (typed two-pointer separation instead of a delta

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -1,13 +1,13 @@
-# RTX 4090 under Windows 11 / WSL2 (Docker) — reproduction notes
+# RTX 4090 under Windows 11 / WSL2 (Docker): reproduction notes
 
 *The WSL2 half of the two-box campaign; the native half is
 [ubuntu-3090.md](ubuntu-3090.md), with the earlier full 3090 reproduction in
-[reproductions/threadchip-3090.md](reproductions/threadchip-3090.md).*
+[reproductions/native-3090.md](reproductions/native-3090.md).*
 
 The docker path reproduces on a 4090 under Docker Desktop's WSL2 backend with **zero
-repo changes** — `.env` plus `VLLM_WSL2_ENABLE_PIN_MEMORY=1`, exactly as
+repo changes**: `.env` plus `VLLM_WSL2_ENABLE_PIN_MEMORY=1`, exactly as
 `docs/docker.md` prescribes. All numbers below: client-measured wall-clock (256-token
-generations, greedy, median of 3) — *not* harness rows; the existing 4090 harness row
+generations, greedy, median of 3), *not* harness rows; the existing 4090 harness row
 in the README (#32) covers C1.
 
 ## CTX ladder (SPEC=dflash2, DFLASH_TOKENS=7)
@@ -16,11 +16,11 @@ in the README (#32) covers C1.
 |---|---:|---:|---:|---:|---|
 | fast | 65,536 | 68,605 | 134.7 | 144.5 | easy-formulaic 295.8 |
 | long | 131,072 | 136,429 | 138.0 | 180.6 | int8 KV; code *faster* than fast here |
-| huge | 245,760 | **268,169** | 122.9 | — | pool byte-identical to the reference 3090 |
+| huge | 245,760 | **268,169** | 122.9 | - | pool byte-identical to the reference 3090 |
 
-- **huge at depth** (72,631-token prompt, prefix-cached): 35.6 tok/s decode — on the
+- **huge at depth** (72,631-token prompt, prefix-cached): 35.6 tok/s decode, on the
   reference decay curve (32.0 @ 112k). First call ~71s incl. prefill (~1,080 tok/s).
-- WSL2 tax at these workloads: none measurable — pools identical to native-Linux
+- WSL2 tax at these workloads: none measurable; pools identical to native-Linux
   reference, speeds silicon-proportional.
 
 ## Concurrency ladder (`bench/conc_ladder.py --n 1,2,4,8 --out 256 --reps 2`, CTX=long, MAX_SEQS=8)
@@ -32,12 +32,12 @@ in the README (#32) covers C1.
 | 4 | 79.0 | **517** | 71.1 | 0 |
 | 8 | 57.2 | 351* | 98.2 | 2 |
 
-\* never reached steady state — the pool cannot hold 8 at ~4k ctx each.
+\* never reached steady state: the pool cannot hold 8 at ~4k ctx each.
 
 ## The KV_MEM pin: leave it alone (measured both ways)
 
 Raising `KV_MEM` 5.58 → 6.53 GB on the 4090's spare headroom grows the pool to
-159,643 tokens — and costs **8% C1 decode** (126.6 vs 138.0), and under 8-way load
+159,643 tokens, but costs **8% C1 decode** (126.6 vs 138.0), and under 8-way load
 the server **OOM-crashes on a 58 MiB activation allocation**: the headroom the pin
 preserves is what concurrency spikes spend. The shipped constant transfers to the
 4090/WSL2 as-is. Windows are design caps (131,072 for dflash2+long; 245,760 huge),
@@ -56,23 +56,23 @@ Same standing config, warmed second-pass medians, CTX=long:
 
 **RETRACTED (same day): the "#38 costs ~5.5%" row above was a COLD-BOOT
 artifact, not a regression.** The c954724 `LOOKUP=1` numbers came from the first
-boot after the image rebuild — empty torch.compile/JIT caches — and the README's
+boot after the image rebuild (empty torch.compile/JIT caches), and the README's
 "first run reads low" warning operates at *boot* granularity: a warmed **third**
 boot of the identical config measured **140.4 / 184.8** (vs 130.6/170.0 on boot
-one — **+8.7% boot-to-boot on the same build and flags**). Warm-boot old-vs-new is
+one: **+8.7% boot-to-boot on the same build and flags**). Warm-boot old-vs-new is
 138.0/180.6 → 140.4/184.8: **no regression**; the pickup is clean.
 
 Consequences, which outlive the mistake:
-- **Boot-to-boot variance on this stack is ~8-9%** — larger than most effects
+- **Boot-to-boot variance on this stack is ~8-9%**, larger than most effects
   worth arguing about. Any A/B whose arms require a server restart (every env-var
   toggle) is a *cross-boot* comparison and needs boot-median protocol (≥2 boots
   per arm) or effects >2× the boot floor to be claimed at all.
 - The `LOOKUP=0` vs `LOOKUP=1` deltas on this card are therefore **unresolved**
-  (prose 140.6 vs 140.4 — identical; code 194.6 vs 184.8 — inside two boot
+  (prose 140.6 vs 140.4, identical; code 194.6 vs 184.8, inside two boot
   floors). Upstream's own README numbers (+7% copy, flat prose) were taken within
   one server session and remain the best-sourced claim.
-- The instrument list gains an item: **the warm-state of the serving process** —
-  which boot, how many requests old, cache volume state.
+- The instrument list gains an item: **the warm-state of the serving process**
+  (which boot, how many requests old, cache volume state).
 
 ## Chain mode + #42 int4-KV, tested (2026-08-27, boot-floor-aware)
 
@@ -82,21 +82,21 @@ of **~0.1%** here (copy cell: 221.6 / 221.6 across boots). The floor is a proper
 what state the boot inherited, not of the stack.
 
 **`VLLM_DFLASH2_CHAIN=1`** (2 boots/arm, ~0.1% floors): copy **221.6 → 268.0
-(+21%)** — triple the README's +7% on this card — prose 140.4 → 136.75 (**−2.5%**,
+(+21%)**, triple the README's +7% on this card; prose 140.4 → 136.75 (**−2.5%**,
 small but real). A per-workload flag: on for reproduction jobs, off for novel
 generation.
 
 **#42 int4-KV profile (`alternative.sh`, GPU_UTIL=0.93 per its own WSL2 note):**
 window/pool **256,000 tokens on one card**, 22.0GB, serves clean. Shallow prose
-118.0 (≈12% under bf16 — near the claimed cost). ~~**But at 72.6k depth, cached-prefix
-decode collapses to 3.6 tok/s** — ~10× under KVarN's 35.6 at the same depth, with
-healthy acceptance (~30% — ~3.1 tok/step): the cliff is **step time (~860ms)**, i.e.
+118.0 (≈12% under bf16, near the claimed cost). ~~**But at 72.6k depth, cached-prefix
+decode collapses to 3.6 tok/s**, ~10× under KVarN's 35.6 at the same depth, with
+healthy acceptance (~30%, ~3.1 tok/step): the cliff is **step time (~860ms)**, i.e.
 the verify attention over a long int4 cache. The repo's int8 long mode needed a
 dedicated split-KV verify kernel for exactly this (its notes price unsplit Triton
 attention at 7.4ms/layer at 128k); int4 has no analogous kernel yet.~~
 
 ~~**Mechanism CONFIRMED by the discriminating arm** (proposed by the 3090 seat: same
-profile, same depth, speculation off — single-token decode is single-query
+profile, same depth, speculation off; single-token decode is single-query
 attention, so if the multi-query verify path is the cause, the cliff disappears):~~
 
 | int4 @ 72.6k depth | decode tok/s |
@@ -108,7 +108,7 @@ attention, so if the multi-query verify path is the cause, the cliff disappears)
 
 **STRUCK 2026-08-27 (same night, twice).** First the attribution died: we built
 the missing split-KV verify kernel (6× in isolation, 43.5→7.2 ms/step at 72.6k)
-and end-to-end deep decode did not move — verify was ~5% of the step, and the
+and end-to-end deep decode did not move: verify was ~5% of the step, and the
 spec-off arm removes the drafter as well as the verify, so it could never
 attribute the difference (the 3090 seat retracted the test's design themselves).
 Then the premise died: **the "3.6 tok/s deep decode" was never a decode rate.**
@@ -121,21 +121,21 @@ total-window measurement. Streamed with TTFT split out, the true numbers at
 
 | int4 @ 72.6k, decode-only | tok/s | accept | emitted/step | step ms |
 |---|---:|---:|---:|---:|
-| speculation off | **35.55** | — | 1 | 28 |
+| speculation off | **35.55** | - | 1 | 28 |
 | SPEC=dflash2 n7, stock dispatch | 8.14 | .248 | 2.74 | 336 |
 | SPEC=dflash2 n7 + MQ split-KV kernel | 25.23 | .302 | 3.11 | 123 |
 
 **Corrected verdict:** #42's real deep-use blockers are (1) **zero prefix-cache
-reuse under int4 × DFlash2** — isolated by ablation: int8+DFlash2 reuses fine
+reuse under int4 × DFlash2**, isolated by ablation: int8+DFlash2 reuses fine
 (3090), int4 *without* DFlash2 reuses fine (TTFT 62.1s → 3.9s on repeat); only
-the combination never hits — and (2) the slow int4 chunked prefill itself
+the combination never hits; and (2) the slow int4 chunked prefill itself
 (~1,170 tok/s at depth).
 
 **Blocker (1) is WORKED AROUND with one flag: `--prefix-match-unit 848`**
 (pass via `EXTRA_ARGS` to `alternative.sh`). Root cause: the patch stack's
 sliding-window prefix-cache guard (`port(kvarn-v2)`, issue #18) returns a
 permanent clean miss when the drafter's SW block size (848 under int4's
-halved-page geometry) is not a multiple of the hash unit (1696) — and the
+halved-page geometry) is not a multiple of the hash unit (1696); the
 hybrid coordinator's min turns that one group's miss into zero reuse
 model-wide. The stack's own GCD hash-unit logic excludes SW groups, so the
 default never resolves it; the explicit flag (=gcd of the block sizes) makes
@@ -143,7 +143,7 @@ every divisibility clause pass with no geometry change and zero pool cost.
 Verified on this card: per-group hits converge at 71,232/72,591 tokens
 (98.1%), **TTFT 62.0s → 4.1s on the warm repeat**, warm generation
 byte-identical to cold, decode rate and acceptance unchanged. Two caveats
-were raised and both resolved same-day: (1) ~~pool unchanged (253,965)~~ — an
+were raised and both resolved same-day: (1) ~~pool unchanged (253,965)~~: an
 apparent +19% pool difference under the flag (301,974 vs 253,965) was traced
 to boot-time free-VRAM drift, not the flag: a same-hour no-flag control boot
 also reports 301,974. The flag does not touch capacity; quote any pool number
@@ -151,10 +151,10 @@ together with its boot's GPU state. (2) The byte-identical warm-vs-cold result
 was confounded by the drafter's suffix-lookup history (request order alone can
 change greedy output on this stack); re-verified with the lookup lane disabled
 (`LOOKUP=0`): warm TTFT 4.12s, per-group hits converge at 71,232, and the warm
-generation remains byte-identical to cold — reuse reproduces the cold
+generation remains byte-identical to cold; reuse reproduces the cold
 computation exactly. The value is per-card AND
 per-profile: the unit must EQUAL the sliding-window group's block size
-exactly (848 here — finer divisors get zero reuse from the guard's alignment
+exactly (848 here; finer divisors get zero reuse from the guard's alignment
 clause), and that block size moves with model, KV dtype, and DFLASH_TOKENS
 (n=3 chooses 1616/808). The int8 profile never needs the flag (its geometry
 lands 864/864, so the guard cannot fire). Deep *decode* was never 10× under KVarN. Speculation
@@ -165,13 +165,13 @@ spec-off** (35.5, matching KVarN-with-spec's 35.6). The MQ kernel (2.73× step �
 oracles at depth, a full-length exactness pass, and a shallow-context crossover
 (shallow shows −16%; the dispatch needs a seq_len floor and a capture-aware
 variant switch). It still does not obsolete `CTX=huge`/KVarN today.
-~~Quality-at-depth remains unmeasured here on purpose — Austen needles are
+~~Quality-at-depth remains unmeasured here on purpose: Austen needles are
 memorization-contaminated (PPL 1.06), and the proper needle-recall harness run
 is queued on the 3090.~~ **Measured (3090 seat, 2026-08-27): 4/4 exact needle
 recall under int4 KV at 29,653 / 96,368 / 168,542 / 218,085 prompt tokens
-(spec-off, MAX_LEN=256000, pool 266,520, 22,612 MiB) — the same 218k depth
+(spec-off, MAX_LEN=256000, pool 266,520, 22,612 MiB), the same 218k depth
 where KVarN 4/2-bit recalls exactly on that box. Scope stated precisely: a
-needle is a RECALL test, not a quality test — a distinctive literal string is
+needle is a RECALL test, not a quality test; a distinctive literal string is
 near the easiest thing a degraded cache can still retrieve. This licenses
 "int4 does not lose the plot at 218k," not "int4 is lossless at 218k"; the
 latter needs a perplexity or teacher-forced comparison at depth against bf16,
@@ -180,7 +180,7 @@ card.** With recall clean, the MQ split-KV kernel (3.1× deep decode) and
 `--prefix-match-unit` in hand, the remaining objections to #42 at depth are
 performance items with known fixes, not correctness ones.
 
-## ⚠ INSTRUMENT INVERSION (2026-08-28) — read before any deep spec-on number below
+## ⚠ INSTRUMENT INVERSION (2026-08-28): read before any deep spec-on number below
 
 Every deep **spec-on** "decode tok/s" below measured by the streaming probe
 before 2026-08-28 late is **VOID: it counted SSE chunks, and under
@@ -193,22 +193,22 @@ a saved deep generation tokenizes to 455 tokens against 149 counted chunks
 
 | deep 72.6k decode-only, TRUE tok/s | | |
 |---|---:|---|
-| **int4 + MQ split-KV kernel** | **70.5–75.2** | the fastest deep config on the box |
-| long (int8) | 64.0–67.7 | |
-| huge (KVarN) | 59.9–62.7 | old "35.6" void (unknown instrument) |
+| **int4 + MQ split-KV kernel** | **70.5-75.2** | the fastest deep config on the box |
+| long (int8) | 64.0-67.7 | |
+| huge (KVarN) | 59.9-62.7 | old "35.6" void (unknown instrument) |
 | any profile, spec-off | ~35.5 | |
 | int4 stock dispatch | 22.3 | |
 
-**Inverted verdicts:** speculation at depth WINS ~2× (never was break-even —
+**Inverted verdicts:** speculation at depth WINS ~2× (never was break-even:
 the q=8 step costs 43ms vs q=1's 28ms, +54% for ~3× tokens); ~~run deep int4
 work spec-off~~ → **spec-on is the deep mode**; the MQ kernel's true e2e is
-~3.3×; the deep crown moves to int4+kernel (held behind its promotion gates —
+~3.3×; the deep crown moves to int4+kernel (held behind its promotion gates;
 this measurement is not the default-flip gate). The shallow spec-on figures
-(102–138 class) from the same probe are also step-contaminated and the
+(102-138 class) from the same probe are also step-contaminated and the
 shallow crossover awaits token-true re-measurement. The mixed-load and
 politeness sections' *decode* columns are step rates (~×3 for tokens);
 their TTFT/starvation findings are timing-based and stand. Lesson kept:
-**know what one unit of the thing you are counting actually is** — chunks,
+**know what one unit of the thing you are counting actually is**. Chunks,
 steps, tokens, requests, and windows were five different quantities in this
 document's history.
 
@@ -216,43 +216,43 @@ document's history.
 
 | profile | KV format | window | pool (tok) | shallow prose | deep 72.6k decode | windows @72.6k | notes |
 |---|---|---:|---:|---:|---:|---:|---|
-| fast | bf16 | 65,536 | 68,605 | 134.7 | — (window < 72.6k) | — | code 144.5, easy 295.8 |
+| fast | bf16 | 65,536 | 68,605 | 134.7 | - (window < 72.6k) | - | code 144.5, easy 295.8 |
 | long | int8 | 131,072 | 136,429 | **138.0** | 25.3 (spec-on) | 1.9 | code 180.6; the daily driver |
 | huge | KVarN 4/2-bit | 245,760 | 268,169 | 122.9 | **35.6** | 3.7 | on the reference decay curve (32.0 @ 112k) |
-| int4 (#42) | int4 per-token-head | **256,000** | 266k–302k† | 118.0 | **35.55** spec-off · 25.23 spec-on+MQ-kernel · 8.14 spec-on stock | 3.7–4.2 | recall 4/4 to 218k (3090); needs `--prefix-match-unit 848`; only boots at n=7 |
+| int4 (#42) | int4 per-token-head | **256,000** | 266k-302k† | 118.0 | **35.55** spec-off · 25.23 spec-on+MQ-kernel · 8.14 spec-on stock | 3.7-4.2 | recall 4/4 to 218k (3090); needs `--prefix-match-unit 848`; only boots at n=7 |
 
 † Pool numbers are **boot-state-scoped** (this card measured 253,965 and
-301,974 under identical config, hours apart — free-VRAM drift); the 3090
+301,974 under identical config, hours apart: free-VRAM drift); the 3090
 reports 266,520 at MAX_LEN=256000, the patch header 314,915. Quote a pool with
-its boot. Full-window concurrency is ~1.0–1.2× everywhere — these are
+its boot. Full-window concurrency is ~1.0-1.2× everywhere: these are
 single-user profiles; "windows @72.6k" is the honest concurrency-depth column.
 
 Deep prefill is the shared pain, not a differentiator: huge ~1,080 tok/s,
-int4 ~1,170 tok/s at 72.6k (~60–70s first call). Deep-cached calls need a
+int4 ~1,170 tok/s at 72.6k (~60-70s first call). Deep-cached calls need a
 verified cache: huge's 35.6 sits on the reference decay curve (independent
 corroboration); int4's requires the prefix-match-unit flag; long's is
 threadchip-verified (0→60.4% hit rate).
 
 **Long at depth, measured 2026-08-27 (the last empty cell):** 25.31 / 25.33
-tok/s across two runs (spec-on n7, acceptance .22–.24, cache verified: warm
+tok/s across two runs (spec-on n7, acceptance .22-.24, cache verified: warm
 TTFT 1.31s, engine hit rate 49.4%). So at 72.6k the daily driver is the
-SLOWEST of the three — statistically identical to int4 spec-on+kernel (25.2)
+SLOWEST of the three: statistically identical to int4 spec-on+kernel (25.2)
 and 29% behind huge (35.6). The consistent physics: deep verify steps are
 KV-bandwidth-bound, and huge's 4/2-bit cache reads roughly half the bytes of
 int8 per step. Long spec-off at depth remains unmeasured (same physics
 predicts ~35). One measurement scar worth its line: **the chat template is
-part of the prefix** — a request with `enable_thinking` toggled renders a
+part of the prefix**. A request with `enable_thinking` toggled renders a
 different prompt prefix and misses the cache entirely (61s re-prefill,
 observed); pin template kwargs when benchmarking cached depth.
 
 **Reading of the tradeoffs:** with kvarn installed (both our boxes), **huge
-is the depth default, now confirmed against the daily driver** — fastest deep
+is the depth default, now confirmed against the daily driver**: fastest deep
 decode (35.6), slightly better shallow than int4, no flag, no n-brittleness. int4's case is (a) **stock-vLLM
-machinery** — it needs no kvarn install, only 3 small patches, which makes it
+machinery**: it needs no kvarn install, only 3 small patches, which makes it
 the *portable* 256k profile and the upstream-relevant one; (b) +4% window /
 up to +13% pool; (c) it's where the MQ split-KV kernel and any future
 int8-IMMA prefill work land. Run int4 spec-off at depth (25.2 spec-on <
-35.5 spec-off even with the kernel — acceptance ~.30 × n7 loses to q=1).
+35.5 spec-off even with the kernel: acceptance ~.30 × n7 loses to q=1).
 
 ## Three-way concurrency ladder (2026-08-27, all MAX_SEQS=8, ~4k prompts, out=256, reps=2)
 
@@ -266,23 +266,23 @@ branded by its boot's pool line (long 136,429 / huge 268,169 / int4 250,486).
 | 4 | 41.8 / 208 | 62.5 / 330 | 81.5 / **452** |
 | 8 | 35.1 / 190* | 46.2 / **303*** | 54.4 / 242* |
 
-C1 TTFT: long 1.8s · int4 2.7s · huge 5.5s (17.9s at C8 — the KVarN prefill
-tax, which drops huge's end-to-end aggregate to 34–66, worst of the three;
-int4's e2e is best from C2 up at 99–121). \*C8 rows are tail measurements —
+C1 TTFT: long 1.8s · int4 2.7s · huge 5.5s (17.9s at C8: the KVarN prefill
+tax, which drops huge's end-to-end aggregate to 34-66, worst of the three;
+int4's e2e is best from C2 up at 99-121). \*C8 rows are tail measurements:
 no instant had all 8 decoding; long preempted twice at 98% kv, int4 hit 99%.
-ms/pass: int4 flattest (25.9→31.6 — healthy batching), long steepest
+ms/pass: int4 flattest (25.9→31.6, healthy batching), long steepest
 (34.5→70.9). **Caveats:** this long boot ran 29% under its own earlier
-documented C1 (107 vs 149.7, identical config) — the boot floor applies to
-ladders too, so treat C1 ordering as unconfirmed; the C2–C4 gaps (1.5–2×)
+documented C1 (107 vs 149.7, identical config): the boot floor applies to
+ladders too, so treat C1 ordering as unconfirmed; the C2-C4 gaps (1.5-2×)
 exceed any observed boot wobble. kv% is harness-internal (block-granularity),
 comparable within a run only.
 
 ~~**Practical read: long for single-user shallow, huge for single-user depth,
-int4 for concurrency (C2–C4).**~~ **CONTAMINATED AND CORRECTED same evening
+int4 for concurrency (C2-C4).**~~ **CONTAMINATED AND CORRECTED same evening
 (caught by Michael: "I thought we were pulling ~500 at C4?").** The long/huge
 rows above were measured with a forced `MAX_SEQS=8` that overflows their
-CUDA-graph reservations (start_qwen.sh sizes capture for its own defaults —
-long=4, huge=2 — and documents the overflow mode: "bigger batches run
+CUDA-graph reservations: start_qwen.sh sizes capture for its own defaults,
+long=4 and huge=2, and documents the overflow mode ("bigger batches run
 piecewise instead of captured: slower, alive"). Rerun at designed configs:
 
 Cells: decode-aggregate (per-stream) / TTFT.
@@ -294,9 +294,9 @@ Cells: decode-aggregate (per-stream) / TTFT.
 | 4 | **517** (82.5) / 4.2s | 228* (101.4) / 10.9s | 452 (81.5) / 4.7s |
 | 8 | **470*** (75.5) / 8.2s | 191* (80.8) / 19.7s | 242* (54.4) / 8.5s |
 
-\* not steady state — no instant had all N decoding. The CAUSE differs per
+\* not steady state: no instant had all N decoding. The CAUSE differs per
 profile and the `run`/kv% columns in the JSONs separate them: huge C4/C8 =
-**admission cap** (MAX_SEQS=2; run=2, kv% 44.7 — pool half empty; extra
+**admission cap** (MAX_SEQS=2; run=2, kv% 44.7, pool half empty; extra
 streams queue, TTFT 10.9s→19.7s, throughput pinned at ≈C2 by construction);
 long C8 = the same cap at 4; int4 C8 = genuine **pool pressure** (kv% 99.4).
 
@@ -306,16 +306,16 @@ first-to-last-token average, dragged down by the phase where its decode
 interleaves with other streams' chunked prefills; decode-aggregate opens only
 after EVERY stream has its first token (all prefills done) and reads the
 server counter during pure joint decode. Long C4: joint decode is 517
-(~129/stream) while lifetime per-stream averages 82.5 — aggregate is server
+(~129/stream) while lifetime per-stream averages 82.5; aggregate is server
 capacity, per-stream is user experience. long's C4 now three-times confirmed
 (517 here, 517 documented, 533 on the standing stack). ms/pass at designed
 configs: long flat 23.8→27.8 (captured).
 
-**Corrected read: long is the concurrency king outright** — best aggregate at
+**Corrected read: long is the concurrency king outright**: best aggregate at
 every N, zero preemptions, even its over-cap C8 (470) beats the field. int4
 is second and keeps two distinctions: only profile admitting >4 resident, and
 the 256k window (long caps at 131k). huge is a 1-2 user depth instrument.
-Standing lesson: **MAX_SEQS is a graph-budget choice, not a free knob — a
+Standing lesson: **MAX_SEQS is a graph-budget choice, not a free knob: a
 concurrency number is only comparable at the capture config it was captured
 under.** Ladder JSONs (both passes) kept with the bench record.
 
@@ -327,15 +327,15 @@ The uniform ladder above can't see the real serving hazard. Mix one 72.6k
 | scenario | whale TTFT | minnow TTFT (min/med/max) | minnow decode | wall |
 |---|---:|---|---|---:|
 | C2: whale+1, cold | 65.6s | 2.8s | **1.2 tok/s** (starved) | 69s |
-| C4: whale+3, cold | 62.6s | 63.5/68.2/70.2s | 22–40 (after waiting) | 72s |
+| C4: whale+3, cold | 62.6s | 63.5/68.2/70.2s | 22-40 (after waiting) | 72s |
 | C8: whale+7, cold | 68.6s | 2.2/**75.9**/81.6s | 0.9/14.5/36.3 | 83s |
-| **C4: whale+3, whale CACHED** | **4.9s** | **5.5/6.9/11.2s** | 15–35 (immediate) | **13.5s** |
+| **C4: whale+3, whale CACHED** | **4.9s** | **5.5/6.9/11.2s** | 15-35 (immediate) | **13.5s** |
 
-**A deep prefill monopolizes the engine for its full ~65s** — chunked prefill
+**A deep prefill monopolizes the engine for its full ~65s**: chunked prefill
 either rations an admitted minnow to ~1 tok/s (each pass = a 2,020-token whale
 chunk + one minnow token) or queues minnows behind the entire prefill. Decode
 coexistence afterward is fine. So the serving constraint is **prefill
-head-of-line blocking, not decode concurrency** — and the fix is the prefix
+head-of-line blocking, not decode concurrency**; the fix is the prefix
 cache: with the whale's prefix warm, the same scenario collapses 72s → 13.5s
 and every stream's first token lands inside ~11s. Pin your whales' prefixes.
 
@@ -345,30 +345,30 @@ Same cold-whale C4 mix as above, CTX=long, sweeping the per-pass token budget:
 
 | budget | whale TTFT | minnow TTFT | minnow decode during whale prefill | wall |
 |---|---:|---|---|---:|
-| 2048 (default) | 62.6s | 63–70s (queued) | 22–40 only after | 72.2s |
-| 1024 | 69.6s | **4.2–7.2s** | 6.8–14.3 | 73.0s |
-| 512 | 72.2s | **4.5–7.6s** | **14.2–21.8** | 75.4s |
+| 2048 (default) | 62.6s | 63-70s (queued) | 22-40 only after | 72.2s |
+| 1024 | 69.6s | **4.2-7.2s** | 6.8-14.3 | 73.0s |
+| 512 | 72.2s | **4.5-7.6s** | **14.2-21.8** | 75.4s |
 
-At 2048 a whale chunk fills the whole budget and minnow prefills queue behind
-the entire whale; at ≤1024 the scheduler interleaves and minnows are live in
+At 2048 a whale chunk fills the whole budget, so minnow prefills queue behind
+the entire whale; at ≤1024 the scheduler interleaves, so minnows are live in
 ~5s. Whale decode is unaffected (25.4 everywhere). **Mixed serving: budget
-512 + pinned whale prefixes (with the cache, the whale itself starts in ~5s
-— see the cached-whale row above); dedicated single-user depth: keep 2048.**
+512 + pinned whale prefixes (with the cache, the whale itself starts in ~5s;
+see the cached-whale row above); dedicated single-user depth: keep 2048.**
 Caveat for the boot ritual below: smaller budgets slow ALL prefill, so the
 warm-pair ratio compresses (7.7× at 2048 → ~2.8× at 512); the ½ threshold
 still held.
 
-## Cache-dead boots (observed 2026-08-27/28) — add a warm-pair check to the boot ritual
+## Cache-dead boots (observed 2026-08-27/28): add a warm-pair check to the boot ritual
 
 One CTX=long boot served correctly but **never produced a prefix-cache hit**
 (0.0% across 32 windows; three identical-prompt pairs all re-prefilled ~62s),
 with verifiably healthy 864/864 block geometry. A config-identical restart hit
 normally (warm TTFT 3.5s; per-group trace converging at 71,712). Cause
-unknown — the dead boot was recycled before deep inspection; treat as a real,
+unknown: the dead boot was recycled before deep inspection; treat as a real,
 rare, nondeterministic boot state. ~~Detection is cheap: send a ~2k-token
 prompt twice and require the second TTFT < half the first.~~ **CORRECTED
 (3090 seat caught it failing on its first healthy boot): a fixed-size probe
-is structurally blind when it spans ≤1 block — reuse is (blocks−1)×B, so 2k
+is structurally blind when it spans ≤1 block: reuse is (blocks−1)×B, so 2k
 tokens at B=1696 (int4) reuses NOTHING and a healthy boot reads dead; at
 B=864 it's one reusable block, a coin flip. Size the probe from the block
 size the engine chose, out of its own boot log:**
@@ -382,12 +382,12 @@ Verified both boxes: 3090 int8 cold 7.58s → warm 0.99s (7.7×); 4090 int8
 cold 4.94s → warm 0.64s (7.7×). Restart on failure. Until root-caused, no
 "deep-cached" number should be trusted from a boot that hasn't passed the
 sized pair check. (Third instance in one day of a test tuned to a constant
-it didn't read — the constant is never portable and always in the boot log.)
+it didn't read: the constant is never portable and always in the boot log.)
 
-## Batch mode on the 4090 (2026-08-28) — the other wing
+## Batch mode on the 4090 (2026-08-28): the other wing
 
 First boot of the repo's `batch` profile here (fp8 KV, no speculation, engine
-block 800, pool 175,515 @150k, `GPU_UTIL=0.93` — **0.972 never fits under
+block 800, pool 175,515 @150k, `GPU_UTIL=0.93`; **0.972 never fits under
 WSL2's reserve on a desktop-attached card**; the MAX_LEN defaults are
 fp8-geometry-specific, don't carry int4 numbers over). Token-true ladder,
 distinct 4k prompts:
@@ -399,84 +399,84 @@ distinct 4k prompts:
 | ms/pass | 18.3 | 19.8 | 20.5 | 20.9 | 23.7 |
 
 Textbook batch scaling: tokens/pass ≡ N, ms/pass essentially flat C1→C16,
-zero preemptions (the profile's 64-way graph budget is pre-sized — no
+zero preemptions (the profile's 64-way graph budget is pre-sized: no
 piecewise trap). **Doctrine: the spec wing (single+DFlash) wins up to
-~C4–C8 (long C4 = 517 agg); batch takes over around C10 and scales to 64**
-(README: ~1,094 at C64 on a 3090). At C1 batch costs 2.7× vs spec — spec IS
+~C4-C8 (long C4 = 517 agg); batch takes over around C10 and scales to 64**
+(README: ~1,094 at C64 on a 3090). At C1 batch costs 2.7× vs spec: spec IS
 the single-user profile.
 
-**Retention under batch — prediction falsified, informatively:** with NO
+**Retention under batch (prediction falsified, informatively):** with NO
 drafter groups, 3 contexts at 85% naive utilization still fully evicted. The
 retention tax's center of mass is the **mamba state** (equal-sized mamba
 pages per attention block, by construction ≈ 2× per cached context), with
 the drafter adding the rest of spec-mode's ~2.7×. Universal for this hybrid
-model: **cached seats ≈ pool ÷ (2–2.7 × context) on every profile** — one
-warm deep whale per box; a CPU offload tier (the in-tree #33 patch /
+model: **cached seats ≈ pool ÷ (2-2.7 × context) on every profile** (one
+warm deep whale per box); a CPU offload tier (the in-tree #33 patch /
 LMCache, noted for investigation) is the only door to more. *(That door is
-now open — see the offload section below.)*
+now open; see the offload section below.)*
 
 ## TP=2 (2×4090) under WSL2 (2026-08-27)
 
 Boots clean (PYNCCL; no NCCL env tweaks needed). **Capacity play, not a speed play
 on this platform**: KV pool **593,574 tokens** at CTX=long (4.53× concurrency at
-131k — four full windows resident at once), but C1 decode drops 22–33% (prose
+131k: four full windows resident at once), but C1 decode drops 22-33% (prose
 107.3, code 121.6 vs 138.0/180.6 single-card) and N=4 aggregate falls to 358 vs the
 single card's 517. The PCIe all-reduce under WSL2 inverts #40's native-3090 result
-(+16–35%) — recorded as a **platform-dependence datapoint**, not an explanation.
+(+16-35%). Recorded as a **platform-dependence datapoint**, not an explanation.
 The #40-era `start_qwen.sh` TP calibration (auto-skip of the single-card KV_MEM
 pin) worked exactly as documented. One caveat: the desktop compositor's ~1.7GB on
 the second card means `GPU_UTIL=0.90` there, not 0.93.
 
-## CPU offload tier under WSL2 — the OffloadingConnector fix (2026-08-28)
+## CPU offload tier under WSL2: the OffloadingConnector fix (2026-08-28)
 
 The in-tree #33 OffloadingConnector (CPU tier over a pinned `/dev/shm` mmap)
 crashed WSL2 with an illegal memory access on the first real eviction, after a
 misdirection cascade that blamed two innocent async bystanders (the mamba-state
-copy, then the block zeroer — `CUDA_LAUNCH_BLOCKING` serializes **kernels**, not
+copy, then the block zeroer: `CUDA_LAUNCH_BLOCKING` serializes **kernels**, not
 async copies, so the fault surfaced on whatever synchronized next).
 
 **Root cause:** the Triton `swap_blocks` kernel dereferences raw **host** virtual
 addresses of the `cudaHostRegistered` region. Under native-Linux UVA the host VA
-happens to equal the device VA, so it works — by coincidence, not contract. WSL2
+happens to equal the device VA, so it works (by coincidence, not contract). WSL2
 registers successfully but maps the region at a **different device address**, so
 the kernel faults. Registration succeeding was mistaken for device-address
-equivalence; `cudaHostGetDevicePointer` — the API's own answer for exactly this
-case — was never called.
+equivalence; `cudaHostGetDevicePointer` (the API's own answer for exactly this
+case) was never called.
 
 **The fix** (`patches/offload-wsl2-devptr.patch`, applied in the stack): after
 registration, ask for the device pointer, carry the delta on each CPU view, and
 add it where `compute_sub_block_ptrs` builds addresses. Delta is 0 on native
-Linux — no behavior change. Every failure branch **raises** rather than warning:
+Linux: no behavior change. Every failure branch **raises** rather than warning:
 a platform where the device pointer is unavailable refuses to start instead of
 proceeding into silent-unsafe zero-copy. That makes the fix more falsifiable
-than a warn-and-continue shape — a live engine with the patch applied is itself
+than a warn-and-continue shape: a live engine with the patch applied is itself
 evidence the query ran and succeeded.
 
 **Loader gotcha** (cost one review round): standard pip installs ship only
 *versioned* cudart sonames at absolute wheel paths, so `CDLL("libcudart.so")`
 throws on most native boxes. The patch resolves from the process image first
-(`CDLL(None)` — torch has already dlopen'd cudart), then system sonames, then a
+(`CDLL(None)`: torch has already dlopen'd cudart), then system sonames, then a
 glob over the torch wheel's `nvidia/*/lib/`.
 
 **Falsification bracket, both platforms:**
 
 | Arm | WSL2 / 4090 | Native / 3090 |
 |---|---|---|
-| With fix | 3×72.6k whales primed, all recheck **warm 4.2–4.3s**, 0 IMAs | 52.4 tok/s, token sha byte-identical to baseline, **805 MB** moved through the tier live |
+| With fix | 3×72.6k whales primed, all recheck **warm 4.2-4.3s**, 0 IMAs | 52.4 tok/s, token sha byte-identical to baseline, **805 MB** moved through the tier live |
 | Fix removed | IMA returns (count 3), first prime dies | returns to baseline exactly |
 | Loader | resolves tier 1 (also carries unversioned soname) | resolves tier 0 (`CDLL(None)`), rc=0, **delta=0** |
 
 On WSL2 the delta line prints (`delta=-133564122513408 … translating kernel
-addresses`); on native it must be **absent** — both observed. First time the CPU
+addresses`); on native it must be **absent** (both observed). First time the CPU
 tier carried state on either box: ~590k page-tokens held beyond the 252k GPU
 pool; a 72.6k whale primes in ~62s and rechecks warm in 4.3s.
 
-**Operator notes:** the 8 GB `/dev/shm` backing file **outlives the process** —
+**Operator notes:** the 8 GB `/dev/shm` backing file **outlives the process**:
 confirmed empirically on the 3090 (still resident after a teardown kill), and
 because shm is RAM-backed the stranded file **holds those gigabytes for as long
 as the box sits idle**. Cleaning at startup (`start_qwen.sh` does) recovers it
 for the next run, but on a small-RAM box the held memory is the next boot's
-OOM — clean at shutdown too. Docker needs `--ipc host`: the 64 MB default shm
+OOM, so clean at shutdown too. Docker needs `--ipc host`: the 64 MB default shm
 makes the region's `madvise(MADV_POPULATE_WRITE)` fail with EFAULT at boot.
 
 Status: validated on both boxes for correctness and round-trip. The
@@ -486,14 +486,14 @@ work.
 
 **Three agents, measured (2026-08-28):** with the tier armed, three
 simultaneous agents each on its own 72.6k context fire repeatedly with
-**zero recomputes** — unqueued tier restores in 5–7s, the LRU-rotated seat
-~16s restoring under load, against 62s cold. Those 4–7s rechecks are tier
+**zero recomputes**: unqueued tier restores in 5-7s, the LRU-rotated seat
+~16s restoring under load, against 62s cold. Those 4-7s rechecks are tier
 restores, *not* GPU-warm hits: the tier-off control (K=2 round-robin at
 72.6k = **0/2**, K=3 = 0/3 on a 300,583-token pool) shows the GPU holds
-about one such context warm — real per-context cost exceeds 150k tokens at
+about one such context warm; real per-context cost exceeds 150k tokens at
 72.6k depth, a >2.07× multiplier. A corrective banner line computed from
 the engine's own spec bytes (constant mamba + linear attention) predicted
-2/2 and was falsified by that same control — it is parked on the
+2/2 and was falsified by that same control; it is parked on the
 `banner-capacity-experiment` branch, unmerged, while the gap mechanism
 (drafter group pages · per-group block rounding · prefix-retention
 granularity at the 848 hash unit) stays open.

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -1,0 +1,40 @@
+# RTX 4090 under Windows 11 / WSL2 (Docker) — reproduction notes
+
+The docker path reproduces on a 4090 under Docker Desktop's WSL2 backend with **zero
+repo changes** — `.env` plus `VLLM_WSL2_ENABLE_PIN_MEMORY=1`, exactly as
+`docs/docker.md` prescribes. All numbers below: client-measured wall-clock (256-token
+generations, greedy, median of 3) — *not* harness rows; the existing 4090 harness row
+in the README (#32) covers C1.
+
+## CTX ladder (SPEC=dflash2, DFLASH_TOKENS=7)
+
+| CTX | window | KV pool (tok) | prose | code | notes |
+|---|---:|---:|---:|---:|---|
+| fast | 65,536 | 68,605 | 134.7 | 144.5 | easy-formulaic 295.8 |
+| long | 131,072 | 136,429 | 138.0 | 180.6 | int8 KV; code *faster* than fast here |
+| huge | 245,760 | **268,169** | 122.9 | — | pool byte-identical to the reference 3090 |
+
+- **huge at depth** (72,631-token prompt, prefix-cached): 35.6 tok/s decode — on the
+  reference decay curve (32.0 @ 112k). First call ~71s incl. prefill (~1,080 tok/s).
+- WSL2 tax at these workloads: none measurable — pools identical to native-Linux
+  reference, speeds silicon-proportional.
+
+## Concurrency ladder (`bench/conc_ladder.py --n 1,2,4,8 --out 256 --reps 2`, CTX=long, MAX_SEQS=8)
+
+| N | per-stream | decode agg | kv% | preempt |
+|---|---:|---:|---:|---:|
+| 1 | 149.7 | 149 | 19.7 | 0 |
+| 2 | 119.8 | 278 | 36.0 | 0 |
+| 4 | 79.0 | **517** | 71.1 | 0 |
+| 8 | 57.2 | 351* | 98.2 | 2 |
+
+\* never reached steady state — the pool cannot hold 8 at ~4k ctx each.
+
+## The KV_MEM pin: leave it alone (measured both ways)
+
+Raising `KV_MEM` 5.58 → 6.53 GB on the 4090's spare headroom grows the pool to
+159,643 tokens — and costs **8% C1 decode** (126.6 vs 138.0), and under 8-way load
+the server **OOM-crashes on a 58 MiB activation allocation**: the headroom the pin
+preserves is what concurrency spikes spend. The shipped constant transfers to the
+4090/WSL2 as-is. Windows are design caps (131,072 for dflash2+long; 245,760 huge),
+not VRAM accidents: `MAX_LEN` above them is clamped.

--- a/docs/wsl2-4090.md
+++ b/docs/wsl2-4090.md
@@ -38,3 +38,21 @@ the server **OOM-crashes on a 58 MiB activation allocation**: the headroom the p
 preserves is what concurrency spikes spend. The shipped constant transfers to the
 4090/WSL2 as-is. Windows are design caps (131,072 for dflash2+long; 245,760 huge),
 not VRAM accidents: `MAX_LEN` above them is clamped.
+
+## Retest at c954724 (upstream pickup, 2026-08-27)
+
+Rebuilt at upstream head (four new patches incl. n-gram chains #38, int4-KV #42).
+Same standing config, warmed second-pass medians, CTX=long:
+
+| build | LOOKUP | prose | code |
+|---|---|---:|---:|
+| 60daef8 | 1 (default) | 138.0 | 180.6 |
+| c954724 | 1 (default) | 130.6 | 170.0 |
+| c954724 | **0** | **140.6** | **194.6** |
+
+Two findings: the #38 chain rework costs the **default `LOOKUP=1` lane ~5.5%** on
+non-reproduction prompts (global paths are unregressed — lookup-off *beats* the old
+build), and on novel-generation workloads the lookup lane is net overhead either
+way — its value is context reproduction, per the `DFLASH_TOKENS=15` docs. Standing
+config on this box is now `LOOKUP=0`, flipped on per-workload for verbatim-
+reproduction tasks.

--- a/patches/offload-wsl2-devptr.patch
+++ b/patches/offload-wsl2-devptr.patch
@@ -1,0 +1,95 @@
+diff --git a/vllm/v1/kv_offload/cpu/gpu_worker.py b/vllm/v1/kv_offload/cpu/gpu_worker.py
+index 40b57ac..0a3471b 100644
+--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
++++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
+@@ -99,7 +99,9 @@ def compute_sub_block_ptrs(
+     assert skip_count < blocks_per_chunk
+ 
+     num_sub_blocks = len(output)
+-    base_ptr = tensor.data_ptr()
++    # (fix 2026-08-28) device-VA translation for non-UVA platforms (delta 0
++    # on native Linux; the attribute exists only on offload-mmap CPU views).
++    base_ptr = tensor.data_ptr() + getattr(tensor, "_offload_ptr_delta", 0)
+     row_stride = tensor.stride(0)
+ 
+     if blocks_per_chunk == 1:
+@@ -148,6 +150,69 @@ def pin_mmap_region(region: SharedOffloadRegion) -> None:
+             region.total_size_bytes / 1e9,
+         )
+         region.is_pinned = True
++        # (fix 2026-08-28) Host VA == device VA only under true UVA. WSL2
++        # registers successfully but maps the region at a different device
++        # address; kernels dereferencing the host VA fault (IMA). Ask the
++        # API for the device pointer and carry the delta into pointer
++        # arithmetic. Delta is 0 on native Linux — no behavior change.
++        import ctypes as _ctypes
++        import glob as _glob
++        import os as _os
++
++        def _load_cudart():
++            # The process image first: torch has already dlopen'd cudart, and
++            # standard pip installs ship ONLY versioned sonames at absolute
++            # wheel paths never on the loader search path (so a bare
++            # CDLL("libcudart.so") fails on most native Linux boxes).
++            candidates = [None, "libcudart.so", "libcudart.so.13",
++                          "libcudart.so.12"]
++            import torch as _torch
++            _sp = _os.path.dirname(_os.path.dirname(_torch.__file__))
++            candidates += sorted(_glob.glob(
++                _os.path.join(_sp, "nvidia", "*", "lib", "libcudart.so*")))
++            for _cand in candidates:
++                try:
++                    _lib = _ctypes.CDLL(_cand)
++                    _lib.cudaHostGetDevicePointer  # symbol must resolve
++                    return _lib
++                except (OSError, AttributeError):
++                    continue
++            return None
++
++        try:
++            _libcudart = _load_cudart()
++            if _libcudart is None:
++                raise RuntimeError(
++                    "KV offload: cudart with cudaHostGetDevicePointer not "
++                    "loadable from the process image, system sonames, or the "
++                    "wheel path — cannot verify device addressability of the "
++                    "registered mmap; refusing unsafe zero-copy transfers.")
++            _devptr = _ctypes.c_void_p()
++            _rc = _libcudart.cudaHostGetDevicePointer(
++                _ctypes.byref(_devptr), _ctypes.c_void_p(base_ptr), 0)
++            if _rc == 0 and _devptr.value:
++                region.device_delta = _devptr.value - base_ptr
++                if region.device_delta != 0:
++                    logger.warning(
++                        "KV offload mmap: device VA differs from host VA "
++                        "(delta=%d) — non-UVA platform (e.g. WSL2); "
++                        "translating kernel addresses.", region.device_delta)
++            else:
++                # Fail LOUD: proceeding with host VAs on a platform where the
++                # device pointer is unavailable is exactly the silent-unsafe
++                # shape this fix exists to remove. Refuse; the operator can
++                # disable offload or use a staged-DMA build.
++                raise RuntimeError(
++                    "KV offload: cudaHostGetDevicePointer failed "
++                    f"(rc={_rc}) for the registered mmap. Zero-copy kernels "
++                    "would dereference unmapped host addresses (illegal "
++                    "memory access). Refusing to start with the "
++                    "OffloadingConnector on this platform.")
++        except OSError as _e:
++            raise RuntimeError(
++                "KV offload: could not query the device pointer for the "
++                f"registered mmap ({_e}); refusing unsafe zero-copy "
++                "transfers.") from _e
+ 
+ 
+ def _new_descriptor_buffers(
+@@ -492,6 +557,9 @@ class CPUOffloadingWorker(OffloadingWorker):
+ 
+             if mmap_region is not None:
+                 cpu_tensor = mmap_region.create_next_view(cpu_page_size_bytes)
++                # (fix 2026-08-28) ride the device-VA delta with the view
++                cpu_tensor._offload_ptr_delta = (
++                    getattr(mmap_region, "device_delta", 0) or 0)
+             else:
+                 t0 = time.monotonic()
+                 cpu_tensor = torch.zeros(

--- a/patches/spec-decode-int4-kv-mq3d.patch
+++ b/patches/spec-decode-int4-kv-mq3d.patch
@@ -1,0 +1,87 @@
+diff --git a/vllm/v1/attention/ops/int4_per_token_head.py b/vllm/v1/attention/ops/int4_per_token_head.py
+index 6e8de72..1400469 100644
+--- a/vllm/v1/attention/ops/int4_per_token_head.py
++++ b/vllm/v1/attention/ops/int4_per_token_head.py
+@@ -12,6 +12,7 @@ kernel, the RHT transform, and the public ``reshape_and_cache_int4`` /
+ 
+ from __future__ import annotations
+ 
++import os
+ from typing import Any
+ 
+ import torch
+@@ -741,16 +742,41 @@ def _launch_packed_attn(
+         head_size, sliding_window_val, q.element_size(), is_prefill=False
+     )
+ 
++    # syv-fork (fermion, 2026-08-27) — int4 multi-query 3D: DFlash2's verify is
++    # an 8-row multi-query batch, and excluding max_seqlen_q > 1 from the
++    # split-KV path forces a ~20-CTA 2D serial walk of the whole KV per step
++    # (measured: 3.6 tok/s at 72.6k depth vs 29.0 with speculation off). The
++    # q=1 equivalence "tokens == num_seqs" is what the old num_seqs check
++    # silently relied on for scratch-buffer capacity; multi-query breaks that
++    # equivalence, so capacity is checked against the token-indexed scratch
++    # buffers directly. Opt-in via VLLM_INT4_MQ_3D=1 (promotion gates open).
++    _mq = max_seqlen_q > 1
++    _mq_3d_enabled = os.environ.get("VLLM_INT4_MQ_3D", "0") == "1"
++    _capacity_ok = (
++        softmax_segm_output is not None
++        and softmax_segm_max is not None
++        and softmax_segm_expsum is not None
++        and q.shape[0] <= softmax_segm_output.shape[0]
++        and q.shape[0] <= softmax_segm_max.shape[0]
++        and q.shape[0] <= softmax_segm_expsum.shape[0]
++    )
+     use_3d = not (
+         seq_threshold_3D is None
+         or num_par_softmax_segments is None
+         or softmax_segm_output is None
+         or softmax_segm_max is None
+         or softmax_segm_expsum is None
+-        or max_seqlen_q > 1
++        or (_mq and not (_mq_3d_enabled and max_seqlen_q <= 16 and _capacity_ok))
+         or num_seqs > seq_threshold_3D
+         or is_batch_invariant
+     )
++    if os.environ.get("VLLM_INT4_MQ_3D_DEBUG") == "1":
++        print(
++            f"[int4-mq3d] tokens={q.shape[0]} num_seqs={num_seqs} "
++            f"max_seqlen_q={max_seqlen_q} use_3d={use_3d} "
++            f"segments={num_par_softmax_segments if use_3d else 1}",
++            flush=True,
++        )
+ 
+     # 3D never reads ``output_ptr`` and 2D never reads the segm tensors,
+     # but Triton needs a non-null pointer everywhere; reuse ``out`` as
+diff --git a/vllm/v1/attention/ops/triton_unified_attention.py b/vllm/v1/attention/ops/triton_unified_attention.py
+index f4d9ba9..e92cc4c 100644
+--- a/vllm/v1/attention/ops/triton_unified_attention.py
++++ b/vllm/v1/attention/ops/triton_unified_attention.py
+@@ -715,6 +715,27 @@ def reduce_segments(
+     # sequence len for this particular sequence
+     seq_len = tl.load(seq_lens_ptr + seq_idx)
+ 
++    # syv-fork (fermion, 2026-08-27): zero-length (padded) rows. The producer
++    # early-returns without writing any segment for seq_len == 0, and
++    # cdiv(0, 0) below makes act_num_segments garbage, so the masked loads
++    # could read unwritten scratch (NaN-poisoning the output through the
++    # rescale path even past the expsum==0 guard). Write zeros and leave.
++    if seq_len == 0:
++        _z_dim_mask = tl.where(
++            tl.arange(0, HEAD_SIZE_PADDED) < HEAD_SIZE, 1, 0
++        ).to(tl.int1)
++        _z_offset = (
++            query_token_idx * output_stride_0
++            + query_head_idx * output_stride_1
++            + tl.arange(0, HEAD_SIZE_PADDED)
++        )
++        tl.store(
++            output_ptr + _z_offset,
++            tl.zeros([HEAD_SIZE_PADDED], dtype=output_ptr.dtype.element_ty),
++            mask=_z_dim_mask,
++        )
++        return
++
+     # number of segments for this particular sequence
+     num_segments = NUM_SEGMENTS_PER_SEQ
+     tiles_per_segment = cdiv_fn(seq_len, num_segments * TILE_SIZE)

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -533,7 +533,7 @@ fi
 
 exec venv/bin/vllm serve "$MODEL" \
   --served-model-name qwen3.8-27b \
-  --host 0.0.0.0 --port $PORT \
+  --host ${HOST:-0.0.0.0} --port $PORT \
   --gpu-memory-utilization $GPU_UTIL \
   --max-model-len $MAX_LEN \
   --max-num-seqs $MAX_SEQS \


### PR DESCRIPTION
## Summary

This PR is the writeup of a two box effort: an RTX 4090 under Windows 11 / WSL2
(Docker) and an RTX 3090 on native Ubuntu (Python 3.14, venv, no container).
Everything below was measured on at least one of the boxes, and the load
bearing claims were measured on both. The detailed notes ship with the PR:
[docs/wsl2-4090.md](docs/wsl2-4090.md), [docs/ubuntu-3090.md](docs/ubuntu-3090.md),
and [docs/reproductions/native-3090.md](docs/reproductions/native-3090.md).

What it carries:

1. **A fix for the CPU offload tier on WSL2** (`patches/offload-wsl2-devptr.patch`).
   The OffloadingConnector crashes with an illegal memory access on WSL2. We
   root caused it, fixed it, and validated the fix on both platforms. This is
   probably an upstream vLLM bug rather than a repo bug: any WSL2 user of the
   connector should hit it, with any model.
2. **A one flag fix for prefix caching going dead** on int4 KV + DFlash2
   (`--prefix-match-unit 848`), with the analysis of why it dies.
3. **An int4 attention kernel for speculative decoding**
   (`patches/spec-decode-int4-kv-mq3d.patch`), opt in via `VLLM_INT4_MQ_3D=1`.
   About 3.3x end to end on deep int4 spec decode. It defaults off, and section
   3 lists the tests it still owes before it earns default on.
4. **A measurement correction** that matters to anyone benchmarking this stack
   over SSE. It reversed one of our own early conclusions.
5. **Operating notes**: what actually stays cached at depth, which settings
   matter under mixed load, and what the engine's startup numbers do and do not
   tell you.

## 1. If you benchmark speculation over SSE, read this first

With speculation on, each SSE chunk is one speculative step, not one token; at
n7 a chunk averages about 3 tokens. A benchmark that counts chunks per second
therefore undercounts spec-on throughput by roughly 3x while counting spec-off
correctly, so every comparison is biased against speculation. We made exactly
this mistake, concluded "speculation loses at depth" from it, and retracted.
The fix: request `stream_options.include_usage` and read
`usage.completion_tokens`; report emitted tokens per step alongside as the
sanity check. Both boxes reproduced the effect independently. Every spec-on
number in this PR is counted in tokens.

## 2. Deep context numbers (72.6k token prompt, 4090/WSL2)

| config | decode tok/s (deep) |
|---|---|
| int4 KV + MQ-3D kernel, DFlash2 n7 | **70.5 to 75.2** |
| long (int8 KV), DFlash2 n7 | 64 to 68 |
| huge (KVarN 4/2-bit), DFlash2 n7 | ~60 to 63 |
| int4 KV, spec off | 35.55 |
| int4 KV, stock #42 dispatch, DFlash2 n7 | 22.3 |

With the right kernel and flags, speculation wins by about 2x at depth. Our
earlier conclusion that it loses was two errors compounding: the chunk counting
above, plus the stock int4 dispatch, which genuinely does lose (0.63x against
spec off).

## 3. The int4 MQ-3D kernel

Stock #42 launches its spec-verify attention once per query position (a 2D
grid), but DFlash2's verify is an 8 row multi-query batch, so each step walks
the whole KV serially: measured 8.14 steps/s at 72.6k depth. Dispatching all
query rows in one 3D launch with a reducer guard (33 lines) restores split-KV
for the verify batch: 8.14 to 25.2 steps/s, which is 22.3 to ~73 tok/s end to
end (~3.3x).

It ships opt in (`VLLM_INT4_MQ_3D=1`, default off) because six checks are still
owed before anyone should trust it as a default: a 72k operator/logit oracle,
full length exactness, per position logit comparison, eager+captured+q=9
parity, a shallow crossover floor (shallow currently reads -16%), and capture
aware dual variant switching. It is its own commit, so it drops cleanly if you
want the rest without it.

## 4. Prefix cache zero reuse on int4 + DFlash2: the one flag fix

Symptom: with int4 KV and DFlash2 together, the prefix cache never hits.
Every request re-prefills; a warm 72.6k prompt costs 62 seconds every time.
The cross box isolation: int8 + DFlash2 hits, int4 without DFlash2 hits,
therefore the bug is the interaction of the two.

Cause: two sites in the kvarn v2 port carry assumptions that contradict each
other. The GCD computation excludes sliding window groups (its comment says
their block divides the primary by construction, which is true) and lands on
hash unit 1696. But the SW guard then requires the SW block (848) to be a
multiple of that hash unit, and 848 % 1696 is never 0: the exclusion
guarantees the guard fails. Under int8 both values are 864, so the
contradiction is invisible there.

Fix: the port's own escape hatch, `--prefix-match-unit 848` (the GCD). Every
clause then passes by arithmetic (1696 % 848 = 0, 848 % 848 = 0, both read
clauses). Verified: warm whale TTFT 62s to 4.3s. The rule that generalizes:
the prefix match unit must equal the SW block, and it is per model, KV dtype,
and draft length... 848 is this model's number, not a constant.

## 5. Retention: what actually stays cached

Some vocabulary we used throughout, so the numbers below read plainly: a
**whale** is one large prompt (say 72k tokens); **minnows** are the small 4k
requests competing with it for the same engine.

The engine's startup line ("Maximum concurrency for N tokens per request:
X.XXx") divides the pool by max_model_len. We measured what that number means
in practice, and the answer depends on the question you ask:

- **Capacity** (recheck only the newest context): the newest one is warm.
  On the 3090, 2.24s against a 50.35s cold prime, a 22x speedup.
- **Round robin** (recheck A, B, C in order, the pattern a multi user service
  actually runs): **0 of 3 hit**, because each recheck's own prefill evicts
  the next context before it is asked.

Then we measured the per context cost directly, by finding the largest context
length where two contexts both stay warm (per length salts, offload tier off,
and each boundary re-run alone in a fresh boot before we called it a
measurement): a cached context costs about **2.5 to 2.9x its token count** at
51k to 61k on the 4090 (int4 geometry, 300,583 token pool), and about
**2.3 to 2.7x** at 25k to 29k on the 3090 (int8, 136,429 pool). The extra cost
is the per sequence state: mamba state pages are constant size per sequence,
therefore they do not shrink with shorter prompts, and the drafter adds its
own groups.

We then tried to pin down the cost model and killed both simple candidates,
one per geometry, with pre-registered tests: pure multiplicative
(`cost = m * L`) fails on int4 (the K=2 boundary caps m at 2.93 but a K=3 test
demands more than 3.18; no m satisfies both), and pure additive
(`cost = L + F`) fails on int8 (the K=2 and K=3 boundaries demand F in
disjoint intervals). An affine shape fits every boundary on both boxes, but
with two free parameters against six one sided constraints that is a shape
with room to spare, not a finding; this PR ships the measured brackets and
leaves the cost model open.

The practical takeaways:

- The startup concurrency number is **correct for a single full length
  request** (section 7 has the measurement) but overstates warm multi context
  capacity by 2x or more, and nothing in the log says which case you are in.
- **The offload fix in section 6 changes the round robin story**: with the
  CPU tier, the same 3-whale round robin goes from 0/3 to 3/3. Not because
  the GPU holds them (it holds about one), but because eviction becomes a
  RAM restore instead of a full re-prefill.

## 6. The OffloadingConnector fix

Full writeup: docs/wsl2-4090.md, the offload section. The short version:

The Triton `swap_blocks` kernel dereferences **host** virtual addresses of the
`cudaHostRegistered` /dev/shm region. On native Linux, UVA makes host VA equal
device VA, so this works; but that is a coincidence of the platform, not a
contract of the API. WSL2 registers successfully and maps the region at a
**different** device address, therefore the kernel faults (illegal memory
access) on the first real eviction.

The fix: after registration, ask `cudaHostGetDevicePointer` for the device
address, carry the delta on the CPU views, and add it where
`compute_sub_block_ptrs` builds pointers. The delta is 0 on native Linux, so
no behavior change there. Every failure branch raises: a platform where the
device pointer is unavailable refuses to start instead of running with
addresses that fault later.

Validation, both platforms:

| arm | WSL2 / 4090 | native / 3090 |
|---|---|---|
| with fix | 3x 72.6k whales primed, all recheck warm in 4.2 to 4.3s, 0 IMAs | 52.4 tok/s, tokens byte identical to baseline, **805 MB** moved through the tier live |
| fix removed | the IMA returns (count 3), first prime dies | returns to baseline exactly |
| loader | resolves in-process, delta prints and translates | `CDLL(None)`, rc=0, delta=0 |

One honesty note that section 9 leans on: the first version of this fix
"passed" its native arms while inert, because a bare `CDLL("libcudart.so")`
throws on standard pip installs (the wheels ship only versioned sonames), so
its happy path never executed. v3 resolves from the process image first and
raises on every failure, therefore a live patched engine is itself proof the
device pointer query ran and succeeded.

Follow-on hardening, tracked but not in this PR: typed two pointer separation
instead of a delta attribute, transfer records, restored state checksums, and
lifecycle/teardown coverage.

## 7. Concurrency: two serving modes, and MAX_SEQS

- **Speculation wins at low concurrency, batch mode wins past ~C10.** Long
  profile C4 on the 4090: 517 tok/s aggregate. Batch mode on the 3090 at
  `GPU_UTIL=0.972` (boots on a headless native box; WSL2 refuses that
  setting): ms per forward pass goes 23.3 to 28.2 across C1 to C16, a 21%
  spread over a 16x batch, with **zero preemptions at every level**. The spec
  profile preempted twice at N=8 on the same box, so the two modes do not
  just differ in speed: they differ in what goes wrong under pressure.
- **MAX_SEQS is part of the profile's design, not a free knob.** On the 3090,
  running the long profile at its designed MAX_SEQS=4 instead of 8 was worth
  +6.1% aggregate at N=4, purely from not over provisioning slots. And on
  huge, MAX_SEQS=2 shows 44.7% KV used at N=2, which looks like headroom;
  but 2 x 245,760 is more than the 268,169 pool, so two full length requests
  can never both fit. MAX_SEQS there is a worst case admission bound,
  deliberately overcommitted for realistic prompt sizes. The kv% gauge
  understates that risk, the concurrency banner overstates capacity
  (section 5), therefore neither gauge is safe to tune MAX_SEQS against:
  size it to the prompt lengths your workload actually sends.
- **The banner is honest at N=1, measured.** A single request on huge climbed
  to 234,158 tokens (95.3% of max_model_len) and completed with exact needle
  recall at every rung. The last 4.7% is untested because the corpus ran out,
  not the engine.
- **Prefill blocks small requests, and one flag fixes it.** A 72.6k prefill
  takes ~65 seconds, and while it runs, small requests starve (about 1 tok/s).
  `--max-num-batched-tokens 512` caps how much prefill each scheduler pass
  takes, therefore decode steps interleave and a 4k request answers in ~5s
  during the big prefill. The cost: the big prefill runs about 15% slower.
- Pin one whale prefix per box and it holds warm across turns.

## 8. Operator notes

- The 8 GB `/dev/shm` offload region **outlives the process** (confirmed on
  both boxes; one teardown kill left it resident). shm is RAM backed, so the
  stranded file holds those gigabytes until removed. Clean stale regions at
  shutdown as well as startup; on a small RAM box the stranded region is the
  next boot's OOM.
- Docker needs `--ipc host` for the offload tier: the 64 MB default shm makes
  the region's `madvise(MADV_POPULATE_WRITE)` fail with EFAULT at boot.
- `single-user/alternative.sh` hardcodes `--speculative-config` and ignores
  `SPEC=off`, so an A/B against it silently runs two spec-on arms. The tell:
  the emitted per step receipt read 2.29 on an arm that must read 1.00 with
  speculation off. An unrecognized `SPEC` should refuse, not proceed.
- `GPU_UTIL=0.972` never fits under WSL2 (compositor and WDDM overhead); it
  is fine on headless native. fp8 MAX_LEN geometry does not transfer to int4.
- `verify.sh` verifies patch application, not runtime behavior; we were bitten
  by the difference twice.

## 9. How we worked

Every arm ran with predictions registered before the result came back, and the
standard for "fixed" was the full bracket: reproduce the failure, apply the
fix, watch it pass, remove the fix, watch it fail again. Six mechanism stories
died on instruments built to kill them, and several of the deaths were our own
published claims, retracted within hours.

Three rules we paid for and now keep:

- **A pass from a branch that never executed is indistinguishable from a
  pass.** Only the execution count tells you which you have (the v1 loader
  story in section 6).
- **A retention measurement is only valid when nothing else can produce a
  fast recheck.** A tier restore, a shared prefix between test rungs, and
  pool residue from a prior rung all read as "retained" through a latency
  threshold. Corollaries: retention numbers are only valid with the offload
  tier off; test rungs must share no prefix; and a boundary rung must
  reproduce alone in a fresh boot before the number is real.
- **Over-determination is the only thing that can kill a model, and
  pre-registration is what makes the kill honest.** Two boundaries fitting
  two one parameter models is an exactly determined fit that cannot lose;
  a second boundary at a different K rejects one model outright, but only
  because both predictions were written down first.

The same discipline killed one of our own contributions before it shipped: a
startup banner patch that printed model derived warm context capacity passed
its internal consistency check, then failed its pre-registered tier-off test
(predicted 2/2, measured 0/2). It is parked on an experiment branch as
mechanism data, unmerged, because a wrong honesty line is worse than none.
Corrections throughout the docs are struck in place rather than cleaned, so
the record keeps its own history readable.
