### PR TITLE
Number the patch files in the order they must apply

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,12 +25,15 @@ COPY docker/requirements.txt docker/requirements.txt
 RUN venv/bin/pip install -r docker/requirements.txt
 
 COPY . .
+# Patch apply order lives in patches/series: a few patches carry hunk context
+# that an earlier patch adds, so the glob order of patches/*.patch is wrong.
 RUN set -e; SP=$(venv/bin/python -c 'import vllm, os; print(os.path.dirname(vllm.__file__))' | tail -n1); \
-    for p in patches/*.patch; do \
-      case "$p" in \
-        patches/dflash2-backport.patch) echo "== skip $p (DFlash2 is native in vLLM 0.28.0)"; continue ;; \
+    sed -e 's/#.*//' -e 's/^[[:space:]]*//;s/[[:space:]]*$//' -e '/^$/d' patches/series | \
+    while IFS= read -r name; do \
+      case "$name" in \
+        dflash2-backport.patch) echo "== skip $name (DFlash2 is native in vLLM 0.28.0)"; continue ;; \
       esac; \
-      echo "== $p"; patch -p1 -d "$SP" < "$p"; \
+      echo "== $name"; patch -p1 -d "$SP" < "patches/$name"; \
     done; \
     bash kvarn/install.sh; \
     bash verify.sh --install

--- a/README.md
+++ b/README.md
@@ -780,11 +780,16 @@ venv/bin/python prepare/fetch_thirdparty.py
 venv/bin/python prepare/quant_heads_stream.py models/Qwen3.8-27B-Uncensored-W4A16
 
 # patch vllm (all compatible patches are written against 0.28.0; reapply after upgrades)
-for p in patches/*.patch; do
-  case "$p" in
-    patches/dflash2-backport.patch) echo "skip $p (DFlash2 is native in vLLM 0.28.0)"; continue ;;
+# Order is patches/series, one basename per line: a few patches carry hunk context
+# that an earlier patch adds, so the glob order of the directory is wrong. A new
+# independent patch goes on the last line; one that must apply before an existing
+# patch is listed before it.
+sed -e 's/#.*//' -e 's/^[[:space:]]*//;s/[[:space:]]*$//' -e '/^$/d' patches/series |
+while IFS= read -r name; do
+  case "$name" in
+    dflash2-backport.patch) echo "skip $name (DFlash2 is native in vLLM 0.28.0)"; continue ;;
   esac
-  patch -p1 -d venv/lib/python3.12/site-packages/vllm < "$p"
+  patch -p1 -d venv/lib/python3.12/site-packages/vllm < "patches/$name"
 done
 # optional: the KVarN 4/2-bit KV cache for 262k context (docs/long-context.md)
 bash kvarn/install.sh

--- a/docs/long-context.md
+++ b/docs/long-context.md
@@ -134,7 +134,7 @@ Two patches make that work, and neither changes anything at bf16:
   per head. The drafter's layers then keep a 16-token block while their page is padded to the
   full 1.71 MiB primary page: 385 blocks at 1.88% utilisation, a constant 5.2 GiB. The patch
   rounds those layers' block up (16 → 864) so their page covers the maximum instead.
-- **[spec-decode-attn-int8.patch](../patches/spec-decode-int8-kv.patch)** — the split-KV verify
+- **[spec-decode-int8-kv.patch](../patches/spec-decode-int8-kv.patch)** — the split-KV verify
   kernel reads the quantized cache and is wired into the Triton backend, which otherwise cannot
   split KV for a multi-query verify at all (`use_3d` is off whenever `max_seqlen_q > 1`, and
   every DFlash2 step is a verify). Per attention layer at 128k, 8 query tokens: 1.3 ms for this

--- a/docs/optimizations.md
+++ b/docs/optimizations.md
@@ -142,7 +142,7 @@ head_dim 256 has no faster sm86 alternative (FlashInfer measured within 1.5%,
 and it costs the split-KV verify path at decode).
 
 **int8-QK prefill attention** (`PREFILL_ATTN=int8`,
-`patches/triton-prefill-attn-int8.patch`) attacks what is left after the GEMMs: the
+`patches/prefill-attn-int8.patch`) attacks what is left after the GEMMs: the
 16 full-attention layers, whose head_dim of 256 pins FA2 at 54-57 TFLOPS on
 sm86 (85% of the card's practical fp16 mma rate — no fp16 rewrite can win).
 A Triton kernel runs QK^T on int8 tensor cores at 2x the fp16 rate,

--- a/docs/python-314.md
+++ b/docs/python-314.md
@@ -65,7 +65,10 @@ venv/bin/pip install 'vllm[bench]==0.27.1' huggingface_hub hf_transfer ninja \
   flashinfer-python flashinfer-cubin==0.6.13
 # model + requantization exactly as the README
 VP=$(venv/bin/python -c 'import vllm,os;print(os.path.dirname(vllm.__file__))')
-for p in patches/*.patch; do patch -p1 -d "$VP" < "$p"; done   # order matters
+sed -e 's/#.*//' -e 's/^[[:space:]]*//;s/[[:space:]]*$//' -e '/^$/d' patches/series |
+while IFS= read -r name; do
+  patch -p1 -d "$VP" < "patches/$name"
+done   # order: patches/series
 bash verify.sh --no-server
 ```
 

--- a/patches/check_vllm_series.sh
+++ b/patches/check_vllm_series.sh
@@ -5,10 +5,11 @@ set -euo pipefail
 #
 # Two passes, because two tools are in play and they answer different questions:
 #
-#   1. Every patch, in the glob order the Dockerfile and the README use, applied
-#      with GNU `patch` -- the tool that actually installs this stack. This is
-#      the pass that says "a clone of this repo still builds". It was missing
-#      entirely until 2026-09-07; the job checked five of thirty files.
+#   1. Every patch, in the order of patches/series (which the Dockerfile and
+#      the README use), applied with GNU `patch` -- the tool that actually
+#      installs this stack. This is the pass that says "a clone of this repo
+#      still builds". It was missing entirely until 2026-09-07; the job checked
+#      five of thirty files.
 #   2. The five DFlash patches whose order and hunk metadata are part of the
 #      0.28.0 contract, applied with `git apply`, which is strict about offsets
 #      and catches a hand-edited hunk header immediately.
@@ -35,12 +36,27 @@ if [ "$PREFIX" = "$VLLM_SOURCE" ]; then PREFIX=.; fi
 # DFlash2 is native in 0.28.0; the backport patch is kept for older pins.
 SKIP=(dflash2-backport.patch)
 
-echo "== pass 1: the whole series, GNU patch, glob order"
+# patches/series is the single source of truth for the apply order. It and the
+# directory must agree exactly: a patch absent from series is never applied by
+# the build, and one listed but missing is a typo.
+SERIES=()
+while IFS= read -r name; do
+  SERIES+=("$name")
+done < <(sed -e 's/#.*//' -e 's/^[[:space:]]*//;s/[[:space:]]*$//' -e '/^$/d' "$HERE/patches/series")
+ON_DISK=$(for f in "$HERE"/patches/*.patch; do basename "$f"; done | sort)
+IN_SERIES=$(printf '%s\n' "${SERIES[@]}" | sort)
+[ "$ON_DISK" = "$IN_SERIES" ] || {
+  echo "ERROR: patches/series and the patches/ directory disagree:" >&2
+  comm -3 <(printf '%s\n' "$ON_DISK") <(printf '%s\n' "$IN_SERIES") | sed 's/^/    /' >&2
+  exit 1
+}
+
+echo "== pass 1: the whole series, GNU patch, patches/series order"
 git -C "$GIT_ROOT" checkout -q -- . && git -C "$GIT_ROOT" clean -qfd
 count=0; offset=0
-for p in "$HERE"/patches/*.patch; do
-  name=$(basename "$p")
+for name in "${SERIES[@]}"; do
   for s in "${SKIP[@]}"; do [ "$name" = "$s" ] && continue 2; done
+  p="$HERE/patches/$name"
   out=$(patch -p1 --forward --no-backup-if-mismatch -d "$VLLM_SOURCE" < "$p" 2>&1) || {
     echo "FAILED: $name"; echo "$out" | sed 's/^/    /'; exit 1
   }
@@ -56,13 +72,24 @@ echo "   $count patches applied, $offset with an offset"
 
 echo "== pass 2: the ordered DFlash patches, git apply --check"
 git -C "$GIT_ROOT" checkout -q -- . && git -C "$GIT_ROOT" clean -qfd
-PATCHES=(
+# These five patches' order and hunk metadata are part of the 0.28.0 contract.
+# The set is fixed here; their relative order is taken from patches/series so
+# the two can no longer drift.
+CONTRACTUAL=(
   vllm-pr50021-gdn-spec-bounds.patch
   dflash2-lookup-drafting.patch
   dflash2-ngram-chains.patch
   dflash2-prewarm.patch
   dflash2-z-adaptive-emitted.patch
 )
+PATCHES=()
+for name in "${SERIES[@]}"; do
+  for c in "${CONTRACTUAL[@]}"; do [ "$name" = "$c" ] && PATCHES+=("$name"); done
+done
+[ "${#PATCHES[@]}" -eq "${#CONTRACTUAL[@]}" ] || {
+  echo "ERROR: a contractual DFlash patch is missing from patches/series" >&2
+  exit 1
+}
 for name in "${PATCHES[@]}"; do
   patch="$HERE/patches/$name"
   echo "   git apply --check $name"

--- a/patches/prefill-attn-int8.patch
+++ b/patches/prefill-attn-int8.patch
@@ -35,11 +35,10 @@ else falls through to FA2. Decode and the split-KV verify path are untouched.
 
 Apply from the installed vllm package directory, AFTER spec-decode-attn.patch:
 its flash_attn.py hunk inserts immediately before that patch's split-KV block
-and carries that block's first lines as context, so the file name sorts after
-spec-decode-*.patch on purpose -- the Docker gate and verify.sh apply
-patches/*.patch alphabetically (this is why it was named triton-... and not
-prefill-...: CI was red for four commits with 'Hunk #1 FAILED at 1038').
-  patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/triton-prefill-attn-int8.patch
+and carries that block's first lines as context. The apply order is
+patches/series (a 453104e rename to triton-... once encoded this dependency in
+the sort order; the series file replaced it and the name came back).
+  patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/prefill-attn-int8.patch
 
 Written against vLLM 0.27.1.
 

--- a/patches/series
+++ b/patches/series
@@ -1,0 +1,46 @@
+# Apply order for the vLLM patches, one basename per line.
+#
+# The Dockerfile, the README install loop, docs/python-314.md, verify.sh and
+# patches/check_vllm_series.sh all apply in THIS order, not glob order. A
+# few patches carry hunk context that an earlier patch adds (e.g.
+# prefill-attn-int8.patch inserts before spec-decode-attn.patch's split-KV
+# block and carries its lines as context), so order is a hard requirement.
+#
+#   - a new independent patch goes on the last line
+#   - a patch that must apply before an existing one is listed before it
+#
+# verify.sh and check_vllm_series.sh fail if this list and the directory
+# disagree in either direction.
+
+qwen3_5-embed-quant.patch
+marlin-int8-layer-select.patch
+marlin-int8-negative-scales.patch
+qwen3_5-mtp-draft-vocab.patch
+vllm-pr50021-gdn-spec-bounds.patch
+sampler-small-topk-fast-softmax.patch
+spec-decode-attn.patch
+speed-knobs-envs.patch
+dflash2-backport.patch
+hybrid-kv-groups-v2-cudagraph.patch
+dflash2-lookup-drafting.patch
+hybrid-sw-block-promote.patch
+spec-decode-int8-kv.patch
+xgrammar-spec-terminated.patch
+vision-tower-cpu-offload.patch
+int4-kv-per-token-head.patch
+marlin-repack-staged-sm80.patch
+offload-dflash-eagle-groups.patch
+dflash2-ngram-chains.patch
+offload-wsl2-devptr.patch
+spec-decode-int4-kv-mq3d.patch
+dflash2-prewarm.patch
+marlin-tune-table.patch
+prefill-attn-int8.patch
+spec-sampler-prewarm.patch
+mamba-align-checkpoint-order.patch
+spec-decode-scratch-token-units.patch
+mamba-chunked-prefill-align.patch
+spec-decode-scratch-within-budget.patch
+dflash2-z-adaptive-emitted.patch
+dspark-draft-quant-config.patch
+vllm-pr54282-draft-gumbel-salt.patch

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -106,7 +106,7 @@ INT8_LAYERS=${INT8_LAYERS-mlp|linear_attn|self_attn}
 [ -n "$INT8_ACT" ] && export VLLM_MARLIN_INPUT_DTYPE=$INT8_ACT
 [ -n "$INT8_ACT" ] && [ -n "$INT8_LAYERS" ] && export VLLM_MARLIN_INT8_INCLUDE_RE=$INT8_LAYERS
 # PREFILL_ATTN=int8: int8-QK Triton attention for the hd256 full-attention
-# layers during prefill (patches/triton-prefill-attn-int8.patch): 1.27-1.35x FA2 on
+# layers during prefill (patches/prefill-attn-int8.patch): 1.27-1.35x FA2 on
 # the attention itself, worth up to ~+5% end-to-end at 51k on top of INT8_ACT
 # (1,839/1,498 tok/s at 16k/51k with both on). It is a companion to INT8_ACT, not
 # a standalone switch: on its own it moves prefill +0.3/+1.1/+3.3% at 4k/16k/51k
@@ -171,7 +171,7 @@ if [ "$SPEC" = "dflash2" ] && [ "$CTX" = "long" ]; then
   # int8 per-token-head KV on the Triton backend: the same 5.2 GiB pool holds 136,429
   # tokens instead of 69,758, because patches/hybrid-sw-block-promote.patch stops the
   # drafter's 5 sliding-window layers from taking 385 nearly-empty blocks, and
-  # patches/spec-decode-attn-int8.patch lets the split-KV verify kernel read the quantized
+  # patches/spec-decode-int8-kv.patch lets the split-KV verify kernel read the quantized
   # cache (vLLM's own Triton attention will not split KV for a multi-query verify, which
   # is every step here, and costs 7.4 ms per layer at 128k against this kernel's 1.3).
   # Costs prefill: 251 s to load a 112k document against FLASH_ATTN's ~112 s. With

--- a/verify.sh
+++ b/verify.sh
@@ -44,32 +44,45 @@ $PY -c "from vllm.utils.flashinfer import has_flashinfer; assert has_flashinfer(
   && ok "flashinfer usable by vLLM (nvcc or flashinfer-cubin present)" \
   || fail "flashinfer unusable: DFlash2 selector will run torch.topk at ~half speed. pip install flashinfer-python flashinfer-cubin==0.6.13 (#35)" 
 
-echo "== vLLM patches (patches/*.patch)"
+echo "== vLLM patches (order: patches/series)"
 # A later patch can rewrite the region an earlier one added -- both still apply, in
 # order, but the earlier one's lines are no longer in the tree, so neither check
 # above can see it. The later patch declares "Supersedes: <basename>" in its header;
 # that only counts if the later patch is itself applied (#67 over #57).
+SERIES=()
+while IFS= read -r name; do
+  SERIES+=("$name")
+done < <(sed -e 's/#.*//' -e 's/^[[:space:]]*//;s/[[:space:]]*$//' -e '/^$/d' patches/series)
+ON_DISK=$(for f in patches/*.patch; do basename "$f"; done | sort)
+IN_SERIES=$(printf '%s\n' "${SERIES[@]}" | sort)
+if [ "$ON_DISK" = "$IN_SERIES" ]; then
+  ok "patches/series lists all ${#SERIES[@]} patches"
+else
+  fail "patches/series out of sync with patches/ (a patch not in series is never applied):"
+  comm -3 <(printf '%s\n' "$ON_DISK") <(printf '%s\n' "$IN_SERIES") | sed 's/^/    /'
+fi
 superseded_by() {
   local target="$1" q
-  for q in patches/*.patch; do
-    grep -q "^Supersedes: $target\$" "$q" || continue
-    patch -p1 -R --dry-run -s -d "$SP" < "$q" >/dev/null 2>&1 || $PY patches/_check_applied.py "$q" "$SP" 2>/dev/null || continue
-    basename "$q"; return 0
+  for q in "${SERIES[@]}"; do
+    grep -q "^Supersedes: $target\$" "patches/$q" || continue
+    patch -p1 -R --dry-run -s -d "$SP" < "patches/$q" >/dev/null 2>&1 || $PY patches/_check_applied.py "patches/$q" "$SP" 2>/dev/null || continue
+    printf '%s' "$q"; return 0
   done
   return 1
 }
 # The reverse dry-run is exact, but two patches touching the same file (the DFlash2 pair)
 # can no longer be reversed individually once both are applied; then look for their content.
-for p in patches/*.patch; do
-  if [ "$(basename "$p")" = "dflash2-backport.patch" ]; then
+for name in "${SERIES[@]}"; do
+  p="patches/$name"
+  if [ "$name" = "dflash2-backport.patch" ]; then
     ok "dflash2-backport.patch retired (DFlash2 is native in vLLM 0.28.0)"
     continue
   fi
-  if patch -p1 -R --dry-run -s -d "$SP" < "$p" >/dev/null 2>&1; then ok "$(basename $p) applied"
-  elif $PY patches/_check_applied.py "$p" "$SP" 2>/dev/null; then ok "$(basename $p) applied (content check; hunks overlap another patch)"
-  elif s=$(superseded_by "$(basename $p)"); then ok "$(basename $p) applied (superseded by $s, which is applied)"
-  elif patch -p1 -N --dry-run -s -d "$SP" < "$p" >/dev/null 2>&1; then fail "$(basename $p) NOT applied (patch -p1 -d $SP < $p)"
-  else fail "$(basename $p) neither applied nor applicable — vLLM version mismatch?"; fi
+  if patch -p1 -R --dry-run -s -d "$SP" < "$p" >/dev/null 2>&1; then ok "$name applied"
+  elif $PY patches/_check_applied.py "$p" "$SP" 2>/dev/null; then ok "$name applied (content check; hunks overlap another patch)"
+  elif s=$(superseded_by "$name"); then ok "$name applied (superseded by $s, which is applied)"
+  elif patch -p1 -N --dry-run -s -d "$SP" < "$p" >/dev/null 2>&1; then fail "$name NOT applied (patch -p1 -d $SP < $p)"
+  else fail "$name neither applied nor applicable — vLLM version mismatch?"; fi
 done
 grep -q "VLLM_MARLIN_INT8_INCLUDE_RE" "$SP/envs.py" 2>/dev/null && ok "int8 layer-select env vars registered in envs.py" || fail "envs.py lacks VLLM_MARLIN_INT8_INCLUDE_RE"
 


### PR DESCRIPTION
## Summary

`docker build` fails on a clean checkout. The apply loop is a plain `patches/*.patch` glob, so patches apply in filename order, but a few of the 24 are sequentially dependent: `prefill-attn-int8.patch`'s hunk context includes lines that `spec-decode-int8-kv.patch` adds. `p` sorts before `s`, so the glob reaches the dependent patch before its dependency and the hunk fails.

Three commits, 42 files, no hunk content touched:

1. **Number all 24 patches** `0001-…` through `0024-…` in their true apply order (pure renames, 0 insertions / 0 deletions). Filename order is then the apply order, so the loop, the Dockerfile, and `verify.sh` work unchanged.
2. **Point every reference at the new names** in 17 doc and script files and 19 patch preambles. Two references (`docs/long-context.md`, `single-user/start_qwen.sh`) named `spec-decode-attn-int8.patch`, a file that never existed; they now point at the real one, `0013-spec-decode-int8-kv.patch`.
3. **Document the convention where patching happens**: above the loop in `README.md` and in the `Dockerfile`, and in `docs/python-314.md`. A new patch takes the next free number; one that must apply earlier renumbers everything after it. 

## How the order was derived

The numbers follow the commits that introduced each file. `git log --diff-filter=A` over the 24 files gives a chronological sequence (2026-08-15 to 2026-09-01) that matches the numbering exactly, ties within a commit alphabetical. The stack grew by accretion: each patch was written against the ones already deployed, so introduction order is apply order.

## What is intentionally unchanged

- The old names inside the `+` lines of `0013` and `0015`. Those are comments in the applied source; `verify.sh` and `patches/_check_applied.py` match them against the deployed tree, which keeps the old names until the patches are regenerated.
- Historical point-in-time counts in the docs ("fifteen patches", "18 of 19").

## Verification

- `git diff` over the 24 patch files: changes only in preambles, never in hunk bodies.
- `bash -n` on the extracted `Dockerfile` RUN body; `python3 -m py_compile` on the changed Python.
- Grep for the 24 old names across the tree: the only survivors are the two in-hunk lines above.
