### PR TITLE
launchers: ASYNC_ARGS and TOOL_ARGS as arrays (finishes the #59 conversion)

### DIFF
--- a/batch/start_qwen.sh
+++ b/batch/start_qwen.sh
@@ -105,7 +105,10 @@ fi
 # 0.27.1, which is the tool-side adapter of the same parser engine that
 # --reasoning-parser qwen3 already uses (vllm/parser/qwen3.py).
 TOOL_PARSER=${TOOL_PARSER:-qwen3_coder}
-TOOL_ARGS=$([ "${TOOLS:-1}" = 1 ] && echo --enable-auto-tool-choice --tool-call-parser $TOOL_PARSER)
+# Array, not $( [ ] && echo ): exits 1 when TOOLS is off (the shape #59 fixed)
+# and word-splits $TOOL_PARSER; the array keeps the parser as one element.
+TOOL_ARGS=()
+[ "${TOOLS:-1}" = 1 ] && TOOL_ARGS=(--enable-auto-tool-choice --tool-call-parser "$TOOL_PARSER")
 
 # REQ_METRICS=1: per-request timing fields + usage on every response (issue #51).
 # Not with --disable-log-stats (the timing fields need the engine-stats path).
@@ -192,5 +195,5 @@ exec venv/bin/vllm serve "$MODEL" \
   --reasoning-parser qwen3 \
   --enable-prompt-tokens-details \
   "${METRICS_ARGS[@]}" \
-  ${TOOL_ARGS} \
+  "${TOOL_ARGS[@]}" \
   ${EXTRA_ARGS}

--- a/single-user/alternative.sh
+++ b/single-user/alternative.sh
@@ -64,7 +64,10 @@ VISION_ARGS="--language-model-only"
 PREFIX_ARGS=""
 [ "$PREFIX_CACHE" = 1 ] && PREFIX_ARGS="--enable-prefix-caching --mamba-cache-mode align"
 
-ASYNC_ARGS=$([ "$ASYNC_SCHED" = 1 ] && echo --async-scheduling || echo --no-async-scheduling)
+# Array, not $( ... || echo ... ): the fallback makes it errexit-safe, but an
+# unquoted expansion still word-splits; match SPEC_ARGS/METRICS_ARGS.
+ASYNC_ARGS=(--no-async-scheduling)
+[ "$ASYNC_SCHED" = 1 ] && ASYNC_ARGS=(--async-scheduling)
 
 # REQ_METRICS=1: per-request timing fields + usage on every response (issue #51).
 # Not with --disable-log-stats (the timing fields need the engine-stats path).
@@ -83,7 +86,7 @@ exec vllm serve "$MODEL" \
   ${VISION_ARGS} \
   ${ATTN_ARGS} \
   --mamba-ssm-cache-dtype float16 \
-  ${ASYNC_ARGS} \
+  "${ASYNC_ARGS[@]}" \
   --max-num-batched-tokens 2048 \
   "${SPEC_ARGS[@]}" \
   --compilation-config "{\"max_cudagraph_capture_size\":$CG,\"custom_ops\":[\"+rms_norm\",\"+silu_and_mul\"]}" \

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -518,7 +518,10 @@ fi
 # synchronously, which is the only path on which vLLM lets the worker choose how many draft
 # tokens to put up for verification. Note --async-scheduling is already the default in
 # 0.27.1: --no-async-scheduling is what turns it off.
-ASYNC_ARGS=$([ "${ASYNC_SCHED:-1}" = 1 ] && echo --async-scheduling || echo --no-async-scheduling)
+# Array, not $( ... || echo ... ): errexit-safe via the fallback, but the
+# unquoted expansion word-splits; match METRICS_ARGS below.
+ASYNC_ARGS=(--no-async-scheduling)
+[ "${ASYNC_SCHED:-1}" = 1 ] && ASYNC_ARGS=(--async-scheduling)
 
 # Tool / function calling. Without BOTH flags vLLM rejects any request carrying
 # `tools` with tool_choice "auto": 400 '"auto" tool choice requires
@@ -536,7 +539,10 @@ ASYNC_ARGS=$([ "${ASYNC_SCHED:-1}" = 1 ] && echo --async-scheduling || echo --no
 # 0.27.1, which is the tool-side adapter of the same parser engine that
 # --reasoning-parser qwen3 already uses (vllm/parser/qwen3.py).
 TOOL_PARSER=${TOOL_PARSER:-qwen3_coder}
-TOOL_ARGS=$([ "${TOOLS:-1}" = 1 ] && echo --enable-auto-tool-choice --tool-call-parser $TOOL_PARSER)
+# Array, not $( [ ] && echo ): exits 1 when TOOLS is off (the shape #59 fixed)
+# and word-splits $TOOL_PARSER; the array keeps the parser as one element.
+TOOL_ARGS=()
+[ "${TOOLS:-1}" = 1 ] && TOOL_ARGS=(--enable-auto-tool-choice --tool-call-parser "$TOOL_PARSER")
 
 # REQ_METRICS=1: per-request timing fields in every response plus usage on
 # every request (--enable-per-request-metrics --enable-force-include-usage,
@@ -647,12 +653,12 @@ exec venv/bin/vllm serve "$MODEL" \
   ${VISION_ARGS} \
   $ATTN_ARGS \
   --mamba-ssm-cache-dtype float16 \
-  ${ASYNC_ARGS} \
+  "${ASYNC_ARGS[@]}" \
   --max-num-batched-tokens 2048 \
   "${SPEC_ARGS[@]}" \
   --compilation-config "{\"max_cudagraph_capture_size\":$CG,\"custom_ops\":[\"+rms_norm\",\"+silu_and_mul\"]${CG_MODE}}" \
   --reasoning-parser qwen3 \
   --enable-prompt-tokens-details \
   "${METRICS_ARGS[@]}" \
-  ${TOOL_ARGS} \
+  "${TOOL_ARGS[@]}" \
   ${EXTRA_ARGS}


### PR DESCRIPTION
Continues the array conversion #59 started for `METRICS_ARGS`. Two command-substitution arg lists remained in the launchers:

- **ASYNC_ARGS** (`single-user/alternative.sh`, `single-user/start_qwen.sh`) was `$( [ ... ] && echo ... || echo ... )`. The `|| echo` fallback always exits 0, so it is errexit-safe and never killed a script — but the unquoted `${ASYNC_ARGS}` expansion is word-split, the same latent shape #59 removed from `METRICS_ARGS`.

- **TOOL_ARGS** (`single-user/start_qwen.sh`, `batch/start_qwen.sh`) was `$( [ ... ] && echo ... )` with no fallback — the exact shape #59 fixed. The substitution exits 1 whenever `TOOLS=0`, so it would kill a launcher under `set -e` today; it only survives because neither of those two scripts uses `set -e`. It also word-split `$TOOL_PARSER`.

Both are now arrays guarded by a top-level AND-OR list (errexit-exempt, the pattern #59 introduced) and expanded quoted with `"${...[@]}"`, matching `SPEC_ARGS` and `METRICS_ARGS`. `$TOOL_PARSER` is now a single quoted array element, so a parser name containing whitespace no longer splits.

## Verified

- `bash -n` on all three launchers.
- Under `set -e`: `ASYNC_SCHED` ∈ {unset, 0, 1} and `TOOLS` ∈ {unset, 0, 1} each expand to the expected argument list (no silent exit).
- An empty `TOOL_ARGS` expands to zero arguments (not one empty string), so the `exec vllm serve` line is unchanged when tools are off.
