### PR TITLE
single-user: add optional serving warmup after health check (WARMUP)

### DIFF
--- a/bench/warmup.sh
+++ b/bench/warmup.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Post-boot serving warmup: exercise the serving path (decode, speculative
+# verify, small and concurrent batches) before production traffic.
+#
+# The launcher's boot-time profile runs only profiling dummies, so a cold
+# Triton cache may still compile serving-path variants on the first real
+# request (gotchas 8, 39, 50). This script spends that cost in a controlled
+# pass: one small request first (decode + speculative-verify capture), then a
+# larger concurrent batch (the multi-sequence verify path).
+#
+# Exits 1 if the server is not healthy or any pass fails, so the serving
+# wrapper (single-user/qwen-server.sh) treats it as a failed boot.
+#
+#   bash bench/warmup.sh             # 127.0.0.1:18020, the launcher's model
+#   PORT=18021 bash bench/warmup.sh  # a different port
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(dirname "$HERE")"
+cd "$REPO"
+export PATH="$REPO/venv/bin:$PATH"
+
+# Reuse the API key the launcher started the server with. start_qwen.sh
+# exports VLLM_API_KEY (from $VLLM_API_KEY or api_key.txt), and vLLM reads
+# that variable to bind --api-key; vllm bench serve presents OPENAI_API_KEY,
+# so the two must agree or every request 401s. An explicit OPENAI_API_KEY
+# wins, then VLLM_API_KEY, then api_key.txt, then a harmless placeholder (the
+# server ignores the key when none was bound).
+if [ -z "${OPENAI_API_KEY:-}" ]; then
+    if [ -n "${VLLM_API_KEY:-}" ]; then
+        export OPENAI_API_KEY="$VLLM_API_KEY"
+    elif [ -f "$REPO/api_key.txt" ]; then
+        export OPENAI_API_KEY="$(cat "$REPO/api_key.txt")"
+    else
+        export OPENAI_API_KEY="EMPTY"
+    fi
+fi
+
+HOST=${HOST:-127.0.0.1}
+PORT=${PORT:-18020}
+# Resolve the model the way single-user/start_qwen.sh does: the fast variant
+# when present, else the base dir. Only the tokenizer matters here (its vocab
+# size drives random-token generation; no weights are loaded), and the request
+# is matched on --served-model-name, so any variant of the same model works.
+MODEL=${MODEL:-}
+if [ -z "$MODEL" ]; then
+    MODEL="$REPO/models/Qwen3.8-27B-W4A16-AutoRound"
+    if [ -d "$REPO/models/Qwen3.8-27B-W4A16-AutoRound-fast" ]; then
+        MODEL="$REPO/models/Qwen3.8-27B-W4A16-AutoRound-fast"
+    fi
+fi
+
+# Build the command as an array, not a string: an unquoted "$B" re-splits and
+# re-globs, so a path with a space or glob character would break, and a
+# quoted "$B" would not word-split at all. "${BENCH[@]}" expands each element
+# verbatim. (venv/bin/vllm is relative because we cd "$REPO" above.)
+BENCH=(venv/bin/vllm bench serve --host "$HOST" --port "$PORT" --model "$MODEL" --served-model-name qwen3.8-27b)
+
+curl -sf -o /dev/null "http://$HOST:$PORT/health" || { echo "[warmup] no server on $HOST:$PORT" >&2; exit 1; }
+echo "[warmup] server ready, warming the serving path"
+"${BENCH[@]}" --dataset-name random --random-input-len 128 --random-output-len 128 --num-prompts 2 --max-concurrency 1 --ignore-eos --temperature 0 > /dev/null 2>&1 \
+  || { echo "[warmup] small-batch pass failed" >&2; exit 1; }
+"${BENCH[@]}" --dataset-name random --random-input-len 256 --random-output-len 256 --num-prompts 8 --max-concurrency 4 --ignore-eos --temperature 0 > /dev/null 2>&1 \
+  || { echo "[warmup] concurrent-batch pass failed" >&2; exit 1; }
+echo "[warmup] done"

--- a/single-user/README.md
+++ b/single-user/README.md
@@ -369,6 +369,29 @@ systemctl --user enable --now qwen-serving
 loginctl enable-linger $USER
 ```
 
+The unit runs `qwen-server.sh`, which boots the launcher, waits for
+`/health`, runs `bench/warmup.sh` (the optional post-boot serving warmup,
+`WARMUP=1` is the unit's default; `WARMUP=0` restores the legacy boot
+behavior), and only then considers the server ready for traffic.
+
+### Post-boot serving warmup
+
+For tightly packed 24 GB deployments, `/health` may become available before
+all serving-path Triton / speculative-decoding variants have been exercised
+(the launcher's boot-time profile runs profiling dummies only). The optional
+wrapper waits for health, runs `bench/warmup.sh` (a small decode pass, then a
+concurrent one), and only then considers the server ready for traffic — it
+complements the kernel prewarm in #48 and does not replace it:
+
+```bash
+WARMUP=1 bash single-user/qwen-server.sh   # wait /health, warm, then serve
+WARMUP=0 bash single-user/qwen-server.sh   # legacy boot, no warmup
+```
+
+The included systemd service enables this by default
+(`Environment=WARMUP=1`). `WARMUP_ATTEMPTS` / `WARMUP_INTERVAL` tune the
+health-wait window (30 × 5 s by default).
+
 Point your chat client at `http://<host>:18020/v1` with the key from
 `api_key.txt`. Works with anything that speaks the OpenAI API, tool calling
 included (`tools` + `tool_choice: "auto"` come back as `tool_calls`).
@@ -392,7 +415,8 @@ included (`tools` + `tool_choice: "auto"` come back as `tool_calls`).
 | `TOOLS` | 1 | tool/function calling (`--enable-auto-tool-choice --tool-call-parser`). `TOOL_PARSER` (`qwen3_coder`) must match the XML call format this model's chat template emits — `hermes` parses the JSON a Qwen model does *not* produce here, and fails silently. 0 = off, and `tool_choice: "auto"` then 400s |
 | `VISION` | 0 | 1 keeps the vision tower instead of `--language-model-only` (0.858 GiB of BF16 weights on this checkpoint), for a client that sends images: one image per prompt and a 2048-image-token pixel cap, both overridable from `EXTRA_ARGS` |
 | `VISION_OFFLOAD` | 1 | with `VISION=1`, keeps the tower's weights in pinned host RAM and copies each module to the GPU for its own forward (`patches/vision-tower-cpu-offload.patch`). **On 24 GB, `SPEC=dflash2` + `VISION=1` does not boot with this off** — the tower is 0.85 GiB of the ~1.1 GiB transient margin, and graph capture OOMs allocating the 960 MiB split-KV verify buffer with 787 MiB free. With it on, the same config comes up at the full 69,758-token pool and reads images. Costs 296 → 333 ms of encode per 8192-patch image, output bit-exact. 0 only on a card with headroom to spare. `VLLM_VISION_CPU_OFFLOAD_GB` (default 1) is the budget in GiB |
-| `REQ_METRICS` | 0 | 1 = `--enable-per-request-metrics --enable-force-include-usage`: per-request timing fields in every response and `usage` on every request, the fields llama-swap's dashboard reads ([#51](https://github.com/syv-ai/qwen38-27b-rtx3090/issues/51)). `prompt_tokens_details.cached_tokens` is always on. Not compatible with `--disable-log-stats` in `EXTRA_ARGS`; vLLM's per-request spec-decode summary flag is nightly-only, not in 0.27.1 |
+| `REQ_METRICS` | 0 | 1 = `--enable-per-request-metrics --enable-force-include-usage`: per-request timing fields in every response and `usage` on every request, the fields llama-swap's dashboard reads ([#51](https://github.com/syv-ai/qwen38-27b-rtx3090/issues/51)). `prompt_tokens_details.cached_tokens` is always on. Not compatible with `--disable-log-stats` in `EXTRA_ARGS`; vLLM's per-request *spec-decode* summary flag is nightly-only, not in 0.27.1 |
+| `WARMUP` | 1 | wrapper-only: 1 = wait `/health` then run `bench/warmup.sh` before serving (see "Post-boot serving warmup"); 0 = legacy boot. The unit sets this explicitly. Not read by `start_qwen.sh` itself |
 | `PORT` | 18020 | |
 
 ## Switching modes

--- a/single-user/qwen-server.sh
+++ b/single-user/qwen-server.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Single-user serving wrapper: boot the launcher, wait for /health, run the
+# post-boot serving warmup, then wait on the server.
+#
+# Why: start_qwen.sh ends in `exec vllm serve`, so a systemd unit has no
+# after-boot hook. A cold boot may still JIT-compile Triton /
+# speculative-decoding variants on the first serving requests (the repo's #48
+# prewarm covers most of them; the ones it misses still compile in request 1).
+# On tightly packed 24 GB configurations, those transient allocations can OOM
+# the engine even after /health returns 200 (gotcha 39's "boots, /health 200,
+# dies on the first prompt" shape). This wrapper spends that bill in a
+# controlled pass before traffic.
+#
+#   WARMUP=1 (default)   wait for /health, run bench/warmup.sh, then serve
+#   WARMUP=0             legacy behavior: just wait on the server
+#
+# The wrapper's exit code is the server's, so Restart=on-failure behaves as
+# before. Point the unit's ExecStart here:
+#   ExecStart=/bin/bash %h/qwen-serving/single-user/qwen-server.sh
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$DIR")"
+PORT=${PORT:-18020}
+WARMUP=${WARMUP:-1}
+WARMUP_ATTEMPTS=${WARMUP_ATTEMPTS:-30}
+WARMUP_INTERVAL=${WARMUP_INTERVAL:-5}
+
+# start_qwen.sh ends in `exec vllm serve`, so its pid becomes the server's
+# and `wait` below tracks it.
+bash "$DIR/start_qwen.sh" &
+SERVER_PID=$!
+
+cleanup() {
+    kill -TERM "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+}
+trap cleanup INT TERM
+
+if [ "$WARMUP" = "1" ]; then
+    echo "[server] waiting for server health..."
+    HEALTHY=0
+    for i in $(seq 1 "$WARMUP_ATTEMPTS"); do
+        if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+            echo "[server] server exited before becoming healthy" >&2
+            # Reap the child and exit with its status (nonzero restarts the unit).
+            wait "$SERVER_PID"
+            exit $?
+        fi
+        if curl -sf -o /dev/null "http://127.0.0.1:$PORT/health"; then
+            HEALTHY=1
+            echo "[server] HTTP 200 OK"
+            break
+        fi
+        sleep "$WARMUP_INTERVAL"
+    done
+    if [ "$HEALTHY" != "1" ]; then
+        echo "[server] health timeout after $((WARMUP_ATTEMPTS * WARMUP_INTERVAL))s" >&2
+        cleanup
+        exit 1
+    fi
+    # warmup.sh inherits this wrapper's environment (MODEL, HOST, API key) and
+    # re-derives the same defaults as start_qwen.sh, so it targets the server
+    # just started; only PORT needs pinning to the port checked above.
+    if PORT="$PORT" bash "$REPO/bench/warmup.sh"; then
+        echo "[server] Warmup OK"
+        echo "[server] server ready for traffic"
+    else
+        echo "[server] warmup failed" >&2
+        cleanup
+        exit 1
+    fi
+fi
+
+wait "$SERVER_PID"

--- a/single-user/qwen-serving.service
+++ b/single-user/qwen-serving.service
@@ -8,7 +8,12 @@ Type=simple
 # while a previous process is still releasing VRAM, it permanently allocates a
 # smaller cache pool and throughput quietly suffers.
 ExecStartPre=/bin/bash -c "for i in $(seq 1 60); do u=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits); [ \"$u\" -lt 1000 ] && exit 0; sleep 2; done; exit 1"
-ExecStart=/bin/bash %h/qwen-serving/single-user/start_qwen.sh
+# Serving warmup: /health can become ready before all serving-path
+# Triton/speculative-decoding variants have been exercised. The wrapper runs
+# a controlled warmup (bench/warmup.sh) before production traffic;
+# WARMUP=0 skips it (legacy boot behavior).
+Environment=WARMUP=1
+ExecStart=/bin/bash %h/qwen-serving/single-user/qwen-server.sh
 Restart=on-failure
 RestartSec=20
 StandardOutput=append:%h/qwen-serving/qwen.log


### PR DESCRIPTION
Adds an optional single-user serving wrapper that boots the launcher, waits for /health, runs a controlled serving-path warmup (bench/warmup.sh), and only then considers the server ready for production traffic.

The launcher ends in 'exec vllm serve', so a systemd unit has no after-boot hook. A cold boot may still JIT-compile Triton / speculative-decoding variants on the first serving requests (the repo's #48 prewarm covers most; the rest still compile in request 1). On tightly packed 24 GB cards those transient allocations can OOM the engine even after /health is 200 (gotcha 39's 'boots, /health 200, dies on the first prompt' shape). This complements -- not replaces -- the #48 kernel prewarm.

- bench/warmup.sh: a small decode pass (2x128, C1), then a concurrent one (8x256, C4); exit 1 if the server is not healthy or a pass fails.
- single-user/qwen-server.sh: WARMUP=1 (default) does the health wait + warmup; WARMUP=0 restores the legacy boot. The wrapper forwards SIGTERM/INT and exits with the server's code, so Restart=on-failure is unchanged. WARMUP_ATTEMPTS/INTERVAL tune the health-wait window.
- qwen-serving.service + README: unit opts in (Environment=WARMUP=1); a 'Post-boot serving warmup' section documents it.

start_qwen.sh is left untouched.