### PR TITLE
fix(single-user): alternative.sh exits silently under set -e when REQ_METRICS is unset

### DIFF
--- a/single-user/alternative.sh
+++ b/single-user/alternative.sh
@@ -68,7 +68,7 @@ ASYNC_ARGS=$([ "$ASYNC_SCHED" = 1 ] && echo --async-scheduling || echo --no-asyn
 
 # REQ_METRICS=1: per-request timing fields + usage on every response (issue #51).
 # Not with --disable-log-stats (the timing fields need the engine-stats path).
-METRICS_ARGS=$([ "${REQ_METRICS:-0}" = 1 ] && echo --enable-per-request-metrics --enable-force-include-usage)
+METRICS_ARGS=$([ "${REQ_METRICS:-0}" = 1 ] && echo --enable-per-request-metrics --enable-force-include-usage || true)
 
 exec vllm serve "$MODEL" \
   --served-model-name qwen3.8-27b \


### PR DESCRIPTION
`bash single-user/alternative.sh` (the documented 256k int4-KV path) exits
silently on a clean checkout — no output, exit 1 — so the server never starts.

Root cause: the script runs with `set -e`, and

    METRICS_ARGS=$([ "${REQ_METRICS:-0}" = 1 ] && echo --enable-per-request-metrics --enable-force-include-usage)

returns 1 when `REQ_METRICS` is unset (the `[ ... ]` test fails and the `&&`
short-circuits), so the command substitution fails and `set -e` terminates the
script right before `exec vllm serve`.

The neighbouring `ASYNC_ARGS` line already uses the safe `|| echo ...` fallback;
this change adds `|| true` to `METRICS_ARGS` for the same behaviour
(empty by default, set when `REQ_METRICS=1`).

Repro before fix:

    bash -x single-user/alternative.sh   # stops right after `+ METRICS_ARGS=`
