### PR TITLE
int4 3D scratch: allocate inside the memory budget (#57 follow-up)

### DIFF
--- a/bench/mq3d_scratch_pool_test.py
+++ b/bench/mq3d_scratch_pool_test.py
@@ -1,0 +1,45 @@
+"""The int4 3D scratch pool (spec-decode-scratch-within-budget.patch), on CPU tensors: a model-load
+allocation is adopted by builders, builders of one geometry share it, a smaller derived capacity
+adopts the larger pool, a larger one allocates and replaces, an exclusive (ubatching) builder never
+shares, and a different geometry is a different key. Ends with a negative control: with the
+exclusive flag off, the second builder DOES share, which is the case the guard exists to prevent.
+
+Runs inside the image, no GPU:  /app/venv/bin/python bench/mq3d_scratch_pool_test.py
+Exit 0 = every assertion held (assert raises otherwise)."""
+import logging, sys
+import torch
+import vllm
+import vllm.v1.attention.backends.triton_attn as m
+logging.getLogger("vllm").setLevel(logging.ERROR)
+P = m.Mq3dScratchPlan
+def plan(cap, heads=4, hd=64):
+    row = 4 * (heads * m.NUM_PAR_SOFTMAX_SEGMENTS * hd + 2 * heads * m.NUM_PAR_SOFTMAX_SEGMENTS)
+    return P(num_heads_q=heads, num_heads_kv=2, headdim_padded=hd, seq_threshold_3D=32,
+             max_query_len_3d=16, capacity=cap, row_bytes=row, max_num_batched_tokens=2048, max_num_seqs=4)
+dev = torch.device("cpu")
+pool = m._MQ3D_SCRATCH_POOL; pool.clear()
+a = m.mq3d_scratch_acquire(plan(64), dev, "model load")
+assert a.origin == "model load" and a.adopters == 0 and len(pool) == 1, "load allocates, pooled"
+b = m.mq3d_scratch_acquire(plan(64), dev, "metadata builder")
+c = m.mq3d_scratch_acquire(plan(64), dev, "metadata builder")
+assert b is a and c is a and a.adopters == 2, "two builders share the load-time set"
+d = m.mq3d_scratch_acquire(plan(32), dev, "metadata builder")
+assert d is a and d.capacity == 64, "smaller derived adopts the larger pool"
+e = m.mq3d_scratch_acquire(plan(128), dev, "metadata builder")
+assert e is not a and e.capacity == 128 and pool[next(iter(pool))] is e and e.adopters == 1, "larger derived allocates and replaces"
+pool.clear()
+x = m.mq3d_scratch_acquire(plan(64), dev, "model load")
+y = m.mq3d_scratch_acquire(plan(64), dev, "metadata builder", exclusive=True)
+z = m.mq3d_scratch_acquire(plan(64), dev, "metadata builder", exclusive=True)
+assert y is x and z is not x and z.capacity == 64 and pool[next(iter(pool))] is x, "exclusive: first adopts, second allocates its own, pool keeps the first"
+w = m.mq3d_scratch_acquire(plan(64), dev, "metadata builder", exclusive=False)
+assert w is x, "non-exclusive still shares"
+g = m.mq3d_scratch_acquire(plan(64, heads=8), dev, "metadata builder")
+assert g is not x and len(pool) == 2, "different geometry is a different key"
+print("POOL UNIT TEST OK: 9 assertions")
+# negative control: the exclusive guard removed -> sharing across exclusive builders would be wrong
+pool.clear()
+x = m.mq3d_scratch_acquire(plan(64), dev, "model load")
+m.mq3d_scratch_acquire(plan(64), dev, "metadata builder", exclusive=True)
+shared_when_it_must_not = m.mq3d_scratch_acquire(plan(64), dev, "metadata builder", exclusive=False) is x
+print("NEGATIVE CONTROL (exclusive=False on the second builder shares):", shared_when_it_must_not)

--- a/docs/spec-decode-scratch-token-units.md
+++ b/docs/spec-decode-scratch-token-units.md
@@ -219,3 +219,103 @@ The boot log states the capacity formula as a sentence. The inputs and the resul
 and can be recomputed, which is how the second mutation was caught, but the sentence could go
 stale relative to the code. Left as a follow-up rather than folded in because the independent
 check verified these exact bytes.
+
+## Follow-up: the scratch is now inside the memory budget
+
+`spec-decode-scratch-within-budget.patch`, applied after this one.
+
+### What was wrong
+
+The metadata builder that owns the three `softmax_segm_*` buffers is constructed in
+`initialize_attn_backend`, which `initialize_kv_cache` runs after `determine_available_memory`
+has already fixed the KV budget (`gpu_worker.py`: the `memory_profiling` block wraps only
+`profile_run`; `initialize_from_config` comes later). Nothing in the profiled window touches the
+builder, so the buffers were allocated after the budget was set and came out of the headroom the
+profile had reserved for activations. The merge review measured it as +182 MiB resident at
+`max_num_seqs=64` with a byte-identical KV pool. The resident figure is itself an under-read:
+the caching allocator serves the scratch from segments the profiler already reserved, so
+`nvidia-smi` sees little of it. There are four builders on this model (two attention groups, two
+head counts), so the unaccounted total was four buffer sets, not the one the boot line reported:
+112.88 MiB at `MAX_SEQS=4`, 451.50 MiB at 16, 903 MiB at 32 and above (the capacity formula's
+ceiling on this config). On the reference 3090 the scratch stepped +226 / +452 / +0 MiB from 8 to
+16 to 32 to 64 sequences while the KV budget stepped +30 / +180 / +250 MiB: uncorrelated, the
+budget was tracking per-sequence state and never the scratch. At `MAX_SEQS=32` that left 319 MiB
+free after boot, inside the burst zone gotcha 39 describes.
+
+### The fix
+
+The attention `Impl` is constructed during `load_model`, inside the window whose consumption the
+profile counts (`memory_profiling.total_consumed` is free memory at worker init minus free memory
+after the profile, and `Model loading took` reports it). So the first `Impl` of a given geometry
+allocates the scratch into a module-level pool, and every builder of that geometry adopts it. The
+derivation did not change; it moved into `mq3d_scratch_plan`, and the property test still holds
+with both negative controls red. Two rules fell out of the first boot:
+
+- **Geometry is the model config's, not the layer's.** The builder sizes rows from
+  `vllm_config.model_config` (head size, KV heads); the drafter's layers carry their own numbers
+  (head 128, 8 KV heads here) and a pool keyed on those is one the drafter's builder can never
+  adopt. The first cut did exactly that, and its smoke boot showed the drafter's builder on the
+  WARNING path with 32.25 MiB still outside the budget.
+- **One set per geometry, not per builder.** At model load the number of KV cache groups is not
+  known, so builders of one geometry share a set. This is safe for the reason the existing sharing
+  across a group's layers is safe: an attention call writes and reduces the scratch within the
+  call, on one stream. It halves the footprint (four builders, two geometries). Under ubatching
+  (DBO) a group's builders run on separate streams, so a builder then passes `exclusive` and adopts
+  only a set no builder has adopted; the rest allocate their own, after the profile, and say so.
+  `use_ubatching` is off in every launcher here.
+
+A builder that finds nothing to adopt still allocates and says so at WARNING (`allocated at
+metadata builder (AFTER the memory profile: these bytes are not in the KV budget)`), so the
+unaccounted case cannot recur silently. `resolve_cudagraph_mode_and_sizes` can re-round the
+capture sizes after the model loads, so a builder may derive a capacity the `Impl` did not:
+smaller adopts the larger pool (the declared capacity is the pool's, asserted `>=` derived),
+larger takes the WARNING path. `bench/mq3d_scratch_pool_test.py` exercises the pool on CPU
+tensors (share, adopt-smaller, replace-larger, exclusive, distinct geometry) and ends with a
+negative control (guard off, the second builder shares); it ran inside the image on the 4090 box.
+
+### Measured
+
+Oracle: at the same `MAX_SEQS`, `Available KV cache memory` (and the KV token count) drops by the
+bytes allocated at model load, `Model loading took` rises by the same, every builder line reads
+`adopted`, and no line reads `AFTER the memory profile`. Resident memory is not an oracle.
+
+**Reference 3090** (native, `alternative.sh` int4, `MAX_LEN=180000`, `SPEC=dflash2`, fresh compile
+cache per boot; stock repeated at 8 and 32, identical to the token). Patched minus stock:
+
+| `MAX_SEQS` | allocated at load | `Model loading took` | `Available KV` | KV tokens | free VRAM after boot | builder lines | 3.7k prompt |
+|---|---|---|---|---|---|---|---|
+| 8 | 112.88 MiB | +113 MiB | -164 MiB | -7,798 | +280 MiB | 4 adopted / 0 after | ok |
+| 16 | 225.75 MiB | +225 MiB | -266 MiB | -12,347 | +462 MiB | 4 adopted / 0 after | ok |
+| 32 | 451.50 MiB | +461 MiB | -471 MiB | -22,094 | +1,004 MiB | 4 adopted / 0 after | ok |
+| 64 | 451.50 MiB | +461 MiB | -420 MiB | -20,144 | +824 MiB | 4 adopted / 0 after | ok |
+
+The model-load figure rises by the allocation; the torch peak is unchanged; the budget falls by
+the allocation plus -31 to +51 MiB. With stock boots reproducing to the token, that remainder is
+the allocator's segment behaviour at load, the true cost, with the right sign. At `MAX_SEQS=32`
+free VRAM after boot goes 319 to 1,323 MiB, out of the burst zone, for about 22k of 230k KV tokens.
+That is the price the review asked to have made visible.
+
+**4090, WSL2** (`CTX=long`, `MAX_LEN=81920`, k=7, `PREFIX_CACHE=1`, `GPU_UTIL=0.93`; compile cache
+disabled on every boot, so each profiles cold: the first series mixed a cold and a warm stock boot
+and got 4.86 versus 5.77 GiB of KV budget at the same config, gotcha 13 landing inside the profiled
+window; stock repeated at 4, identical to the token). Then a 6.7k and a 68k prompt:
+
+| `MAX_SEQS` | arm | scratch lines | `Model loading took` | `Available KV` | KV tokens | prompts |
+|---|---|---|---|---|---|---|
+| 4 | stock (x2) | 4 x after profile, 112.88 MiB | 15.92 GiB | 4.85 GiB | 184,701 | ok / ok |
+| 4 | patched | 56.44 MiB at load, 4 adopted, 0 after | 15.98 GiB | 4.79 GiB | 182,666 (-2,035) | ok / ok |
+| 16 | stock | 4 x after profile, 451.50 MiB | 15.93 GiB | 4.76 GiB | 181,139 | ok / ok |
+| 16 | patched | 225.75 MiB at load, 4 adopted, 0 after | 16.14 GiB | 4.54 GiB | 172,998 (-8,141) | ok / ok |
+| 32 | stock | 4 x after profile, 903.00 MiB | 15.93 GiB | 4.62 GiB | 175,542 | ok / ok |
+| 32 | patched | 451.50 MiB at load, 4 adopted, 0 after | 16.37 GiB | 4.18 GiB | 158,751 (-16,791) | ok / ok |
+
+At 28.2 KB per KV token the token drops are 55, 219 and 452 MiB against 56.44, 225.75 and 451.50
+allocated; the pool is allocated in blocks, so the count quantizes at a few MiB. Resident memory
+after boot at `MAX_SEQS=32`: 23,270 MB stock, 22,372 MB patched. The 903 MiB the stock arm took
+outside the budget is gone; half of it is the pool's now and half came back as headroom.
+
+### Known nit, carried
+
+The boot line still states the capacity formula as a sentence (above). It now also states where
+each set was allocated and which builders adopted it, which is the part this follow-up needed
+auditable.

--- a/docs/spec-decode-scratch-token-units.md
+++ b/docs/spec-decode-scratch-token-units.md
@@ -324,3 +324,23 @@ outside the budget is gone; half of it is the pool's now and half came back as h
 The boot line still states the capacity formula as a sentence (above). It now also states where
 each set was allocated and which builders adopted it, which is the part this follow-up needed
 auditable.
+
+### Depth 15, the band the sizing was written for (2026-09-03)
+
+With #63 in (dfee877) depth 15 boots on the int4 path. RTX 4090 under WSL2, the container image built
+from main, `alternative.sh` int4, `DFLASH_TOKENS=15`, `MAX_LEN=32768`, `MAX_SEQS=4`, `VLLM_INT4_MQ_3D=1`,
+`VLLM_INT4_MQ_3D_DEBUG=1`, two tool-calling conversations (about 60 chat completions each) plus one
+short bench per boot:
+
+- Stock main: pool 43,866 tokens; the scratch declares capacity 64 query tokens (min(max_num_seqs=4,
+  seq_threshold_3D=32) x max_query_len_3d=16). Dispatch census: 712 verify-shaped batches
+  (max_seqlen_q <= 16), all 712 on the 3D path, 0 capacity fallbacks, breach_count 0, no DEGRADED
+  line; every width in the 9..16 band present (4 sequences at 10, 12, 14 and 16 query tokens; 1 to 3
+  sequences at 16). The 4,223 prefill chunks (max_seqlen_q 1840) took 2D by the query-length policy.
+- This patch applied at boot: two sets allocated at model load (24.19 MiB at 396,288 B/row and 32.25 MiB
+  at 528,384 B/row, 56.44 MiB together), all four builders adopted, zero "AFTER the memory profile"
+  lines. `Model loading took` 15.92 to 15.98 GiB, `Available KV cache memory` 4.81 to 4.75 GiB, pool
+  43,866 to 43,338 tokens. Same census, same no-fallback result.
+- Quality (thinking off): stock, judgment 8/8, mission 14/18 twice; 3D path off, judgment 6/8, mission
+  15/18 twice; this patch, judgment 6/8, mission 16/18. No repetition or truncation in any row; the
+  judgment bench moves two decisions between boots of the same configuration, so those are noise-shaped.

--- a/docs/spec-decode-scratch-token-units.md
+++ b/docs/spec-decode-scratch-token-units.md
@@ -293,7 +293,12 @@ The model-load figure rises by the allocation; the torch peak is unchanged; the 
 the allocation plus -31 to +51 MiB. With stock boots reproducing to the token, that remainder is
 the allocator's segment behaviour at load, the true cost, with the right sign. At `MAX_SEQS=32`
 free VRAM after boot goes 319 to 1,323 MiB, out of the burst zone, for about 22k of 230k KV tokens.
-That is the price the review asked to have made visible.
+That is the price the review asked to have made visible. One more condition for anyone adding rows: the
+same 3090 booted from the container image instead of the native venv gives identical builders, capacity,
+scratch and model-load figures but a profiled budget about 30 MiB larger and a resident figure about
+500 MiB smaller, before any patch (native stock repeats were digit-identical, so that is the container
+environment, not noise). Compare patched against stock within one arm; never a native row against an
+image row.
 
 **4090, WSL2** (`CTX=long`, `MAX_LEN=81920`, k=7, `PREFIX_CACHE=1`, `GPU_UTIL=0.93`; compile cache
 disabled on every boot, so each profiles cold: the first series mixed a cold and a warm stock boot

--- a/patches/spec-decode-scratch-within-budget.patch
+++ b/patches/spec-decode-scratch-within-budget.patch
@@ -1,0 +1,370 @@
+int4 3D scratch: allocate inside the memory budget
+
+WHAT THIS FIXES, AND WHOSE DEFECT IT IS
+
+The follow-up from the #57 merge review. The three softmax_segm_* scratch
+buffers were allocated by the attention metadata builder, and the builder is
+constructed in initialize_attn_backend, which initialize_kv_cache runs after
+determine_available_memory has already fixed the KV budget. Nothing inside the
+memory_profiling window touches the builder, so the buffers were never in the
+budget: they came out of the headroom the profile had reserved for
+activations. The sizing rule is upstream vLLM's (one set per builder, sized
+by seq_threshold_3D); the exposure is ours, because #46 opened the 3D path to
+multi-query batches and #57 sized the buffers in query tokens, which grows
+them with max_num_seqs (four builders on this model: 112.88 MiB at
+max_num_seqs=4, 903 MiB at 32 and above) while the budget never moved.
+Resident memory under-reads it: the caching allocator serves the scratch
+from segments the profiler already reserved, so nvidia-smi sees little of it
+and the honest figure is the KV budget itself.
+
+THE FIX
+
+The attention Impl is constructed during load_model, inside the window whose
+consumption the profile counts. The first Impl of a geometry allocates the
+scratch into a module-level pool (logged: "allocated at model load (inside
+the memory profile)"); every metadata builder of that geometry adopts it
+("adopted by the metadata builder"). "Model loading took" rises by the
+scratch bytes and "Available KV cache memory" drops by the same. The
+derivation moved into mq3d_scratch_plan and did not change; the property test
+(bench/mq3d_capacity_property.py) is unaffected. Geometry (head size, KV
+heads) is the model config's, as the builder derives it, not the layer's own
+arguments: they differ for the drafter, and a pool keyed on the layer's
+numbers is one the drafter's builder can never adopt.
+
+Builders of one geometry share a set. That is safe because an attention call
+writes and reduces the scratch within the call, on one stream, which is the
+assumption the existing sharing across a group's layers already makes; it also
+halves the footprint (four builders, two geometries). Under ubatching (DBO)
+a group's builders run on separate streams, so a builder then adopts only a
+set no builder has adopted and the rest allocate their own. Any builder that
+finds nothing to adopt allocates and says so at WARNING ("AFTER the memory
+profile: these bytes are not in the KV budget"), so the unaccounted case can
+no longer happen silently. resolve_cudagraph_mode_and_sizes can re-round the
+capture sizes after the model loads, so a builder may derive a capacity the
+Impl did not: smaller adopts the larger pool (declared capacity = the pool's,
+asserted >= derived), larger takes the WARNING path.
+
+SCOPE
+
+One file, v1/attention/backends/triton_attn.py. Applies after
+spec-decode-scratch-token-units.patch (glob order). No kernel, metadata, or
+dispatch change; the buffers' shapes, dtype, and the breach guard in
+int4_per_token_head.py are untouched. Pool logic: bench/mq3d_scratch_pool_test.py
+(CPU tensors, runs inside the image). Measurements and the reading:
+docs/spec-decode-scratch-token-units.md, "Follow-up".
+
+--- a/v1/attention/backends/triton_attn.py
++++ b/v1/attention/backends/triton_attn.py
+@@ -9,7 +9,7 @@
+ 
+ import vllm.envs as envs
+ from vllm._aiter_ops import rocm_aiter_ops
+-from vllm.config import CUDAGraphMode, VllmConfig
++from vllm.config import CUDAGraphMode, VllmConfig, get_current_vllm_config_or_none
+ from vllm.config.cache import CacheDType
+ from vllm.logger import init_logger
+ from vllm.model_executor.layers.quantization.utils.quant_utils import (
+@@ -65,6 +65,175 @@
+ MAX_QUERY_LEN_3D = 16
+ 
+ 
++# ---- SCRATCH INSIDE THE MEMORY BUDGET -----------------------------------------
++# The metadata builder that owns the 3D scratch is constructed in
++# initialize_attn_backend, which initialize_kv_cache runs AFTER
++# determine_available_memory has fixed the KV budget. Buffers allocated there are
++# invisible to the memory profile: they come out of the headroom the profile
++# reserved for activations (measured on the reference config: +182 MiB resident at
++# max_num_seqs=64 with a byte-identical KV pool). The attention Impl is constructed
++# during load_model, inside the window whose consumption the profile does count
++# (memory_profiling: total_consumed = free memory at worker init minus free memory
++# after the profile; "Model loading took" reports it). So the first Impl of a given
++# geometry allocates the scratch into this pool and every builder of that geometry
++# adopts it: the bytes show up in the model-load figure and the KV budget shrinks
++# by exactly that much. The profiling-time builders
++# (initialize_kv_cache(..., is_profiling=True) under profile_cudagraph_memory)
++# adopt too, so the scratch is allocated once per geometry per process, not twice.
++#
++# resolve_cudagraph_mode_and_sizes can re-round cudagraph_capture_sizes for spec
++# decode after the model is loaded, so a builder may derive a capacity the Impl did
++# not: smaller adopts the larger pool (the declared capacity is the pool's), larger
++# allocates again and says so at WARNING. Either way the boot record shows it.
++#
++# The derivation is the one the builder used; it moved, it did not change. That
++# includes where the geometry comes from: head size and KV-head count are the
++# MODEL CONFIG's, as the builder reads them, not the layer's own arguments. The
++# two differ for a speculative drafter (its layers carry their own head size and
++# KV heads; its builder still sizes rows by the target config), and a pool keyed
++# on the layer's numbers is one the drafter's builder can never adopt.
++
++
++@dataclass(frozen=True)
++class Mq3dScratchPlan:
++    num_heads_q: int
++    num_heads_kv: int
++    headdim_padded: int
++    seq_threshold_3D: int          # SEQUENCES  (policy)
++    max_query_len_3d: int          # QUERY TOKENS PER SEQUENCE  (eligibility)
++    capacity: int                  # TOTAL QUERY TOKENS  (allocation)
++    row_bytes: int
++    max_num_batched_tokens: int
++    max_num_seqs: int
++
++
++def mq3d_scratch_plan(vllm_config: VllmConfig, num_heads_q: int) -> Mq3dScratchPlan:
++    model_config = vllm_config.model_config
++    num_heads_kv = model_config.get_num_kv_heads(vllm_config.parallel_config)
++    headdim = model_config.get_head_size()
++    # The launch grid for the 2D kernel is defined as (num_q_blocks, num_heads_kv).
++    # A lower bound for num_q_blocks is the number of sequences.
++    # To ensure the minimum launch grid size is achieved, the number of sequences
++    # must be at least equal to the threshold below.
++    # If this threshold is not reached (i.e., the batch size is not large enough),
++    # the 3D kernel will be selected instead.
++    seq_threshold_3D = MIN_LAUNCH_GRID_SIZE_2D // num_heads_kv
++    compilation_config = vllm_config.compilation_config
++    if compilation_config.cudagraph_mode in (
++        CUDAGraphMode.FULL_AND_PIECEWISE,
++        CUDAGraphMode.FULL_DECODE_ONLY,
++        CUDAGraphMode.FULL,
++    ):
++        capture_sizes = compilation_config.cudagraph_capture_sizes
++        assert capture_sizes, "CUDA Graphs enabled but no capture sizes specified."
++        # Select the CUDA Graph capture size closest to seq_threshold_3D as
++        # threshold. This ensures that each captured graph covers the correct
++        # execution path.
++        seq_threshold_3D = min(capture_sizes, key=lambda x: abs(x - seq_threshold_3D))
++    sched = vllm_config.scheduler_config
++    # Eligibility already requires num_seqs <= seq_threshold_3D, and no batch can
++    # carry more query tokens than the scheduler will place in one, so this is the
++    # smallest capacity that can hold every policy-eligible batch.
++    capacity = min(
++        sched.max_num_batched_tokens,
++        min(sched.max_num_seqs, seq_threshold_3D) * MAX_QUERY_LEN_3D,
++    )
++    headdim_padded = next_power_of_2(headdim)
++    row_bytes = 4 * (
++        num_heads_q * NUM_PAR_SOFTMAX_SEGMENTS * headdim_padded
++        + 2 * num_heads_q * NUM_PAR_SOFTMAX_SEGMENTS
++    )
++    return Mq3dScratchPlan(
++        num_heads_q=num_heads_q,
++        num_heads_kv=num_heads_kv,
++        headdim_padded=headdim_padded,
++        seq_threshold_3D=seq_threshold_3D,
++        max_query_len_3d=MAX_QUERY_LEN_3D,
++        capacity=capacity,
++        row_bytes=row_bytes,
++        max_num_batched_tokens=sched.max_num_batched_tokens,
++        max_num_seqs=sched.max_num_seqs,
++    )
++
++
++class Mq3dScratch:
++    """The three 3D-softmax scratch buffers for one geometry, and where they came from."""
++
++    def __init__(self, plan: Mq3dScratchPlan, device: torch.device, origin: str):
++        rows = plan.capacity
++        self.output = torch.empty(
++            (rows, plan.num_heads_q, NUM_PAR_SOFTMAX_SEGMENTS, plan.headdim_padded),
++            dtype=torch.float32,
++            device=device,
++        )
++        self.max = torch.empty(
++            (rows, plan.num_heads_q, NUM_PAR_SOFTMAX_SEGMENTS),
++            dtype=torch.float32,
++            device=device,
++        )
++        self.expsum = torch.empty_like(self.max)
++        self.plan = plan
++        self.origin = origin
++        self.adopters = 0   # builders using this set
++
++    @property
++    def capacity(self) -> int:
++        return self.output.shape[0]
++
++
++# (device type, device index, num_heads_q, segments, headdim_padded) -> scratch
++_MQ3D_SCRATCH_POOL: dict[tuple, Mq3dScratch] = {}
++
++
++def mq3d_scratch_acquire(
++    plan: Mq3dScratchPlan, device: torch.device, origin: str, exclusive: bool = False
++) -> Mq3dScratch:
++    """origin is "model load" (inside the memory profile) or "metadata builder"
++    (after it). A builder that finds nothing to adopt still gets its buffers, and
++    the boot record says so at WARNING: that is the unaccounted case.
++
++    Builders of one geometry share a set: an attention call writes and reduces the
++    scratch within the call, on one stream, which is the assumption the sharing
++    across a group's layers already makes. Under ubatching (DBO) the builders of a
++    group run on separate streams, so a builder passes exclusive=True and adopts
++    only a set no builder has adopted; the rest allocate their own, after the
++    profile, and say so."""
++    dev = torch.device(device)
++    key = (dev.type, dev.index, plan.num_heads_q, NUM_PAR_SOFTMAX_SEGMENTS, plan.headdim_padded)
++    have = _MQ3D_SCRATCH_POOL.get(key)
++    fits = have is not None and have.capacity >= plan.capacity
++    if fits and not (exclusive and have.adopters > 0):
++        if origin != "model load":
++            have.adopters += 1
++            logger.info(
++                "int4 3D scratch: capacity=%d query tokens adopted by the %s "
++                "(derived %d for this instance; allocated at %s)",
++                have.capacity, origin, plan.capacity, have.origin,
++            )
++        return have
++    inside = origin == "model load"
++    log = logger.info if inside else logger.warning
++    # Bind the inputs and the resulting cost into the boot record: a capacity that
++    # cannot be read back at boot is a capacity nobody can audit later.
++    log(
++        "int4 3D scratch: capacity=%d query tokens (min of max_num_batched_tokens=%d, "
++        "min(max_num_seqs=%d, seq_threshold_3D=%d) * max_query_len_3d=%d); "
++        "%d B/row, %.2f MiB, allocated at %s%s",
++        plan.capacity, plan.max_num_batched_tokens, plan.max_num_seqs,
++        plan.seq_threshold_3D, plan.max_query_len_3d,
++        plan.row_bytes, plan.row_bytes * plan.capacity / 2**20, origin,
++        " (inside the memory profile)" if inside
++        else " (AFTER the memory profile: these bytes are not in the KV budget"
++        + ("; ubatching: builders do not share a set)" if fits else ")"),
++    )
++    scratch = Mq3dScratch(plan, dev, origin)
++    if not inside:
++        scratch.adopters = 1
++    if not fits:
++        _MQ3D_SCRATCH_POOL[key] = scratch   # an exclusive extra set is nobody else's to adopt
++    return scratch
++
++
+ @dataclass
+ class TritonAttentionMetadata:
+     # NOTE(sang): Definition of context_len, query_len, and seq_len.
+@@ -141,30 +310,7 @@
+             )
+         )
+ 
+-        # The launch grid for the 2D kernel is defined as (num_q_blocks, num_heads_kv).
+-        # A lower bound for num_q_blocks is the number of sequences.
+-        # To ensure the minimum launch grid size is achieved, the number of sequences
+-        # must be at least equal to the threshold below.
+-        # If this threshold is not reached (i.e., the batch size is not large enough),
+-        # the 3D kernel will be selected instead.
+-        self.seq_threshold_3D = MIN_LAUNCH_GRID_SIZE_2D // self.num_heads_kv
+-
+-        # Modify the threshold if needed.
+-        if self.decode_cudagraph_enabled:
+-            capture_sizes = self.vllm_config.compilation_config.cudagraph_capture_sizes
+-            assert capture_sizes, "CUDA Graphs enabled but no capture sizes specified."
+-
+-            # Select the CUDA Graph capture size closest to self.seq_threshold_3D
+-            # as threshold. This ensures that each captured graph covers the
+-            # correct execution path.
+-            self.seq_threshold_3D = min(
+-                capture_sizes,
+-                key=lambda x: abs(x - self.seq_threshold_3D),
+-            )
+-
+         self.num_par_softmax_segments = NUM_PAR_SOFTMAX_SEGMENTS
+-        headdim_padded = next_power_of_2(self.headdim)
+-
+         # ---- UNIT SPLIT ------------------------------------------------------------
+         # These three quantities were one variable, in three different units. The
+         # scratch buffers are indexed by QUERY TOKEN, but were sized by
+@@ -185,57 +331,29 @@
+         # requires num_seqs <= seq_threshold_3D, and no batch can carry more query
+         # tokens than the scheduler will place in one, so this is the smallest
+         # capacity that can hold every policy-eligible batch.
+-        self.max_query_len_3d = MAX_QUERY_LEN_3D
+-        _sched = self.vllm_config.scheduler_config
+-        self.scratch_token_capacity_3d = min(
+-            _sched.max_num_batched_tokens,
+-            min(_sched.max_num_seqs, self.seq_threshold_3D) * self.max_query_len_3d,
+-        )
+-
+-        _rows = self.scratch_token_capacity_3d
+-        _row_bytes = 4 * (
+-            self.num_heads_q * self.num_par_softmax_segments * headdim_padded
+-            + 2 * self.num_heads_q * self.num_par_softmax_segments
+-        )
+-        # Bind the inputs and the resulting cost into the boot record: a capacity that
+-        # cannot be read back at boot is a capacity nobody can audit later.
+-        logger.info(
+-            "int4 3D scratch: capacity=%d query tokens (min of max_num_batched_tokens=%d, "
+-            "min(max_num_seqs=%d, seq_threshold_3D=%d) * max_query_len_3d=%d); "
+-            "%d B/row, %.2f MiB for this instance",
+-            _rows, _sched.max_num_batched_tokens, _sched.max_num_seqs,
+-            self.seq_threshold_3D, self.max_query_len_3d,
+-            _row_bytes, _row_bytes * _rows / 2**20,
+-        )
+-
+-        self.softmax_segm_output = torch.empty(
+-            (
+-                _rows,
+-                self.num_heads_q,
+-                self.num_par_softmax_segments,
+-                headdim_padded,
+-            ),
+-            dtype=torch.float32,
+-            device=device,
+-        )
+-        self.softmax_segm_max = torch.empty(
+-            (_rows, self.num_heads_q, self.num_par_softmax_segments),
+-            dtype=torch.float32,
+-            device=device,
+-        )
+-        self.softmax_segm_expsum = torch.empty(
+-            (_rows, self.num_heads_q, self.num_par_softmax_segments),
+-            dtype=torch.float32,
+-            device=device,
+-        )
+-        # All three buffers must agree with the DECLARED capacity. One oversized
+-        # buffer can otherwise mask another undersized one until a different reducer
+-        # path is taken.
++        plan = mq3d_scratch_plan(self.vllm_config, self.num_heads_q)
++        assert (plan.num_heads_kv, plan.headdim_padded) == (
++            self.num_heads_kv, next_power_of_2(self.headdim)
++        ), "int4 3D scratch plan geometry disagrees with the builder's"
++        self.seq_threshold_3D = plan.seq_threshold_3D
++        self.max_query_len_3d = plan.max_query_len_3d
++        scratch = mq3d_scratch_acquire(
++            plan, device, "metadata builder",
++            exclusive=bool(getattr(self.vllm_config.parallel_config, "use_ubatching", False)),
++        )
++        self.softmax_segm_output = scratch.output
++        self.softmax_segm_max = scratch.max
++        self.softmax_segm_expsum = scratch.expsum
++        # The declared capacity is the pool's, never below the derived one. All
++        # three buffers must agree with it: one oversized buffer can otherwise mask
++        # another undersized one until a different reducer path is taken.
++        self.scratch_token_capacity_3d = scratch.capacity
+         assert (
+             self.softmax_segm_output.shape[0]
+             == self.softmax_segm_max.shape[0]
+             == self.softmax_segm_expsum.shape[0]
+             == self.scratch_token_capacity_3d
++            >= plan.capacity
+         ), "int4 3D scratch buffers disagree with the declared token capacity"
+         self.rswa_window = model_config.rswa_window
+         self.persistent_rswa_prefix_lens: torch.Tensor | None = None
+@@ -643,6 +761,20 @@
+         else:
+             self.use_td = td_override
+ 
++        # Allocate the 3D scratch for this layer's head count while the memory
++        # profile can still see it (Mq3dScratch above); the metadata builder
++        # adopts it later. Only num_heads is the layer's: head size and KV heads
++        # are the model config's, as the builder will derive them. Constructed
++        # without a current config (unit tests), there is nothing to size from
++        # and the builder allocates, unaccounted, as before.
++        vllm_config = get_current_vllm_config_or_none()
++        if vllm_config is not None and current_platform.is_cuda_alike():
++            mq3d_scratch_acquire(
++                mq3d_scratch_plan(vllm_config, num_heads),
++                torch.device("cuda", torch.cuda.current_device()),
++                "model load",
++            )
++
+     def forward(
+         self,
+         layer: torch.nn.Module,


### PR DESCRIPTION
The follow-up from the #57 merge review: the int4 3D scratch now allocates inside the memory budget.

1. `patches/spec-decode-scratch-within-budget.patch`: the attention `Impl` (constructed in `load_model`, inside the profiled window) allocates the scratch for its geometry into a pool; every metadata builder adopts it. `Model loading took` rises by the scratch bytes and `Available KV cache memory` drops by the same. The derivation moved into `mq3d_scratch_plan` and did not change; the property test is unaffected.
2. A builder that finds nothing to adopt still allocates, and logs it at WARNING as bytes outside the KV budget, so the unaccounted case cannot recur silently.
3. `bench/mq3d_scratch_pool_test.py`: the pool logic on CPU tensors (share, adopt-smaller, replace-larger, exclusive), with a negative control. Runs inside the image without a GPU.
4. Measurements and the reading in `docs/spec-decode-scratch-token-units.md`, "Follow-up".

Measured (details and conditions in the doc). Reference 3090, native, fresh compile cache per boot, `alternative.sh` int4, `MAX_LEN=180000`, patched minus stock at equal `MAX_SEQS`:

| `MAX_SEQS` | allocated at load | `Model loading took` | `Available KV` | KV tokens | free VRAM after boot | prompt |
|---|---|---|---|---|---|---|
| 8 | 112.88 MiB | +113 MiB | -164 MiB | -7,798 | +280 MiB | ok |
| 16 | 225.75 MiB | +225 MiB | -266 MiB | -12,347 | +462 MiB | ok |
| 32 | 451.50 MiB | +461 MiB | -471 MiB | -22,094 | +1,004 MiB | ok |
| 64 | 451.50 MiB | +461 MiB | -420 MiB | -20,144 | +824 MiB | ok |

At `MAX_SEQS=32` free VRAM after boot goes from 319 MiB to 1,323 MiB, out of the burst zone gotcha 39 describes, for about 22k of 230k KV tokens. That is the cost the review asked to have made visible.

A 4090 under WSL2 (`CTX=long`, k=7, compile cache disabled on every boot so each profiles cold) agrees: two stock boots identical to the token (184,701); patched at `MAX_SEQS` 4 / 16 / 32 drops the KV pool by 2,035 / 8,141 / 16,791 tokens (55 / 219 / 452 MiB) against 56.44 / 225.75 / 451.50 MiB allocated at load, model load +0.06 / +0.21 / +0.44 GiB, every boot 4 adopted and 0 after, every arm alive through a 6.7k and a 68k prompt. Resident memory is not an oracle for this: the caching allocator serves the scratch from segments the profiler already reserved, so `nvidia-smi` under-reads it; the KV line is the measure.

Two things to know:

- Builders of one geometry share a set (four builders, two geometries on this model), which is safe because an attention call writes and reduces the scratch within the call on one stream, the assumption the sharing across a group's layers already makes. Under ubatching (DBO) a group's builders run on separate streams, so a builder then adopts only a set no builder has adopted, and the rest allocate their own, logged. `use_ubatching` is off in every launcher here.
- Geometry is taken from the model config, as the builder derives it, not from the layer's own arguments; they differ for the drafter, and the first cut of this patch keyed on the layer's numbers and left the drafter's builder outside the budget. The boot log shows which path every builder took.

Depth 15 (the 9..16 band this sizing exists for, bootable since #63): 712 of 712 verify-shaped batches on the 3D path with no fallback at capacity 64; with this patch the two sets (56.44 MiB) allocate at model load, all four builders adopt, and the pool moves 43,866 to 43,338 tokens on the 4090 at `MAX_LEN=32768`. Rows and census in the doc's "Depth 15" section.
