### PR TITLE
kvarn: restore the sliding-window page padding hunk dropped in the 0.28.0 runner patch (stacked on #43)

### DIFF
--- a/.github/workflows/patch-integrity.yml
+++ b/.github/workflows/patch-integrity.yml
@@ -1,0 +1,28 @@
+name: patch integrity
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  git-apply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check repository
+        uses: actions/checkout@v4
+
+      - name: Check pinned vLLM source
+        uses: actions/checkout@v4
+        with:
+          repository: vllm-project/vllm
+          ref: v0.28.0
+          path: .ci/vllm
+          fetch-depth: 1
+
+      - name: Validate patch series with git apply
+        run: bash patches/check_vllm_series.sh .ci/vllm

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ venv
 models
 api_key.txt
 bench/results/
+kv-persist-cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Same stack as the README's venv install, frozen: Python 3.12 venv at /app/venv,
-# vLLM 0.27.1 (torch 2.13 / cu130 / Triton 3.7.1), every patch in patches/ applied,
+# vLLM 0.28.0 (torch 2.13 / cu130 / Triton 3.7.1), every compatible patch in
+# patches/ applied,
 # the KVarN KV cache installed, verify.sh --install run at build time.
 #
 # The base image is CUDA "base" + nvcc, not "devel": vLLM's wheels bring their own
@@ -25,7 +26,12 @@ RUN venv/bin/pip install -r docker/requirements.txt
 
 COPY . .
 RUN set -e; SP=$(venv/bin/python -c 'import vllm, os; print(os.path.dirname(vllm.__file__))' | tail -n1); \
-    for p in patches/*.patch; do echo "== $p"; patch -p1 -d "$SP" < "$p"; done; \
+    for p in patches/*.patch; do \
+      case "$p" in \
+        patches/dflash2-backport.patch) echo "== skip $p (DFlash2 is native in vLLM 0.28.0)"; continue ;; \
+      esac; \
+      echo "== $p"; patch -p1 -d "$SP" < "$p"; \
+    done; \
     bash kvarn/install.sh; \
     bash verify.sh --install
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ docker compose --profile batch  up -d    # API backend, many concurrent requests
 | single-stream (C1) decode rate, realistic prompts | 46 tok/s | MTP: **121** tok/s at default sampling, **120** greedy (`CTX=fast`, 64k; 96 / 102 with `CTX=long`, 150k). DFlash2 (`SPEC=dflash2`): **127** default, **130** greedy |
 | reproducing its own context (quoting a document, applying an edit) | 46 tok/s | **381 tok/s** at 25k context — 15.0 tokens per verify step, drafted straight from the prompt (`SPEC=dflash2` + `DFLASH_TOKENS=15`) |
 | trick | 16-bit recurrent state + int8 tensor-core GEMMs | MTP speculation with 4 cheap drafts, a draft vocabulary that covers what the model says, calibrated int4 lm_head/drafter, split-KV verify attention; optionally native vLLM 0.28.0 DFlash2 (7 drafts in one pass, int4-requantized) with a verify block the context fills |
-
 <sub>Single-stream numbers re-measured 2026-08-22 on current main with
 `bash bench/run_benchmarks.sh single` — `vllm bench serve`, the 8 prompts in
 `bench/prompts_real.jsonl`, 1024 output tokens, C1, decode rate taken as
@@ -37,9 +36,8 @@ docker compose --profile batch  up -d    # API backend, many concurrent requests
 length is not measuring the same thing, and mixing the two is how
 [#3](https://github.com/syv-ai/qwen38-27b-rtx3090/issues/3) got confusing.</sub>
 
-> Version note: the install below now pins vLLM 0.28.0. The throughput and quality
-> tables are v0.27.1 baselines and need to be re-benchmarked on a GPU after this
-> upgrade; this environment validated patch application and Python compilation only.
+> Version note: this branch pins vLLM 0.28.0; the throughput and quality tables are
+> retained as reference baselines while the v0.28.0 GPU matrix is being re-measured.
 
 Both modes share one install — the mode is just which launch script you run.
 Speculation wins below ~8 concurrent users on short prompts, plain batching above;

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ did not mix on this path. On WSL2 that showed up as acceptance collapsing to
 about one token per step; on bare metal it also **corrupted the output** —
 special-token ids leaking into the stream, 1 of 1,176 characters matching the
 source instead of all of them. It is the capture rather than the drafter: eager
-is clean, `LOOKUP=0` is not, forcing a fixed verify-block length is not, and
+is clean, `VLLM_DFLASH2_LOOKUP=0` is not, forcing a fixed verify-block length is not, and
 PIECEWISE — which keeps the compiled graphs and leaves only the multi-query
 verify uncaptured — restored both the speed and the correctness on both machines.
 
@@ -668,7 +668,7 @@ greedy):
 | + GPTQ-int4 lm_head (calibrated) | 109 / 112 | 2.8 / 2.8 | 73% / 73% |
 | + GPTQ-int4 MTP module (**fast variant, shipped**) | **~114 / 118-124** | 2.8 / 2.9-3.0 | 74% / 77% |
 | DFlash2 block drafter instead of MTP (`SPEC=dflash2`, int4-requantized) | **118 / 126** | 3.14 / 3.34 | ~75% / ~78% |
-| + drafting from the context (`LOOKUP=1`, on by default) | **130** at C1, up to **259** where the model reproduces its context | 3.3-7.8 | |
+| + drafting from the context (`VLLM_DFLASH2_LOOKUP=1`, on by default) | **130** at C1, up to **259** where the model reproduces its context | 3.3-7.8 | |
 | + a 16-token verify block the context fills (`DFLASH_TOKENS=15`) | **133** at C1, up to **381** reproducing context | 3.4-15.0 | |
 
 (Steps 4-6 are the same 8-prompt protocol; greedy is deterministic for a
@@ -767,6 +767,12 @@ and follow its README:
 
 - **[batch/](batch/)** — throughput. `bash batch/start_qwen.sh`
 - **[single-user/](single-user/)** — latency. `bash single-user/start_qwen.sh`
+
+Both launchers use the bundled Froggeric Qwen 3.8 v22.3 chat template
+(`chat_template-froggeric-v22.4.jinja`) with native XML tool calls. Set
+`CHAT_TEMPLATE=/path/to/another.jinja` to A/B-test or roll back the template
+without changing the model files. The bundled file is pinned to Froggeric
+Hugging Face revision `756cfb69d742355fd310b4ba9d50815a27d9d241` (Froggeric v22.4).
 
 First start takes a few minutes (torch.compile, CUDA graph capture, flashinfer
 JIT). Test it:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,18 @@ docker compose --profile batch  up -d    # API backend, many concurrent requests
 | aggregate, 64 concurrent (128 in / 512 out) | **~1,035 tok/s** steady-state decode, 948 end-to-end (~1,222 / 1,042 with all layers int8) | n/a (8 slots) |
 | single-stream (C1) decode rate, realistic prompts | 46 tok/s | MTP: **121** tok/s at default sampling, **120** greedy (`CTX=fast`, 64k; 96 / 102 with `CTX=long`, 150k). DFlash2 (`SPEC=dflash2`): **127** default, **130** greedy |
 | reproducing its own context (quoting a document, applying an edit) | 46 tok/s | **381 tok/s** at 25k context — 15.0 tokens per verify step, drafted straight from the prompt (`SPEC=dflash2` + `DFLASH_TOKENS=15`) |
-| trick | 16-bit recurrent state + int8 tensor-core GEMMs | MTP speculation with 4 cheap drafts, a draft vocabulary that covers what the model says, calibrated int4 lm_head/drafter, split-KV verify attention; optionally DFlash2 (7 drafts in one pass, int4-requantized, vLLM PR #52816 backported) with a verify block the context fills |
+| trick | 16-bit recurrent state + int8 tensor-core GEMMs | MTP speculation with 4 cheap drafts, a draft vocabulary that covers what the model says, calibrated int4 lm_head/drafter, split-KV verify attention; optionally native vLLM 0.28.0 DFlash2 (7 drafts in one pass, int4-requantized) with a verify block the context fills |
+
+<sub>Single-stream numbers re-measured 2026-08-22 on current main with
+`bash bench/run_benchmarks.sh single` — `vllm bench serve`, the 8 prompts in
+`bench/prompts_real.jsonl`, 1024 output tokens, C1, decode rate taken as
+`C / mean TPOT`. Quote them against that harness: a client with a different output
+length is not measuring the same thing, and mixing the two is how
+[#3](https://github.com/syv-ai/qwen38-27b-rtx3090/issues/3) got confusing.</sub>
+
+> Version note: the install below now pins vLLM 0.28.0. The throughput and quality
+> tables are v0.27.1 baselines and need to be re-benchmarked on a GPU after this
+> upgrade; this environment validated patch application and Python compilation only.
 
 Both modes share one install — the mode is just which launch script you run.
 Speculation wins below ~8 concurrent users on short prompts, plain batching above;
@@ -148,14 +159,14 @@ Every other knob: [single-user/](single-user/).
 ### DFlash2 at 240k: `CTX=huge` (KVarN) also combines with `SPEC=dflash2`
 
 ```bash
-bash kvarn/install.sh                # applies kvarn-v2-runner.patch as its second stage
+bash kvarn/install.sh                # applies the v0.28.0 KVarN + V2-runner ports
 SPEC=dflash2 CTX=huge PREFIX_CACHE=1 bash single-user/start_qwen.sh
 ```
 
 Where `CTX=long` doubles the DFlash2 pool with int8 KV (138k), the KVarN cache
 takes the same idea further: 268k tokens of pool at 245760 max-model-len, on the
 same pinned budget. No kernel work — the KVarN Triton kernels run unmodified on
-the V2 runner; the seven fixes in `kvarn/kvarn-v2-runner.patch` are allocator and
+the V2 runner; the seven fixes in `kvarn/kvarn-v2-runner-0.28.0.patch` are allocator and
 geometry logic (the patch header walks through them, including an upstream vLLM
 bug in the mamba align resume path, and a NaN path in the DFlash2 candidate
 selector that KVarN noise exposes on verbatim-reproduction content). Two
@@ -666,7 +677,7 @@ prefix-cache hits, so single runs carry ±3-5% on tokens/step —
 `bench/run_benchmarks.sh single` reproduces 111.1 / 120.0 tok/s decode at C1,
 the best repeats read 119 / 124.)
 Going deeper (k=5) loses again: 106 / 105. k=4 is the knee, but on vLLM
-0.27.1's FlashInfer backend (needed for fp8 KV, i.e. for 150k context) four
+0.28.0's FlashInfer backend (needed for fp8 KV, i.e. for 150k context) four
 drafts crash the engine with an illegal memory access as soon as one request
 finishes while another is mid-generation — club-3090 reports the same "n=4
 eventually dies, n=3 stable" pattern — so `CTX=long` drafts 3 and gives up
@@ -702,7 +713,7 @@ git clone https://github.com/syv-ai/qwen38-27b-rtx3090 ~/qwen-serving
 cd ~/qwen-serving
 
 python3 -m venv venv
-venv/bin/pip install vllm huggingface_hub hf_transfer ninja \
+venv/bin/pip install vllm==0.28.0 huggingface_hub hf_transfer ninja \
   flashinfer-python flashinfer-cubin==0.6.13
 # flashinfer makes the DFlash2 selector ~2x faster than its torch.topk fallback,
 # and vLLM only *uses* it if nvcc is on PATH or flashinfer-cubin is installed --
@@ -735,9 +746,12 @@ venv/bin/python prepare/fetch_dflash2.py
 venv/bin/python prepare/fetch_thirdparty.py
 venv/bin/python prepare/quant_heads_stream.py models/Qwen3.8-27B-Uncensored-W4A16
 
-# patch vllm (all written against 0.27.1; reapply after upgrades)
+# patch vllm (all compatible patches are written against 0.28.0; reapply after upgrades)
 for p in patches/*.patch; do
-  patch -p1 -d venv/lib/python3.12/site-packages/vllm < $p
+  case "$p" in
+    patches/dflash2-backport.patch) echo "skip $p (DFlash2 is native in vLLM 0.28.0)"; continue ;;
+  esac
+  patch -p1 -d venv/lib/python3.12/site-packages/vllm < "$p"
 done
 # optional: the KVarN 4/2-bit KV cache for 262k context (docs/long-context.md)
 bash kvarn/install.sh
@@ -747,7 +761,7 @@ openssl rand -hex 24 > api_key.txt
 ```
 
 Then `bash verify.sh --no-server` — it checks the venv and vLLM version, that
-every patch in `patches/` is actually applied, and that the model has been
+every compatible patch in `patches/` is actually applied, and that the model has been
 requantized (lm_head, embeddings, MTP module, draft head). Then pick a mode
 and follow its README:
 

--- a/batch/README.md
+++ b/batch/README.md
@@ -14,8 +14,8 @@ config (fp16 recurrent state, int8 activations on the MLP GEMMs):
 | 128/512, 64 concurrent | **~1,094** | 942 | 62.2 ms | 3.0 s* |
 | 256/256, 64 concurrent | ~1,094 | 673 | 81.4 ms | 3.4 s* |
 
-(Re-measured on the current stack; two passes each, within 0.4% of one another. The 128/512
-row read 876 when this repo was first published — the difference is everything that landed
+(Baseline measured on vLLM 0.27.1; re-run after the v0.28.0 upgrade. Two passes each were
+within 0.4% of one another. The 128/512 row read 876 when this repo was first published — the difference is everything that landed
 since. `INT8_LAYERS=.` — int8 activations on every linear, not just the MLP — reaches
 **1,042 tok/s** e2e and ~1,222 steady-state decode, but needs `GPU_UTIL=0.95`: it OOMs inside
 the GDN chunk kernel at the 0.972 default. Quality cost of that row: +3.7% perplexity,

--- a/batch/README.md
+++ b/batch/README.md
@@ -194,6 +194,7 @@ All overridable as env vars, defaults in the script:
 | `INT8_LAYERS` | `mlp` | regex on the layer name that gets int8 activations. `gate_up` for the gentle variant, `.` for everything, or a hand-picked list from `bench/act_calib.py` |
 | `MAX_SEQS` | 64 | scheduler slots; with fp16 state ~70 short requests fit the page pool |
 | `MAX_LEN` | 150000 | max context. Raising it much past this fails startup, the pool can't hold a longer request |
+| `CHAT_TEMPLATE` | `chat_template-froggeric-v22.4.jinja` | Jinja chat template passed to vLLM; set an absolute path to A/B-test or roll back |
 | `TOOLS` | 1 | tool/function calling (`--enable-auto-tool-choice --tool-call-parser`). `TOOL_PARSER` (`qwen3_coder`) must match the XML call format this model's chat template emits — `hermes` parses the JSON a Qwen model does *not* produce here, and fails silently. 0 = off, and `tool_choice: "auto"` then 400s |
 | `PORT` | 18020 | |
 | `GPU_UTIL` | 0.972 | do not raise, see gotchas in the main README. Use 0.93 when you want `prompt_logprobs` (quality checks) |

--- a/batch/start_qwen.sh
+++ b/batch/start_qwen.sh
@@ -102,7 +102,7 @@ fi
 # which reads as the model being bad at tools rather than as a misconfigured server.
 # The name is the call format, not the checkpoint -- nothing here is Qwen3-Coder.
 # qwen3_coder, qwen3_xml and mimo are three names for one Qwen3EngineToolParser in
-# 0.27.1, which is the tool-side adapter of the same parser engine that
+# 0.28.0, which is the tool-side adapter of the same parser engine that
 # --reasoning-parser qwen3 already uses (vllm/parser/qwen3.py).
 TOOL_PARSER=${TOOL_PARSER:-qwen3_coder}
 # Array, not $( [ ] && echo ): exits 1 when TOOLS is off (the shape #59 fixed)

--- a/batch/start_qwen.sh
+++ b/batch/start_qwen.sh
@@ -45,9 +45,15 @@ REPO="$(dirname "$DIR")"
 cd "$REPO"
 
 MODEL=${MODEL:-$REPO/models/Qwen3.8-27B-W4A16-AutoRound}
+CHAT_TEMPLATE=${CHAT_TEMPLATE:-$REPO/chat_template-froggeric-v22.4.jinja}
 PORT=${PORT:-18020}
 MAX_SEQS=${MAX_SEQS:-64}
 API_SERVERS=${API_SERVERS:-1}
+
+if [ ! -f "$CHAT_TEMPLATE" ]; then
+  echo "chat template not found: $CHAT_TEMPLATE" >&2
+  exit 1
+fi
 # KV=fp8 (default): FlashInfer fp8 KV cache, 150k context, fastest.
 # KV=kvarn: the KVarN 4-bit-key / 2-bit-value cache (kvarn/ in this repo,
 # needs `bash kvarn/install.sh` once): 262k context, ~2x the token capacity,
@@ -179,7 +185,15 @@ if [ -z "$VLLM_API_KEY" ] && [ -f "$REPO/api_key.txt" ]; then
   export VLLM_API_KEY="$(cat "$REPO/api_key.txt")"
 fi
 
+# Expose the two throughput-profiled ceilings for controlled A/B tests.  Keep
+# the historical values as defaults; changing them is intentionally opt-in.
+# Use a batch-specific name because the shared .env's MAX_NUM_BATCHED_TOKENS
+# is the proven 4096 setting for the single-user long-context service.
+BATCHED_TOKENS=${BATCH_MAX_NUM_BATCHED_TOKENS:-2048}
+CG=${CG:-64}
+
 exec venv/bin/vllm serve "$MODEL" \
+  --chat-template "$CHAT_TEMPLATE" \
   --served-model-name qwen3.8-27b \
   --host 0.0.0.0 --port $PORT \
   --gpu-memory-utilization $GPU_UTIL \
@@ -190,8 +204,8 @@ exec venv/bin/vllm serve "$MODEL" \
   $KV_ARGS \
   --mamba-ssm-cache-dtype float16 \
   --async-scheduling \
-  --max-num-batched-tokens 2048 \
-  --compilation-config "{\"max_cudagraph_capture_size\":64,\"custom_ops\":[\"+rms_norm\",\"+silu_and_mul\"]}" \
+  --max-num-batched-tokens $BATCHED_TOKENS \
+  --compilation-config "{\"max_cudagraph_capture_size\":$CG,\"custom_ops\":[\"+rms_norm\",\"+silu_and_mul\"]}" \
   --reasoning-parser qwen3 \
   --enable-prompt-tokens-details \
   "${METRICS_ARGS[@]}" \

--- a/bench/labd_bench.py
+++ b/bench/labd_bench.py
@@ -25,7 +25,21 @@ import sys
 import time
 import urllib.request
 
-KEY = open(os.path.expanduser("~/qwen-serving/api_key.txt")).read().strip()
+def load_key():
+    key = os.environ.get("VLLM_API_KEY")
+    if key:
+        return key
+    for path in (os.path.join(os.path.dirname(os.path.dirname(__file__)), "api_key.txt"),
+                 os.path.expanduser("~/qwen-serving/api_key.txt")):
+        try:
+            with open(path) as f:
+                return f.read().strip()
+        except OSError:
+            pass
+    return ""
+
+
+KEY = load_key()
 BASE = "http://127.0.0.1:18020"
 TAG = sys.argv[1] if len(sys.argv) > 1 else "run"
 

--- a/chat_template-froggeric-v22.4.jinja
+++ b/chat_template-froggeric-v22.4.jinja
@@ -1,0 +1,431 @@
+{%- set template_version = "qwen3.8-froggeric-v22.4" %}
+{%- set _tool_format = tool_call_format if tool_call_format is defined else 'xml' %}
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- set add_vision_id = add_vision_id if add_vision_id is defined else false %}
+{%- set enable_thinking = enable_thinking if enable_thinking is defined else true %}
+{%- set auto_disable_thinking_with_tools = auto_disable_thinking_with_tools if auto_disable_thinking_with_tools is defined else false %}
+{%- if preserve_reasoning is defined and preserve_reasoning is not none %}
+    {%- set _preserve_thinking = preserve_reasoning %}
+{%- elif preserve_thinking is defined and preserve_thinking is not none %}
+    {%- set _preserve_thinking = preserve_thinking %}
+{%- else %}
+    {%- set _preserve_thinking = true %}
+{%- endif %}
+{%- set max_tool_arg_chars = max_tool_arg_chars if max_tool_arg_chars is defined else 0 %}
+{%- set max_tool_response_chars = max_tool_response_chars if max_tool_response_chars is defined else 0 %}
+{%- set _default_reasoning_effort = 'medium' %}
+{%- set _has_tools = (tools is defined and tools and tools is iterable and tools is not mapping) %}
+{%- set _effort_raw = (reasoning_effort | string | lower) if reasoning_effort is defined and reasoning_effort is not none else _default_reasoning_effort %}
+{%- set _initial_thinking = enable_thinking %}
+{%- if _effort_raw in ('none', 'off') %}
+    {%- set _initial_thinking = false %}
+    {%- set _initial_effort = 'medium' %}
+{%- elif _effort_raw in ('minimal', 'low') %}
+    {%- set _initial_effort = 'low' %}
+{%- elif _effort_raw in ('high', 'xhigh', 'max', 'ultracode', 'extreme') %}
+    {%- set _initial_effort = 'xhigh' %}
+{%- else %}
+    {%- set _initial_effort = 'medium' %}
+{%- endif %}
+{%- set ns_state = namespace(thinking=_initial_thinking, effort=_initial_effort) %}
+{%- if auto_disable_thinking_with_tools and _has_tools %}
+    {%- set ns_state.thinking = false %}
+{%- endif %}
+{%- for msg in messages %}
+    {%- if msg.role == 'system' or msg.role == 'developer' or msg.role == 'user' %}
+        {%- if msg.content is string %}
+            {%- if '<|think_off|>' in msg.content %}
+                {%- set ns_state.thinking = false %}
+            {%- elif '<|think_on|>' in msg.content %}
+                {%- set ns_state.thinking = true %}
+            {%- elif '<|think_xhigh|>' in msg.content or '<|think_high|>' in msg.content or '<|think_ultracode|>' in msg.content or '<|think_extreme|>' in msg.content or '<|think_max|>' in msg.content %}
+                {%- set ns_state.thinking = true %}
+                {%- set ns_state.effort = 'xhigh' %}
+            {%- elif '<|think_low|>' in msg.content or '<|think_minimal|>' in msg.content %}
+                {%- set ns_state.thinking = true %}
+                {%- set ns_state.effort = 'low' %}
+            {%- elif '<|think_medium|>' in msg.content %}
+                {%- set ns_state.thinking = true %}
+                {%- set ns_state.effort = 'medium' %}
+            {%- endif %}
+        {%- elif msg.content is iterable and msg.content is not mapping %}
+            {%- for item in msg.content %}
+                {%- if item is string %}
+                    {%- set _item_text = item %}
+                {%- elif item is mapping and 'text' in item and item.text is string %}
+                    {%- set _item_text = item.text %}
+                {%- else %}
+                    {%- set _item_text = '' %}
+                {%- endif %}
+                {%- if _item_text %}
+                    {%- if '<|think_off|>' in _item_text %}
+                        {%- set ns_state.thinking = false %}
+                    {%- elif '<|think_on|>' in _item_text %}
+                        {%- set ns_state.thinking = true %}
+                    {%- elif '<|think_xhigh|>' in _item_text or '<|think_high|>' in _item_text or '<|think_ultracode|>' in _item_text or '<|think_extreme|>' in _item_text or '<|think_max|>' in _item_text %}
+                        {%- set ns_state.thinking = true %}
+                        {%- set ns_state.effort = 'xhigh' %}
+                    {%- elif '<|think_low|>' in _item_text or '<|think_minimal|>' in _item_text %}
+                        {%- set ns_state.thinking = true %}
+                        {%- set ns_state.effort = 'low' %}
+                    {%- elif '<|think_medium|>' in _item_text %}
+                        {%- set ns_state.thinking = true %}
+                        {%- set ns_state.effort = 'medium' %}
+                    {%- endif %}
+                {%- endif %}
+            {%- endfor %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- set reasoning_instructions = '' %}
+{%- if ns_state.thinking %}
+    {%- if ns_state.effort == 'xhigh' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to xhigh. Please think carefully through the task, validate key assumptions, consider plausible alternatives, and prioritize correctness, consistency, and clarity in the final answer.' %}
+    {%- elif ns_state.effort == 'low' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to low. Keep your thinking brief and focused, moving directly to the conclusion without unnecessary elaboration.' %}
+    {%- endif %}
+{%- endif %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if item is mapping %}
+                {%- if item.type == 'image' or 'image' in item or 'image_url' in item %}
+                    {%- if is_system_content %}
+                        {{- raise_exception('System message cannot contain images.') }}
+                    {%- endif %}
+                    {%- if do_vision_count %}
+                        {%- set image_count.value = image_count.value + 1 %}
+                    {%- endif %}
+                    {%- if add_vision_id %}
+                        {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                    {%- endif %}
+                    {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+                {%- elif item.type == 'video' or 'video' in item %}
+                    {%- if is_system_content %}
+                        {{- raise_exception('System message cannot contain videos.') }}
+                    {%- endif %}
+                    {%- if do_vision_count %}
+                        {%- set video_count.value = video_count.value + 1 %}
+                    {%- endif %}
+                    {%- if add_vision_id %}
+                        {{- 'Video ' ~ video_count.value ~ ': ' }}
+                    {%- endif %}
+                    {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+                {%- elif 'text' in item %}
+                    {{- item.text }}
+                {%- else %}
+                    {{- raise_exception('Unexpected item type in content.') }}
+                {%- endif %}
+            {%- else %}
+                {{- item | string }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- set head = namespace(count=0, seen_non_system=false) %}
+{%- for message in messages %}
+    {%- set _is_sys = (message.role == 'system' or message.role == 'developer') %}
+    {%- if _is_sys and not head.seen_non_system %}
+        {%- set head.count = head.count + 1 %}
+    {%- else %}
+        {%- set head.seen_non_system = true %}
+    {%- endif %}
+{%- endfor %}
+{%- set sys_state = namespace(content='') %}
+{%- for message in messages[:head.count] %}
+    {%- set _part = render_content(message.content, false, true) | trim %}
+    {%- if '<|think_off|>' in _part %}{%- set _part = _part.split('<|think_off|>') | join('') | trim %}{%- endif %}
+    {%- if '<|think_on|>' in _part %}{%- set _part = _part.split('<|think_on|>') | join('') | trim %}{%- endif %}
+    {%- if '<|think_xhigh|>' in _part %}{%- set _part = _part.split('<|think_xhigh|>') | join('') | trim %}{%- endif %}
+    {%- if '<|think_high|>' in _part %}{%- set _part = _part.split('<|think_high|>') | join('') | trim %}{%- endif %}
+    {%- if '<|think_ultracode|>' in _part %}{%- set _part = _part.split('<|think_ultracode|>') | join('') | trim %}{%- endif %}
+    {%- if '<|think_extreme|>' in _part %}{%- set _part = _part.split('<|think_extreme|>') | join('') | trim %}{%- endif %}
+    {%- if '<|think_max|>' in _part %}{%- set _part = _part.split('<|think_max|>') | join('') | trim %}{%- endif %}
+    {%- if '<|think_medium|>' in _part %}{%- set _part = _part.split('<|think_medium|>') | join('') | trim %}{%- endif %}
+    {%- if '<|think_low|>' in _part %}{%- set _part = _part.split('<|think_low|>') | join('') | trim %}{%- endif %}
+    {%- if '<|think_minimal|>' in _part %}{%- set _part = _part.split('<|think_minimal|>') | join('') | trim %}{%- endif %}
+    {%- if _part %}
+        {%- if sys_state.content %}
+            {%- set sys_state.content = sys_state.content ~ '\n\n' ~ _part %}
+        {%- else %}
+            {%- set sys_state.content = _part %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- set _sc = sys_state.content %}
+{%- set _msgs = messages[head.count:] %}
+{%- if _has_tools %}
+    {{- '<|im_start|>system\n' }}
+    {%- if reasoning_instructions %}
+        {{- reasoning_instructions + '\n\n' }}
+    {%- endif %}
+    {{- '# Tools\n\nYou have access to the following functions:\n\n<tools>' }}
+    {%- for tool in tools %}
+        {{- '\n' }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- '\n</tools>' }}
+    {%- if _tool_format == 'json' %}
+        {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<think>\nBrief explanation of tool call\n</think>\n<tool_call>\n{"name": "example_function_name", "arguments": {"example_parameter_1": "value_1", "example_parameter_2": "This is the value for the second parameter"}}\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- You can use the <think></think> block to plan your next tool call OR to synthesize data and formulate your final response to the user.\n- ALL explanation and reasoning MUST be placed strictly inside the <think></think> block.\n- Function calls MUST follow the specified format: a single JSON object with "name" and "arguments" keys inside <tool_call></tool_call> XML tags.\n- If you choose to call a tool, you MUST output the <tool_call> block IMMEDIATELY after thinking, with NO conversational text before it.\n- The <tool_call> tag MUST be at the very beginning of a new line, with NO spaces or indentation before it.\n- To call multiple functions, output a separate, completely closed <tool_call></tool_call> block for EACH function. Do NOT nest <tool_call> blocks.\n- If you have all necessary data, provide your final answer directly to the user without any tool call.\n</IMPORTANT>' }}
+    {%- else %}
+        {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<think>\nBrief explanation of tool call\n</think>\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- You can use the <think></think> block to plan your next tool call OR to synthesize data and formulate your final response to the user.\n- ALL explanation and reasoning MUST be placed strictly inside the <think></think> block.\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags.\n- If you choose to call a tool, you MUST output the <tool_call> block IMMEDIATELY after thinking, with NO conversational text before it.\n- The <tool_call> and <function> tags MUST be at the very beginning of a new line, with NO spaces or indentation before them.\n- To call multiple functions, output a separate, completely closed <tool_call></tool_call> block for EACH function. Do NOT nest <tool_call> blocks.\n- If you have all necessary data, provide your final answer directly to the user without any tool call.\n</IMPORTANT>' }}
+    {%- endif %}
+    {%- if _sc %}
+        {{- '\n\n' + _sc }}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if _sc %}
+        {{- '<|im_start|>system\n' + (reasoning_instructions + '\n\n' if reasoning_instructions else '') + _sc + '<|im_end|>\n' }}
+    {%- elif reasoning_instructions %}
+        {{- '<|im_start|>system\n' + reasoning_instructions + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set _last_idx = _msgs | length - 1 %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=_last_idx) %}
+{%- for message in _msgs[::-1] %}
+    {%- set index = (_msgs | length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == 'user' %}
+        {%- set _rc = render_content(message.content, false) | trim %}
+        {%- if not (_rc.startswith('<tool_response>') and _rc.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {%- if _last_idx > 50 %}
+        {%- set ns.last_query_index = _last_idx %}
+    {%- else %}
+        {%- set ns.last_query_index = 0 %}
+    {%- endif %}
+{%- endif %}
+{%- set ns2 = namespace(prev_role='', consecutive_failures=0) %}
+{%- for message in _msgs %}
+    {%- set is_system = (message.role == "system" or message.role == "developer") %}
+    {%- set content = render_content(message.content, true, is_system) | trim %}
+    {%- if is_system or message.role == 'user' %}
+        {%- if '<|think_off|>' in content %}{%- set content = content.split('<|think_off|>') | join('') | trim %}{%- endif %}
+        {%- if '<|think_on|>' in content %}{%- set content = content.split('<|think_on|>') | join('') | trim %}{%- endif %}
+        {%- if '<|think_xhigh|>' in content %}{%- set content = content.split('<|think_xhigh|>') | join('') | trim %}{%- endif %}
+        {%- if '<|think_high|>' in content %}{%- set content = content.split('<|think_high|>') | join('') | trim %}{%- endif %}
+        {%- if '<|think_ultracode|>' in content %}{%- set content = content.split('<|think_ultracode|>') | join('') | trim %}{%- endif %}
+        {%- if '<|think_extreme|>' in content %}{%- set content = content.split('<|think_extreme|>') | join('') | trim %}{%- endif %}
+        {%- if '<|think_max|>' in content %}{%- set content = content.split('<|think_max|>') | join('') | trim %}{%- endif %}
+        {%- if '<|think_medium|>' in content %}{%- set content = content.split('<|think_medium|>') | join('') | trim %}{%- endif %}
+        {%- if '<|think_low|>' in content %}{%- set content = content.split('<|think_low|>') | join('') | trim %}{%- endif %}
+        {%- if '<|think_minimal|>' in content %}{%- set content = content.split('<|think_minimal|>') | join('') | trim %}{%- endif %}
+    {%- endif %}
+    {%- if is_system %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- elif message.role == 'user' %}
+        {%- set ns2.consecutive_failures = 0 %}
+        {{- '<|im_start|>user\n' + content + '<|im_end|>\n' }}
+    {%- elif message.role == 'assistant' %}
+        {%- set reasoning_content = '' %}
+        {%- set _explicit_reasoning = '' %}
+        {%- if message.reasoning_content is defined and message.reasoning_content is not none %}
+            {%- if message.reasoning_content is string %}
+                {%- set _explicit_reasoning = message.reasoning_content %}
+            {%- else %}
+                {%- set _explicit_reasoning = message.reasoning_content | string %}
+            {%- endif %}
+        {%- elif message.thinking is defined and message.thinking is not none %}
+            {%- if message.thinking is string %}
+                {%- set _explicit_reasoning = message.thinking %}
+            {%- else %}
+                {%- set _explicit_reasoning = message.thinking | string %}
+            {%- endif %}
+        {%- elif message.reasoning is defined and message.reasoning is not none %}
+            {%- if message.reasoning is string %}
+                {%- set _explicit_reasoning = message.reasoning %}
+            {%- else %}
+                {%- set _explicit_reasoning = message.reasoning | string %}
+            {%- endif %}
+        {%- endif %}
+        {%- if _explicit_reasoning %}
+            {%- set _lead_end = '' %}
+            {%- if content.startswith('<think>') and '</think>' in content %}
+                {%- set _lead_end = '</think>' %}
+            {%- elif content.startswith('<thinking>') and '</thinking>' in content %}
+                {%- set _lead_end = '</thinking>' %}
+            {%- elif content.startswith('</think>') %}
+                {%- set _lead_end = '</think>' %}
+            {%- elif content.startswith('</thinking>') %}
+                {%- set _lead_end = '</thinking>' %}
+            {%- endif %}
+            {%- if _lead_end %}
+                {%- set content = content.split(_lead_end)[-1].lstrip('\n') %}
+            {%- endif %}
+            {%- set reasoning_content = _explicit_reasoning %}
+        {%- else %}
+            {%- set _think_end = '' %}
+            {%- if content.startswith('</think>') %}
+                {%- set _think_end = '</think>' %}
+            {%- elif content.startswith('</thinking>') %}
+                {%- set _think_end = '</thinking>' %}
+            {%- elif '\n</think>' in content %}
+                {%- set _think_end = '\n</think>' %}
+            {%- elif '\n</thinking>' in content %}
+                {%- set _think_end = '\n</thinking>' %}
+            {%- elif '\n</ think>' in content %}
+                {%- set _think_end = '\n</ think>' %}
+            {%- elif '\n</think >' in content %}
+                {%- set _think_end = '\n</think >' %}
+            {%- elif content.startswith('<think>') and '</think>' in content %}
+                {%- set _think_end = '</think>' %}
+            {%- elif content.startswith('<thinking>') and '</thinking>' in content %}
+                {%- set _think_end = '</thinking>' %}
+            {%- endif %}
+            {%- if _think_end %}
+                {%- if 'thinking' in _think_end %}
+                    {%- set _think_start = '<thinking>' %}
+                {%- else %}
+                    {%- set _think_start = '<think>' %}
+                {%- endif %}
+                {%- set reasoning_content = content.split(_think_end)[0].rstrip('\n') %}
+                {%- if _think_start in reasoning_content %}
+                    {%- set reasoning_content = reasoning_content.split(_think_start)[-1].lstrip('\n') %}
+                {%- endif %}
+                {%- set content = content.split(_think_end)[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content | trim %}
+        {%- if (_preserve_thinking or loop.index0 > ns.last_query_index) %}
+            {{- '<|im_start|>assistant\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>assistant\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls is defined and message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined and tool_call.function is not none %}
+                    {%- set tc = tool_call.function %}
+                {%- else %}
+                    {%- set tc = tool_call %}
+                {%- endif %}
+                {%- set tc_name = tc.name if (tc.name is defined and tc.name is not none) else '' %}
+                {%- if _tool_format == 'json' %}
+                    {%- if loop.first %}
+                        {%- if content | trim %}
+                            {{- '\n\n' }}
+                        {%- endif %}
+                    {%- else %}
+                        {{- '\n' }}
+                    {%- endif %}
+                    {%- set _args = '{}' %}
+                    {%- if tc.arguments is defined and tc.arguments is not none %}
+                        {%- if tc.arguments is mapping %}
+                            {%- set _args = tc.arguments | tojson %}
+                        {%- elif tc.arguments is string %}
+                            {%- if tc.arguments %}
+                                {%- set _args = tc.arguments %}
+                            {%- endif %}
+                        {%- else %}
+                            {%- set _args = tc.arguments | tojson %}
+                        {%- endif %}
+                    {%- endif %}
+                    {{- '<tool_call>\n{"name": ' }}{{- tc_name | tojson }}{{- ', "arguments": ' }}{{- _args }}{{- '}\n</tool_call>' }}
+                {%- else %}
+                    {%- if loop.first %}
+                        {%- if content | trim %}
+                            {{- '\n\n<tool_call>\n<function=' + tc_name + '>\n' }}
+                        {%- else %}
+                            {{- '<tool_call>\n<function=' + tc_name + '>\n' }}
+                        {%- endif %}
+                    {%- else %}
+                        {{- '\n<tool_call>\n<function=' + tc_name + '>\n' }}
+                    {%- endif %}
+                    {%- if tc.arguments is defined and tc.arguments is not none %}
+                        {%- if tc.arguments is mapping %}
+                            {%- for args_name, args_value in tc.arguments.items() %}
+                                {{- '<parameter=' + args_name + '>\n' }}
+                                {%- if args_value is string %}
+                                    {%- set _av = args_value %}
+                                {%- else %}
+                                    {%- set _av = args_value | tojson %}
+                                {%- endif %}
+                                {%- if max_tool_arg_chars > 0 and _av | length > max_tool_arg_chars %}
+                                    {{- _av[:max_tool_arg_chars] + '\n[TRUNCATED - original length ' ~ (_av | length | string) ~ ' chars]' }}
+                                {%- else %}
+                                    {{- _av }}
+                                {%- endif %}
+                                {{- '\n</parameter>\n' }}
+                            {%- endfor %}
+                        {%- else %}
+                            {%- if tc.arguments is string %}
+                                {%- set _raw_args = tc.arguments %}
+                            {%- else %}
+                                {%- set _raw_args = tc.arguments | tojson %}
+                            {%- endif %}
+                            {%- if _raw_args %}
+                                {%- if max_tool_arg_chars > 0 and _raw_args | length > max_tool_arg_chars %}
+                                    {{- _raw_args[:max_tool_arg_chars] + '\n[TRUNCATED - original length ' ~ (_raw_args | length | string) ~ ' chars]' }}
+                                {%- else %}
+                                    {{- _raw_args }}
+                                {%- endif %}
+                            {%- endif %}
+                        {%- endif %}
+                    {%- endif %}
+                    {{- '</function>\n</tool_call>' }}
+                {%- endif %}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == 'tool' %}
+        {%- set _content_lower = content | lower %}
+        {%- set _content_head = _content_lower[:120] %}
+        {%- set _is_code_or_grep = ('throw new ' in _content_lower or 'throw error' in _content_lower or 'console.error' in _content_lower or 'logger.error' in _content_lower or 'logging.error' in _content_lower or 'import ' in _content_head or 'def ' in _content_head or 'function ' in _content_head) %}
+        {%- set _exit_code_zero = ('exit code: 0' in _content_head or 'process exited with code 0' in _content_head) %}
+        {%- set _error_field_ok = ('"error": null' in _content_head or '"error":null' in _content_head or '"error": false' in _content_head or '"error":false' in _content_head or '"error": ""' in _content_head or '"error":""' in _content_head) %}
+        {%- set _strong_error = (('"error":' in _content_head and not _error_field_ok) or '"status": "error"' in _content_head or '"status":"error"' in _content_head or 'traceback (most recent call last):' in _content_head or 'command not found' in _content_head or 'invalid syntax' in _content_head or 'fatal:' in _content_head or (('exit code: ' in _content_head or 'process exited with code' in _content_head) and not _exit_code_zero) or _content_head.startswith('exception:') or _content_head.startswith('failed to ')) %}
+        {%- set _weak_error = ('error:' in _content_head or 'err!' in _content_head) %}
+        {%- set _weak_suppressed = ('$ ' in _content_head or 'took ' in _content_head or content | length >= 600) %}
+        {%- if not _is_code_or_grep and (_strong_error or (_weak_error and not _weak_suppressed)) %}
+            {%- set ns2.consecutive_failures = ns2.consecutive_failures + 1 %}
+        {%- else %}
+            {%- set ns2.consecutive_failures = 0 %}
+        {%- endif %}
+        {%- if ns2.prev_role != 'tool' %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {%- if _tool_format != 'json' and max_tool_response_chars > 0 and content | length > max_tool_response_chars %}
+            {%- set content = content[:max_tool_response_chars] + '\n[TRUNCATED - original length ' ~ (content | length | string) ~ ' chars]' %}
+        {%- endif %}
+        {{- '\n<tool_response>\n' + content }}
+        {%- if ns2.consecutive_failures >= 2 %}
+            {{- '\n\n⚠️ SYSTEM WARNING: ' ~ ns2.consecutive_failures ~ ' consecutive tool errors detected. Your previous approach is incorrect. You MUST use a fundamentally different approach or corrected arguments.' }}
+        {%- elif ns2.consecutive_failures == 1 %}
+            {{- '\n\n⚠️ SYSTEM WARNING: The previous tool call returned an error. Diagnose the failure and retry with completely corrected arguments.' }}
+        {%- endif %}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- else %}
+            {%- set _next_role = _msgs[loop.index0 + 1].role %}
+            {%- if _next_role != 'tool' %}
+                {{- '<|im_end|>\n' }}
+            {%- endif %}
+        {%- endif %}
+    {%- else %}
+        {{- '<|im_start|>user\n[' + message.role + ']: ' + content + '<|im_end|>\n' }}
+    {%- endif %}
+    {%- set ns2.prev_role = message.role %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if not ns_state.thinking %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,9 @@
 # PORT and MODELS_DIR are read here: models live in ./models by default
 # (the same layout as the venv install, so both can share one download).
 # One GPU: run either "single" or "batch", not both.
+# KV_DISK_CACHE_HOST_DIR optionally selects the host directory for the
+# persistent KV/GDN filesystem tier.  Set KV_DISK_CACHE_DIR=/cache/kv-persist
+# as well to enable it; otherwise this mount remains unused.
 
 x-qwen: &qwen
   # Prebuilt on every main push by .github/workflows/docker-image.yml; the
@@ -38,6 +41,11 @@ x-qwen: &qwen
     HOME: /cache
   volumes:
     - ${MODELS_DIR:-./models}:/app/models
+    - ./single-user:/app/single-user
+    - ./batch:/app/batch
+    - ./bench:/app/bench
+    - ./patches:/app/patches
+    - ${KV_DISK_CACHE_HOST_DIR:-./kv-persist-cache}:/cache/kv-persist
     - qwen-cache:/cache
 
 x-serve: &serve

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Container entrypoint. First argument selects what to run:
 #   single   single-user/start_qwen.sh  (MTP speculative decoding, low latency)
+#            or start_with_warmup.sh when WARMUP_REQUEST_FILE is set
 #   batch    batch/start_qwen.sh        (throughput)
 #   prepare  docker/prepare.sh          (download + requantize the model into /app/models)
 #   verify   verify.sh [args]
@@ -12,17 +13,41 @@
 # FAIL (patches missing, ...); VERIFY=0 skips that.
 set -e
 cd /app
-cmd=${1:-single}; shift || true
+
+cmd=single
+if [ "$#" -gt 0 ]; then
+  cmd=$1
+  shift
+fi
+
 case "$cmd" in
   single|batch)
     if [ "${PREPARE:-1}" != "0" ]; then
       bash docker/prepare.sh
     fi
-    if [ "${VERIFY:-1}" != "0" ]; then
-      bash verify.sh --no-server || { echo "entrypoint: verify.sh FAILED — fix the above or set VERIFY=0"; exit 1; }
+    if [ "$(printenv VERIFY 2>/dev/null || true)" != "0" ]; then
+      bash verify.sh --no-server || {
+        echo "entrypoint: verify.sh FAILED — fix the above or set VERIFY=0"
+        exit 1
+      }
     fi
-    if [ "$cmd" = single ]; then exec bash single-user/start_qwen.sh "$@"; else exec bash batch/start_qwen.sh "$@"; fi ;;
-  prepare) exec bash docker/prepare.sh "$@" ;;
-  verify)  exec bash verify.sh "$@" ;;
-  *)       exec "$cmd" "$@" ;;
+    if [ "$cmd" = single ]; then
+      if printenv WARMUP_REQUEST_FILE >/dev/null 2>&1; then
+        exec bash single-user/start_with_warmup.sh "$@"
+      else
+        exec bash single-user/start_qwen.sh "$@"
+      fi
+    else
+      exec bash batch/start_qwen.sh "$@"
+    fi
+    ;;
+  prepare)
+    exec bash docker/prepare.sh "$@"
+    ;;
+  verify)
+    exec bash verify.sh "$@"
+    ;;
+  *)
+    exec "$cmd" "$@"
+    ;;
 esac

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,7 +1,8 @@
-# The stack every number in the READMEs was measured on. vllm==0.27.1 pins
-# torch 2.13.0 (cu130), triton 3.7.1 and flashinfer-python 0.6.16.post3 itself;
-# the rest is pinned to what the reference venv resolved to.
-vllm==0.27.1
+# The current vLLM runtime stack. The benchmark tables in the READMEs were
+# measured on the previous v0.27.1 stack and must be re-run after this upgrade.
+# vllm==0.28.0 resolves the compatible torch/cu130, Triton, and FlashInfer set;
+# the rest is pinned to the reference venv resolution.
+vllm==0.28.0
 transformers==5.15.0
 tokenizers==0.22.2
 compressed-tensors==0.17.0

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -17,3 +17,5 @@ ninja==1.13.0
 # members are for HF-hosted --dataset-name values and the plotting subcommands,
 # and this repo's scripts use only `random` and `custom`.
 pandas==3.0.5
+# Required by bench/quality_battery.py for GSM8K/parquet datasets.
+pyarrow==25.0.1

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,8 +4,9 @@ The container image (same stack, frozen) and an independent WSL2 reproduction wi
 
 [← back to the main README](../README.md)
 
-The container image is the same stack, frozen: Python 3.12 venv, vLLM 0.27.1 pinned
-(torch 2.13 / cu130 / Triton 3.7.1), every patch in `patches/` applied and
+The container image is the same stack, frozen: Python 3.12 venv, vLLM 0.28.0 pinned
+(torch 2.13 / cu130 / Triton 3.7.1), every compatible patch in `patches/` applied
+(`dflash2-backport.patch` is retired because DFlash2 is native in v0.28.0), and
 `verify.sh --install` run at build time, KVarN preinstalled. Host prerequisites:
 an NVIDIA driver that speaks CUDA 13 (≥ 580), Docker with the
 [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -172,7 +172,7 @@ Things that each cost us hours, in rough order of pain. Worth skimming before yo
     padded to `num_speculative_tokens` and a worker asking for fewer is ignored, silently.
     Adaptive block length (`LOOKUP=1` with `DFLASH_TOKENS > 7`) needs `ASYNC_SCHED=0`; at
     batch 1 that costs under 1%.
-22. **`--async-scheduling` is already the default in 0.27.1.** The flag exists and passing it
+22. **`--async-scheduling` is already the default in 0.28.0.** The flag exists and passing it
     changes nothing; `--no-async-scheduling` is what turns it off. Two hours of "the adaptive
     block isn't working" was this.
 23. **A longer verify block costs KV pool per request slot, not per token.**
@@ -540,7 +540,7 @@ Things that each cost us hours, in rough order of pain. Worth skimming before yo
     fixed by `patches/xgrammar-spec-terminated.patch`). A speculative verify window
     can legally accept tokens past the point where the xgrammar matcher terminates —
     the newline after a closing `</tool_call>` tag, the stop token itself, anything
-    after it under `ignore_eos`. 0.27.1 treats both arrivals as failure, the
+    after it under `ignore_eos`. The v0.28.0 base treats both arrivals as failure, the
     scheduler logs `Unexpected: grammar rejected tokens ... Terminating request`,
     and the client gets an HTTP error for a request whose output was completely
     valid. The longer the verify block, the more reliably the window covers the

--- a/docs/long-context.md
+++ b/docs/long-context.md
@@ -14,7 +14,7 @@ way past that is a smaller cache, not a different engine, and
 know of: Hadamard rotation + iterative variance normalization + 4-bit keys /
 2-bit values per 128-token tile, at ~840 B/token/layer here. It ships as a
 fork of vLLM 0.23; [kvarn/](../kvarn/) is our port of its dense backend onto the
-0.27.1 this repo runs (`bash kvarn/install.sh`, then `KV=kvarn` in batch mode
+0.28.0 this repo runs (`bash kvarn/install.sh`, then `KV=kvarn` in batch mode
 or `CTX=huge` in single-user mode).
 
 Measured on the 3090 (`--kv-cache-dtype kvarn_k4v2_g128 --block-size 128`,
@@ -73,7 +73,7 @@ set `KV=kvarn` (batch) or `CTX=huge` (single-user); the KV-cache format is an
 engine-level choice in vLLM, so it can't be switched per request. Port notes and what
 to watch when bumping vLLM are in [kvarn/README.md](../kvarn/README.md).
 
-(vLLM 0.27.1 also has TurboQuant built in — `--kv-cache-dtype turboquant_4bit_nc`
+(vLLM 0.28.0 also has TurboQuant built in — `--kv-cache-dtype turboquant_4bit_nc`
 gives a similar 413k-token pool here and about 15% slower decode, but its
 chunked-prefill path allocates O(context) scratch outside the memory profile
 and OOMs at 32k+ prompts on this card at 0.972 utilization, and at 128k even
@@ -81,7 +81,7 @@ at 0.90. KVarN's prefill path is bounded and did 240k.)
 
 ### The built-in per-token-head modes
 
-vLLM 0.27.1 also ships `int8_per_token_head`, `fp8_per_token_head` and
+vLLM 0.28.0 also ships `int8_per_token_head`, `fp8_per_token_head` and
 `int4_per_token_head` (dynamic per-token, per-head scales; the int4 one with a
 rotation and asymmetric zero-points), all only in the Triton attention
 backend. Measured on the 3090 in the batch config at 0.93 utilization, same

--- a/docs/optimizations.md
+++ b/docs/optimizations.md
@@ -208,15 +208,14 @@ plus a selector that walks a coherent path through 16 candidates per slot. On
 the bf16 model it reports 4.80 tokens per step vs 4.28 for MTP at the same block
 size. What it took to make it pay on a 24 GB card, in order:
 
-1. **Backport.** vLLM's support is [PR #52816](https://github.com/vllm-project/vllm/pull/52816)
-   on main, on the V2 model runner. `patches/dflash2-backport.patch` carries it to
-   0.27.1 plus the pieces of main it silently relies on (sentinel `-1` sample
-   rows, sliding-window null-block guards, K draft slots, NaN guards) and one
-   semantic fix: 0.27.1 caches temperature-*applied* draft logits, main caches
-   raw ones, and the PR's selector cached raw scores — on 0.27.1 that would have
-   verified against the wrong q for 0 < T ≠ 1. The draft also shares the target's
-   *quantized* lm_head (upstream refuses), and the V2 sampler now takes our
-   sort-free small-k top-k/top-p path. MTP mode is untouched (re-measured:
+1. **Native support plus the repo port.** vLLM's support is [PR #52816](https://github.com/vllm-project/vllm/pull/52816)
+   and is native in v0.28.0 on the V2 model runner. The old
+   `patches/dflash2-backport.patch` is retired on this tag; v0.28.0's native
+   implementation is layered with `patches/dflash2-lookup-drafting.patch` and
+   `patches/dflash2-ngram-chains.patch`, which carry the quantized candidate
+   head, context lookup, and drafter-free chain extensions. The DFlash2 port
+   also shares the target's *quantized* lm_head (upstream refuses), and the V2
+   sampler now takes our sort-free small-k top-k/top-p path. MTP mode is untouched (re-measured:
    110.7 / 113.4 tok/s, 73,777-token pool).
 2. **The drafter itself is 1.92B parameters, 3.85 GB in bf16** — read once per
    step, that is +5 ms on a 3090 and no gain (106 / 112 tok/s, measured), and it

--- a/kvarn/README.md
+++ b/kvarn/README.md
@@ -1,30 +1,33 @@
-# KVarN KV cache, ported to vLLM 0.27.1
+# KVarN KV cache, ported to vLLM 0.28.0
 
 [KVarN](https://github.com/huawei-csl/KVarN) (Huawei CSL, Apache-2.0) is a
 KV-cache compression scheme — Hadamard rotation, iterative variance
 normalization, 4-bit keys / 2-bit values per 128-token tile — shipped as a
 native vLLM attention backend inside a fork of vLLM 0.23.0. This directory is
-that backend ported onto the vLLM 0.27.1 this repo runs, dense (non-MLA) path
+that backend ported onto the vLLM 0.28.0 this repo runs, dense (non-MLA) path
 only, and tuned for the Qwen3.8-27B / RTX 3090 setup here.
 
 What's in it:
 
 - `files/vllm/...` — the KVarN modules (backend, Triton kernels, config,
-  Sinkhorn reference), copied from KVarN and adapted to the 0.27.1 backend API
-  (every change is marked `# port(0.27.1)`; upstream KVarN headers kept).
-- `kvarn-0.27.1.patch` — the seven small hunks upstream vLLM needs to know the
+  Sinkhorn reference), copied from KVarN and adapted to the 0.28.0 backend API
+  (the original adaptation markers are retained in the source files).
+- `kvarn-0.28.0.patch` — the small hunks upstream vLLM needs to know the
   new `kvarn_*` cache dtypes (cache dtype literals, dtype map, backend registry
   + priority, a `KVQuantMode.KVARN`, the KV-cache spec branch in the attention
   layer, and the hybrid-model page alignment branch).
+- `kvarn-v2-runner-0.28.0.patch` — the V2 runner, sliding-cache, and DFlash2
+  correctness fixes layered on top of the base port.
 - `install.sh` — copies the modules into `venv/lib/python3.12/site-packages/vllm`
   and applies the patch (safe to re-run).
 
 Port notes, for whoever bumps vLLM next:
 
-- 0.27.1 calls `get_kv_cache_shape(..., cache_dtype_str="auto")` for specs
-  whose `kv_quant_mode` is `NONE`; KVarN's shape depends on the preset, so the
-  port adds `KVQuantMode.KVARN` and passes it through the (reused)
-  `TQFullAttentionSpec`. Without that the engine dies at KV-cache init.
+- 0.28.0's attention spec uses `cache_dtype_str="auto"` for specs whose
+  `kv_quant_mode` is `NONE`; KVarN's shape depends on the preset, so the port
+  adds `KVQuantMode.KVARN` and passes the packed slot size through
+  `FullAttentionSpec(state_content_bytes=...)`. Without that the engine dies
+  at KV-cache init.
 - The impl→builder wiring uses `get_layers_from_vllm_config` instead of
   KVarN's `attention.py` `impl.layer_name` hunk, and a small owner registry so
   the MTP draft layer isn't flushed by two builders.

--- a/kvarn/files/vllm/v1/attention/ops/triton_kvarn_decode.py
+++ b/kvarn/files/vllm/v1/attention/ops/triton_kvarn_decode.py
@@ -983,15 +983,17 @@ def kvarn_verify_attention(
 
     # Split-K mirrors the decode driver's heuristic: long context with too few
     # programs to fill the SMs. Verify batches are tiny (NQ <= maxq * B), so
-    # long-context verify nearly always wants the split.
+    # long-context verify nearly always wants the split.  The one-stage
+    # VQ_INDIRECT kernel is not numerically safe for this long-context regime
+    # on sm86: it can return finite but incorrect logits for a multi-token
+    # verify step.  Keep `KVARN_SPLIT_K=1` as an explicit force, but do not
+    # allow `KVARN_SPLIT_K=0` to disable the correctness-required auto split.
     sm_count = getattr(impl, "_sm_count", 0) or torch.cuda.get_device_properties(
         device).multi_processor_count
     _sw = int(getattr(impl, "sliding_window", 0) or 0)
     _sk_env = os.environ.get("KVARN_SPLIT_K")
-    if _sk_env is not None:
-        split_k = _sk_env == "1"
-    else:
-        split_k = (_sw <= 0) and (max_ctx_blocks >= 16) and (NQ * Hk <= sm_count)
+    auto_split = (_sw <= 0) and (max_ctx_blocks >= 16) and (NQ * Hk <= sm_count)
+    split_k = _sk_env == "1" or auto_split
 
     if not split_k:
         _kvarn_fused_decode_kernel[(NQ, Hk)](

--- a/kvarn/files/vllm/v1/attention/ops/triton_kvarn_decode.py
+++ b/kvarn/files/vllm/v1/attention/ops/triton_kvarn_decode.py
@@ -981,19 +981,15 @@ def kvarn_verify_attention(
 
     common["VQ_INDIRECT"] = True
 
-    # Split-K mirrors the decode driver's heuristic: long context with too few
-    # programs to fill the SMs. Verify batches are tiny (NQ <= maxq * B), so
-    # long-context verify nearly always wants the split.  The one-stage
-    # VQ_INDIRECT kernel is not numerically safe for this long-context regime
-    # on sm86: it can return finite but incorrect logits for a multi-token
-    # verify step.  Keep `KVARN_SPLIT_K=1` as an explicit force, but do not
-    # allow `KVARN_SPLIT_K=0` to disable the correctness-required auto split.
-    sm_count = getattr(impl, "_sm_count", 0) or torch.cuda.get_device_properties(
-        device).multi_processor_count
+    # Split-K mirrors the decode driver's long-context heuristic. Verify
+    # batches are tiny (NQ <= maxq * B), so the one-stage VQ_INDIRECT kernel
+    # can return finite but incorrect logits on the long-context sm86 path.
+    # KVARN_SPLIT_K=1 is an explicit force-on; KVARN_SPLIT_K=0 does not disable
+    # the correctness-required auto split.
     _sw = int(getattr(impl, "sliding_window", 0) or 0)
     _sk_env = os.environ.get("KVARN_SPLIT_K")
-    auto_split = (_sw <= 0) and (max_ctx_blocks >= 16) and (NQ * Hk <= sm_count)
-    split_k = _sk_env == "1" or auto_split
+    auto_split = (_sw <= 0) and (max_ctx_blocks >= 16)
+    split_k = auto_split or _sk_env == "1"
 
     if not split_k:
         _kvarn_fused_decode_kernel[(NQ, Hk)](

--- a/kvarn/install.sh
+++ b/kvarn/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Install the KVarN KV-cache port into this repo's vLLM 0.27.1 venv:
+# Install the KVarN KV-cache port into this repo's vLLM 0.28.0 venv:
 # copies the new modules into site-packages/vllm and applies the upstream hunks.
 # usage: bash kvarn/install.sh            (idempotent-ish: re-copying files is fine;
 #        the patch is applied with --forward so a second run is a no-op)
@@ -10,10 +10,10 @@ PY=${PY:-$REPO/venv/bin/python}
 SP=$("$PY" -c 'import vllm, os; print(os.path.dirname(vllm.__file__))' 2>/dev/null | tail -n1)
 [ -n "$SP" ] && [ -d "$SP" ] || { echo "cannot import vllm with $PY (README: Setup)"; exit 1; }
 cp -r "$HERE/files/vllm/." "$SP/"
-patch -p1 -N -r /dev/null -d "$SP" < "$HERE/kvarn-0.27.1.patch" || true
+patch -p1 -N -r /dev/null -d "$SP" < "$HERE/kvarn-0.28.0.patch" || true
 # V2-runner port: lets SPEC=dflash2 run with CTX=huge (KVarN KV + prefix caching, 240k).
-# Depends on hunks from both the patches/ set and kvarn-0.27.1.patch, hence applied last.
-patch -p1 -N -r /dev/null -d "$SP" < "$HERE/kvarn-v2-runner.patch" || true
+# Depends on hunks from both the patches/ set and kvarn-0.28.0.patch, hence applied last.
+patch -p1 -N -r /dev/null -d "$SP" < "$HERE/kvarn-v2-runner-0.28.0.patch" || true
 find "$SP" -type d -name __pycache__ -path "*kvarn*" -prune -exec rm -rf {} + 2>/dev/null || true
 "$PY" - "$SP" "$HERE" <<'PY'
 import sys
@@ -35,7 +35,7 @@ print("tile bytes", c.tile_bytes, "-> per token per head", c.tile_bytes_aligned 
 # counting them per file says exactly which ones did not land.
 sp, here = Path(sys.argv[1]), Path(sys.argv[2])
 want, current = {}, None
-for line in (here / "kvarn-v2-runner.patch").read_text().splitlines():
+for line in (here / "kvarn-v2-runner-0.28.0.patch").read_text().splitlines():
     if line.startswith("+++ b/"):
         current = line[len("+++ b/"):].strip()
         want.setdefault(current, 0)
@@ -48,7 +48,7 @@ for rel, expected in sorted(want.items()):
     if found < expected:
         short.append(f"  {rel}: {found}/{expected} markers")
 if short:
-    print("\nERROR: kvarn-v2-runner.patch did not apply completely:", file=sys.stderr)
+    print("\nERROR: kvarn-v2-runner-0.28.0.patch did not apply completely:", file=sys.stderr)
     print("\n".join(short), file=sys.stderr)
     print(
         "\nThis vLLM tree differs from the one the patch was cut against.\n"

--- a/kvarn/kvarn-0.28.0.patch
+++ b/kvarn/kvarn-0.28.0.patch
@@ -1,0 +1,219 @@
+KVarN dense KV-cache integration for vLLM 0.28.0.
+
+The 0.28 KV cache API uses KVQuantMode values and FullAttentionSpec.state_content_bytes rather than the old TQFullAttentionSpec/tq_slot_size representation. This port preserves the packed KVarN tile layout and tail-pool budgeting on the new interfaces.
+
+--- generated against the v0.28.0 tree after the active repo patches ---
+
+--- a/config/cache.py
++++ b/config/cache.py
+@@ -29,6 +29,10 @@
+     "turboquant_4bit_nc",
+     "turboquant_k3v4_nc",
+     "turboquant_3bit_nc",
++    "kvarn_k4v2_g128",
++    "kvarn_k4v4_g128",
++    "kvarn_k4v2_g64",
++    "kvarn_k4v4_g64",
+     "int4_per_token_head",
+     "int8_per_token_head",
+     "fp8_per_token_head",
+--- a/model_executor/layers/attention/attention.py
++++ b/model_executor/layers/attention/attention.py
+@@ -645,6 +645,26 @@
+                 page_size_padded=shared_page,
+             )
+         else:
++            if isinstance(self.kv_cache_dtype, str) and self.kv_cache_dtype.startswith(
++                "kvarn_"
++            ):
++                from vllm.model_executor.layers.quantization.kvarn.config import (
++                    KVarNConfig,
++                )
++
++                kvarn_config = KVarNConfig.from_cache_dtype(
++                    self.kv_cache_dtype, self.head_size
++                )
++                slot_bytes = kvarn_config.tile_bytes_aligned // kvarn_config.group
++                return FullAttentionSpec(
++                    block_size=block_size,
++                    num_kv_heads=self.num_kv_heads,
++                    head_size=self.head_size,
++                    head_size_v=self.head_size_v,
++                    dtype=self.kv_cache_torch_dtype,
++                    kv_quant_mode=quant_mode,
++                    state_content_bytes=slot_bytes,
++                )
+             return FullAttentionSpec(
+                 block_size=block_size,
+                 num_kv_heads=self.num_kv_heads,
+--- a/platforms/cuda.py
++++ b/platforms/cuda.py
+@@ -151,6 +151,7 @@
+                 AttentionBackendEnum.FLASH_ATTN,
+                 AttentionBackendEnum.TRITON_ATTN,
+                 AttentionBackendEnum.FLEX_ATTENTION,
++                AttentionBackendEnum.KVARN,
+                 AttentionBackendEnum.TURBOQUANT,
+             ]
+         else:
+@@ -159,6 +160,7 @@
+                 AttentionBackendEnum.FLASHINFER,
+                 AttentionBackendEnum.TRITON_ATTN,
+                 AttentionBackendEnum.FLEX_ATTENTION,
++                AttentionBackendEnum.KVARN,
+                 AttentionBackendEnum.TURBOQUANT,
+             ]
+ 
+@@ -349,7 +351,71 @@
+                 "To raise the WSL2 VM memory ceiling, increase the `memory` "
+                 "setting in %%USERPROFILE%%\\.wslconfig and run "
+                 "`wsl --shutdown`."
++            )
++
++        # KVarN keeps a fixed-size fp16 tail pool for each active request.
++        # Bound scheduler concurrency to the pool budget before worker startup;
++        # the backend itself cannot safely grow this allocation after CUDA graph
++        # buffers have been created.
++        cache_config = vllm_config.cache_config
++        cache_dtype = getattr(cache_config, "cache_dtype", None)
++        if (
++            model_config is not None
++            and isinstance(cache_dtype, str)
++            and cache_dtype.startswith("kvarn_")
++            and not getattr(model_config, "use_mla", False)
++        ):
++            from vllm.model_executor.layers.quantization.kvarn.config import (
++                KVarNConfig,
++            )
++
++            head_size = model_config.get_head_size()
++            if head_size not in (128, 256, 512):
++                raise ValueError(
++                    f"{cache_dtype} requires head_dim in (128, 256, 512), "
++                    f"but this model has head_dim={head_size}."
++                )
++
++            # KVarN's dense backend has no sliding-window mask. Preserve the
++            # full-precision SW layers in hybrid models unless explicitly opted in.
++            hf_text_config = getattr(model_config, "hf_text_config", None)
++            layer_types = getattr(hf_text_config, "layer_types", None)
++            has_swa = (
++                "sliding_attention" in layer_types
++                if layer_types
++                else getattr(hf_text_config, "sliding_window", None) is not None
++            )
++            skip_layers = cache_config.kv_cache_dtype_skip_layers
++            if os.environ.get("KVARN_QUANT_SLIDING") == "1":
++                while "sliding_window" in skip_layers:
++                    skip_layers.remove("sliding_window")
++            elif has_swa and "sliding_window" not in skip_layers:
++                skip_layers.append("sliding_window")
++
++            kvarn_cfg = KVarNConfig.from_cache_dtype(cache_dtype, head_size)
++            weight_bytes = kvarn_cfg.estimate_weight_bytes(
++                model_config.model,
++                tensor_parallel_size=parallel_config.tensor_parallel_size,
++            )
++            supported = kvarn_cfg.max_supported_seqs(
++                total_gpu_bytes=cls.get_device_total_memory(),
++                num_kv_heads=model_config.get_num_kv_heads(parallel_config),
++                num_layers=KVarNConfig.num_kvarn_layers(
++                    model_config, parallel_config
++                ),
++                max_num_batched_tokens=scheduler_config.max_num_batched_tokens,
++                gpu_memory_utilization=cache_config.gpu_memory_utilization,
++                weight_bytes=weight_bytes,
+             )
++            if scheduler_config.max_num_seqs > supported:
++                logger.warning(
++                    "KVarN (%s): capping max_num_seqs %d -> %d for the fp16 "
++                    "tail-pool budget.",
++                    cache_dtype,
++                    scheduler_config.max_num_seqs,
++                    supported,
++                )
++                scheduler_config.max_num_seqs = supported
+ 
+     @classmethod
+     def get_current_memory_usage(
+--- a/platforms/interface.py
++++ b/platforms/interface.py
+@@ -807,6 +807,23 @@
+                 dtype=kv_cache_dtype,
+                 kv_quant_mode=kv_quant_mode,
+             ).page_size_bytes
++        elif cache_config.cache_dtype.startswith("kvarn_"):
++            from vllm.model_executor.layers.quantization.kvarn.config import (
++                KVarNConfig,
++            )
++
++            kvarn_config = KVarNConfig.from_cache_dtype(
++                cache_config.cache_dtype, model_config.get_head_size()
++            )
++            slot_bytes = kvarn_config.tile_bytes_aligned // kvarn_config.group
++            attn_page_size_1_token = FullAttentionSpec(
++                block_size=1,
++                num_kv_heads=model_config.get_num_kv_heads(parallel_config),
++                head_size=model_config.get_head_size(),
++                dtype=kv_cache_dtype,
++                kv_quant_mode=kv_quant_mode,
++                state_content_bytes=slot_bytes,
++            ).page_size_bytes
+         elif cache_config.cache_dtype.startswith("turboquant_"):
+             # TQ has a packed K|V layout; the standard FullAttentionSpec
+             # formula over-sizes it and trips unify_kv_cache_spec_page_size
+--- a/utils/torch_utils.py
++++ b/utils/torch_utils.py
+@@ -49,6 +49,10 @@
+     "turboquant_4bit_nc": torch.uint8,
+     "turboquant_k3v4_nc": torch.uint8,
+     "turboquant_3bit_nc": torch.uint8,
++    "kvarn_k4v2_g128": torch.uint8,
++    "kvarn_k4v4_g128": torch.uint8,
++    "kvarn_k4v2_g64": torch.uint8,
++    "kvarn_k4v4_g64": torch.uint8,
+     "nvfp4": torch.uint8,
+     "nvfp4_4over6": torch.uint8,
+ }
+--- a/v1/attention/backends/registry.py
++++ b/v1/attention/backends/registry.py
+@@ -123,6 +123,7 @@
+     )
+     CPU_ATTN = "vllm.v1.attention.backends.cpu_attn.CPUAttentionBackend"
+     CPU_MLA = "vllm.v1.attention.backends.mla.cpu_mla.CPUMLABackend"
++    KVARN = "vllm.v1.attention.backends.kvarn_attn.KVarNAttentionBackend"
+     TURBOQUANT = "vllm.v1.attention.backends.turboquant_attn.TurboQuantAttentionBackend"
+     # Placeholder for third-party/custom backends - must be registered before use
+     # set to None to avoid alias with other backend, whose value is an empty string
+--- a/v1/kv_cache_interface.py
++++ b/v1/kv_cache_interface.py
+@@ -51,6 +51,7 @@
+     TURBOQUANT_4BIT_NC = 7
+     TURBOQUANT_K3V4_NC = 8
+     TURBOQUANT_3BIT_NC = 9
++    KVARN = 10
+ 
+     @property
+     def is_per_token_head(self) -> bool:
+@@ -75,6 +76,11 @@
+             KVQuantMode.TURBOQUANT_K3V4_NC,
+             KVQuantMode.TURBOQUANT_3BIT_NC,
+         )
++
++    @property
++    def is_kvarn(self) -> bool:
++        """True for KVarN packed KV-cache quantization."""
++        return self == KVQuantMode.KVARN
+ 
+ 
+ def get_kv_quant_mode(kv_cache_dtype: str) -> KVQuantMode:
+@@ -89,6 +95,8 @@
+         return KVQuantMode.NVFP4
+     if isinstance(kv_cache_dtype, str) and kv_cache_dtype.startswith("turboquant_"):
+         return KVQuantMode[kv_cache_dtype.upper()]
++    if isinstance(kv_cache_dtype, str) and kv_cache_dtype.startswith("kvarn_"):
++        return KVQuantMode.KVARN
+     if isinstance(kv_cache_dtype, str) and kv_cache_dtype.startswith("fp8"):
+         return KVQuantMode.FP8_PER_TENSOR
+     return KVQuantMode.NONE
+

--- a/kvarn/kvarn-0.28.0.patch
+++ b/kvarn/kvarn-0.28.0.patch
@@ -219,7 +219,7 @@ The 0.28 KV cache API uses KVQuantMode values and FullAttentionSpec.state_conten
 
 --- a/v1/worker/gpu/attn_utils.py
 +++ b/v1/worker/gpu/attn_utils.py
-@@ -305,7 +305,15 @@
+@@ -305,5 +305,12 @@
          )
          dtype_size = get_dtype_size(kv_cache_spec.dtype)
 -        page_stride = kv_cache_spec.page_size_bytes // dtype_size

--- a/kvarn/kvarn-0.28.0.patch
+++ b/kvarn/kvarn-0.28.0.patch
@@ -217,3 +217,19 @@ The 0.28 KV cache API uses KVQuantMode values and FullAttentionSpec.state_conten
          return KVQuantMode.FP8_PER_TENSOR
      return KVQuantMode.NONE
 
+--- a/v1/worker/gpu/attn_utils.py
++++ b/v1/worker/gpu/attn_utils.py
+@@ -305,7 +305,15 @@
+         )
+         dtype_size = get_dtype_size(kv_cache_spec.dtype)
+-        page_stride = kv_cache_spec.page_size_bytes // dtype_size
++        if kv_cache_spec.kv_quant_mode.is_kvarn:
++            # KVarN stores one packed tile per block/head. Hybrid page
++            # unification may publish a larger padded page size for the
++            # shared allocation, but KVarN's physical block stride remains
++            # its packed (unpadded) page size.
++            page_stride = kv_cache_spec.real_page_size_bytes // dtype_size
++        else:
++            page_stride = kv_cache_spec.page_size_bytes // dtype_size
+ 
+         num_blocks_dim = inv_order[0]

--- a/kvarn/kvarn-0.28.0.patch
+++ b/kvarn/kvarn-0.28.0.patch
@@ -225,10 +225,10 @@ The 0.28 KV cache API uses KVQuantMode values and FullAttentionSpec.state_conten
 -        page_stride = kv_cache_spec.page_size_bytes // dtype_size
 +        if kv_cache_spec.kv_quant_mode.is_kvarn:
 +            # KVarN stores one packed tile per block/head. Hybrid page
-+            # unification may publish a larger padded page size for the
-+            # shared allocation, but KVarN's physical block stride remains
-+            # its packed (unpadded) page size.
-+            page_stride = kv_cache_spec.real_page_size_bytes // dtype_size
++            # unification may publish a larger logical page (including
++            # num_head_slots), but the physical block stride is the packed
++            # backend shape: one tile for every physical KV head.
++            page_stride = prod(kv_cache_shape[1:])
 +        else:
 +            page_stride = kv_cache_spec.page_size_bytes // dtype_size
  

--- a/kvarn/kvarn-v2-runner-0.28.0.patch
+++ b/kvarn/kvarn-v2-runner-0.28.0.patch
@@ -51,6 +51,20 @@ These changes are applied after the 0.28 KVarN base port and the repo's DFlash2 
      if not candidates:
          return fallback
      smallest = min(candidates)
+@@ -619,6 +636,13 @@
+             # bytes per block. Otherwise (page_size_padded is None) the smallest
+             # block is fine — ``unify`` scales it up by an integer ratio.
+             shared_page = vllm_config.cache_config.skip_page_size_padded
++            # port(kvarn-v2): hybrid without skip layers: pad the drafter's
++            # SW pages to the mamba/primary page instead of wasting 16-token
++            # blocks inside 1.8 MB uniform pages (26x overhead).
++            if shared_page is None and str(
++                vllm_config.cache_config.cache_dtype
++            ).startswith("kvarn"):
++                shared_page = vllm_config.cache_config.mamba_page_size_padded
+             # The backend owns its packing
+             sw_per_token = self.attn_backend.customize_spec(
+                 SlidingWindowSpec(
 --- a/v1/core/kv_cache_utils.py
 +++ b/v1/core/kv_cache_utils.py
 @@ -635,7 +635,19 @@

--- a/kvarn/kvarn-v2-runner-0.28.0.patch
+++ b/kvarn/kvarn-v2-runner-0.28.0.patch
@@ -1,0 +1,194 @@
+KVarN V2-runner compatibility fixes for vLLM 0.28.0.
+
+These changes are applied after the 0.28 KVarN base port and the repo's DFlash2 patches. They keep sliding-window groups out of prefix-cache arithmetic, use the Mamba group's block size for resumed-state indexing, and harden DFlash2 selector buffers against degenerate scores.
+
+--- generated against the v0.28.0 tree after the active repo and KVarN base patches ---
+
+--- a/model_executor/models/qwen3_dflash.py
++++ b/model_executor/models/qwen3_dflash.py
+@@ -244,6 +244,15 @@
+         )
+ 
+         self.sliding_window = sliding_window
++        # KVarN has no sliding-window backend; keep the drafter's SW layers in
++        # the native cache dtype while the target full-attention layers use KVarN.
++        if cache_config is not None and str(
++            getattr(cache_config, "cache_dtype", "auto")
++        ).startswith("kvarn"):
++            from copy import copy as _kv_copy
++
++            cache_config = _kv_copy(cache_config)
++            cache_config.cache_dtype = "auto"
+         self.attn = Attention(
+             self.num_heads,
+             self.head_dim,
+--- a/model_executor/layers/attention/attention.py
++++ b/model_executor/layers/attention/attention.py
+@@ -110,8 +110,25 @@
+ 
+     sizes = attn_backend.get_supported_kernel_block_sizes()
+     candidates = [s for s in sizes if isinstance(s, int)]
++    mults = [s.base for s in sizes if isinstance(s, MultipleOf)]
++    if mults and page_budget and per_token_bytes > 0:
++        base = min(mults)
++        budget_tokens = page_budget // per_token_bytes
++        scaled = budget_tokens // base * base
++        if fallback and fallback > 0:
++            for step in (128, base):
++                found = 0
++                for d in range(budget_tokens, step - 1, -1):
++                    if fallback % d == 0 and d % step == 0:
++                        found = d
++                        break
++                if found:
++                    scaled = found
++                    break
++        if scaled >= base:
++            candidates.append(scaled)
+     if not candidates:
+-        candidates = [s.base for s in sizes if isinstance(s, MultipleOf)]
++        candidates = mults
+     if not candidates:
+         return fallback
+     smallest = min(candidates)
+--- a/v1/core/kv_cache_utils.py
++++ b/v1/core/kv_cache_utils.py
+@@ -635,7 +635,17 @@
+         if isinstance(g.kv_cache_spec, AttentionSpec)
+         else g.kv_cache_spec.block_size
+         for g in groups
++    ]
++    # Sliding-window groups do not participate in prefix matching. Excluding
++    # them keeps their small rolling-window block from skewing the scheduler
++    # LCM and the prefix-hash GCD used by the target group.
++    non_sw = [
++        bs
++        for g, bs in zip(groups, group_block_sizes)
++        if not isinstance(g.kv_cache_spec, SlidingWindowSpec)
+     ]
++    if non_sw:
++        group_block_sizes = non_sw
+     scheduler_block_size = math.lcm(*group_block_sizes)
+ 
+     # Block hashes are only consumed by prefix caching and KV connectors
+@@ -648,7 +658,7 @@
+     # Mamba groups outside align mode break divisibility; back off to the
+     # scheduler block size. Read the mode from the resolved group spec because
+     # its block size may have been updated independently of cache_config.
+-    if any(
++    if cache_config.prefix_match_unit is None and any(
+         isinstance(g.kv_cache_spec, MambaSpec)
+         and g.kv_cache_spec.mamba_cache_mode != "align"
+         for g in groups
+--- a/v1/core/kv_cache_coordinator.py
++++ b/v1/core/kv_cache_coordinator.py
+@@ -601,7 +601,9 @@
+             manager.block_size for manager in self.single_type_managers
+         ]
+         assert all(
+-            block_size % hash_block_size == 0 for block_size in group_block_sizes
++            block_size % hash_block_size == 0
++            or hash_block_size % block_size == 0
++            for block_size in group_block_sizes
+         ), (
+             "Each KV cache group's real block_size must be divisible by "
+             f"hash_block_size. block_sizes={group_block_sizes}, "
+--- a/v1/core/single_type_kv_cache_manager.py
++++ b/v1/core/single_type_kv_cache_manager.py
+@@ -918,6 +918,11 @@
+         assert dcp_world_size == 1, "DCP not support sliding window attn now."
+         assert pcp_world_size == 1, "PCP not support sliding window attn now."
+         # Fine-grained partial hits are not supported for sliding window now
++        if (
++            kv_cache_spec.block_size % block_pool.hash_block_size != 0
++            or alignment_tokens % kv_cache_spec.block_size != 0
++        ):
++            return tuple([] for _ in kv_cache_group_ids), 0
+         assert alignment_tokens % kv_cache_spec.block_size == 0, (
+             "SlidingWindowManager does not support fine-grained (partial) cache hits"
+         )
+@@ -1105,6 +1110,19 @@
+         window in the future.
+         """
+         return 0
++
++    def cache_blocks(
++        self,
++        request: Request,
++        num_tokens: int,
++        retention_interval: int | None = None,
++    ) -> None:
++        # Prefix reuse is not meaningful for a rolling window. Skip the write
++        # path when the SW block and hash unit are not divisible in either
++        # direction; otherwise resolve_block_hashes would assert later.
++        if self.block_size % self.block_pool.hash_block_size != 0:
++            return
++        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+ 
+ 
+ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
+--- a/v1/worker/gpu/model_states/mamba_hybrid.py
++++ b/v1/worker/gpu/model_states/mamba_hybrid.py
+@@ -100,8 +100,13 @@
+         self.num_accepted_tokens_gpu[req_index].fill_(1)
+         if self._align_mode:
+             # Seed the running state block from the resumed/prefilled position.
++            mamba_bs = (
++                self._mamba_spec.block_size
++                if self._mamba_spec is not None
++                else self.cache_config.block_size
++            )
+             self._mamba_state_idx_gpu[req_index].fill_(
+-                (new_req_data.num_computed_tokens - 1) // self.cache_config.block_size
++                (new_req_data.num_computed_tokens - 1) // mamba_bs
+             )
+ 
+     def _get_mamba_group_info(
+--- a/v1/worker/gpu/spec_decode/dflash2/speculator.py
++++ b/v1/worker/gpu/spec_decode/dflash2/speculator.py
+@@ -94,6 +94,9 @@
+             temperature if SAMPLE_PROBABILISTIC else 0.0,
+             USE_FP64=USE_FP64,
+         )
++        # A degenerate distribution can produce NaN scores. Keep the walk in
++        # bounds; the verify step will reject any bad proposal.
++        index = tl.where(index >= top_k, 0, index)
+         # vLLM 0.28.0's rejection sampler expects pre-temperature logits. With TRUNCATE
+         # the cached row is the truncated proposal (-inf outside the kept support).
+         realized = scores
+@@ -157,7 +160,7 @@
+             torch.arange(self.max_num_reqs, dtype=torch.int64, device=device)
+             * self.num_query_per_req
+         )
+-        self._selector_tokens = torch.empty(
++        self._selector_tokens = torch.zeros(
+             (self.max_num_reqs, self.draft_block),
+             dtype=self.draft_tokens.dtype,
+             device=device,
+@@ -717,6 +720,7 @@
+             hidden_states,
+             anchor_token_ids,
+         )
++        scores = torch.nan_to_num(scores, nan=-1e30, posinf=1e30, neginf=-1e30)
+         self._sample_path(candidate_ids, scores, num_reqs)
+         if self.draft_logits is not None:
+             self._cache_draft_logits(candidate_ids, num_sample)
+--- a/v1/worker/gpu/model_runner.py
++++ b/v1/worker/gpu/model_runner.py
+@@ -1115,9 +1115,14 @@
+             is_prefilling_np=is_prefilling_np,
+             has_prefill=bool(is_prefilling_np.any()),
+         )
+-        return batch_state, get_uniform_decode_token_count(
++        uniform_decode_token_count = get_uniform_decode_token_count(
+             num_reqs, num_toks, max_query_len, batch_state.has_prefill
+         )
++        # A uniform-looking final prefill chunk is still prefill. Do not route
++        # it through a captured speculative-decode graph on a prefix-cache hit.
++        if uniform_decode_token_count is not None and batch_state.has_prefill:
++            uniform_decode_token_count = None
++        return batch_state, uniform_decode_token_count
+ 
+     def prepare_inputs(
+         self,
+

--- a/kvarn/kvarn-v2-runner-0.28.0.patch
+++ b/kvarn/kvarn-v2-runner-0.28.0.patch
@@ -53,11 +53,12 @@ These changes are applied after the 0.28 KVarN base port and the repo's DFlash2 
      smallest = min(candidates)
 --- a/v1/core/kv_cache_utils.py
 +++ b/v1/core/kv_cache_utils.py
-@@ -635,7 +635,17 @@
+@@ -635,7 +635,19 @@
          if isinstance(g.kv_cache_spec, AttentionSpec)
          else g.kv_cache_spec.block_size
          for g in groups
 +    ]
++    _all_group_block_sizes = list(group_block_sizes)
 +    # Sliding-window groups do not participate in prefix matching. Excluding
 +    # them keeps their small rolling-window block from skewing the scheduler
 +    # LCM and the prefix-hash GCD used by the target group.
@@ -66,6 +67,7 @@ These changes are applied after the 0.28 KVarN base port and the repo's DFlash2 
 +        for g, bs in zip(groups, group_block_sizes)
 +        if not isinstance(g.kv_cache_spec, SlidingWindowSpec)
      ]
++    _hash_gcd_all = math.gcd(*_all_group_block_sizes)
 +    if non_sw:
 +        group_block_sizes = non_sw
      scheduler_block_size = math.lcm(*group_block_sizes)
@@ -80,16 +82,40 @@ These changes are applied after the 0.28 KVarN base port and the repo's DFlash2 
          isinstance(g.kv_cache_spec, MambaSpec)
          and g.kv_cache_spec.mamba_cache_mode != "align"
          for g in groups
+@@ -655,3 +667,3 @@
+         for g in groups
+     ):
+-        return scheduler_block_size, scheduler_block_size
++        return scheduler_block_size, _hash_gcd_all
+@@ -668,4 +680,4 @@
+     requested = cache_config.prefix_match_unit
+     hash_block_size = (
+-        requested if requested is not None else math.gcd(*group_block_sizes)
++        requested if requested is not None else _hash_gcd_all
+     )
 --- a/v1/core/kv_cache_coordinator.py
 +++ b/v1/core/kv_cache_coordinator.py
-@@ -601,7 +601,9 @@
+@@ -86,7 +86,8 @@
+         self.enable_caching = enable_caching
+         # The scheduling granularity (LCM of all group block sizes), must be a multiple
+         # of the hash_block_size and the block size of each group.
+         assert scheduler_block_size % hash_block_size == 0 and all(
+-            scheduler_block_size % g.kv_cache_spec.block_size == 0
++            isinstance(g.kv_cache_spec, SlidingWindowSpec)
++            or scheduler_block_size % g.kv_cache_spec.block_size == 0
+             for g in kv_cache_config.kv_cache_groups
+         )
+@@ -601,7 +601,12 @@
              manager.block_size for manager in self.single_type_managers
          ]
          assert all(
 -            block_size % hash_block_size == 0 for block_size in group_block_sizes
-+            block_size % hash_block_size == 0
++            isinstance(g.kv_cache_spec, SlidingWindowSpec)
++            or block_size % hash_block_size == 0
 +            or hash_block_size % block_size == 0
-+            for block_size in group_block_sizes
++            for g, block_size in zip(
++                kv_cache_config.kv_cache_groups, group_block_sizes
++            )
          ), (
              "Each KV cache group's real block_size must be divisible by "
              f"hash_block_size. block_sizes={group_block_sizes}, "
@@ -191,4 +217,3 @@ These changes are applied after the 0.28 KVarN base port and the repo's DFlash2 
  
      def prepare_inputs(
          self,
-

--- a/kvarn/kvarn-v2-runner-0.28.0.patch
+++ b/kvarn/kvarn-v2-runner-0.28.0.patch
@@ -133,7 +133,7 @@ These changes are applied after the 0.28 KVarN base port and the repo's DFlash2 
          assert alignment_tokens % kv_cache_spec.block_size == 0, (
              "SlidingWindowManager does not support fine-grained (partial) cache hits"
          )
-@@ -1105,6 +1110,19 @@
+@@ -1105,6 +1110,24 @@
          window in the future.
          """
          return 0
@@ -146,8 +146,13 @@ These changes are applied after the 0.28 KVarN base port and the repo's DFlash2 
 +    ) -> None:
 +        # Prefix reuse is not meaningful for a rolling window. Skip the write
 +        # path when the SW block and hash unit are not divisible in either
-+        # direction; otherwise resolve_block_hashes would assert later.
-+        if self.block_size % self.block_pool.hash_block_size != 0:
++        # direction, or when the scheduler boundary is finer than the SW
++        # block. The latter would make reachable_block_mask assert before
++        # resolve_block_hashes is reached.
++        if (
++            self.block_size % self.block_pool.hash_block_size != 0
++            or self.scheduler_block_size % self.block_size != 0
++        ):
 +            return
 +        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
  

--- a/patches/check_vllm_series.sh
+++ b/patches/check_vllm_series.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate the patches whose order and hunk metadata are part of the vLLM 0.28.0
+# contract. GNU patch is intentionally permissive about offsets/fuzz; git apply
+# is the stricter format check that catches a hand-edited hunk header immediately.
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+VLLM_SOURCE=${1:?usage: bash patches/check_vllm_series.sh /path/to/vllm-v0.28.0}
+
+git -C "$VLLM_SOURCE" rev-parse --is-inside-work-tree >/dev/null
+
+PATCHES=(
+  vllm-pr50021-gdn-spec-bounds.patch
+  dflash2-lookup-drafting.patch
+  dflash2-ngram-chains.patch
+  dflash2-prewarm.patch
+  dflash2-z-adaptive-emitted.patch
+)
+
+for name in "${PATCHES[@]}"; do
+  patch="$HERE/patches/$name"
+  echo "== git apply --check $name"
+  git -C "$VLLM_SOURCE" apply --check --whitespace=error -p1 < "$patch"
+  git -C "$VLLM_SOURCE" apply --whitespace=error -p1 < "$patch"
+done
+
+git -C "$VLLM_SOURCE" diff --check
+echo "patch integrity: OK"

--- a/patches/dflash2-backport.patch
+++ b/patches/dflash2-backport.patch
@@ -1,3 +1,6 @@
+RETIRED on vLLM 0.28.0: DFlash2 is native in this release. Kept as the
+historical v0.27.1 backport for reference; do not apply it to the current stack.
+
 DFlash2 speculative decoding on vLLM 0.27.1 (single-user SPEC=dflash2).
 
 Backport of vLLM PR #52816 ("[Spec Decode] DFlash2: local convolution + candidate

--- a/patches/dflash2-lookup-drafting.patch
+++ b/patches/dflash2-lookup-drafting.patch
@@ -1,12 +1,964 @@
-DFlash2 candidate-head quantization and lookup drafting ported to vLLM 0.28.0.
-
-This replaces the pre-0.28 DFlash2 backport: 0.28.0 already ships the native DFlash2 model and selector, so this patch layers the repo's quantized candidate selection, trained draft-block sizing, lookup augmentation, and runner wiring on top.
-
---- generated against the v0.28.0 source after the non-DFlash patches ---
-
+diff --git a/model_executor/models/qwen3_dflash.py b/model_executor/models/qwen3_dflash.py
+index 410204490..03b5dd53d 100644
+--- a/model_executor/models/qwen3_dflash.py
++++ b/model_executor/models/qwen3_dflash.py
+@@ -375,6 +375,37 @@ class DFlashQwen3DecoderLayer(nn.Module):
+         return hidden_states, residual
+ 
+ 
++def _dense_kv_rows(attn: nn.Module) -> torch.Tensor:
++    """Return the K/V rows of a QKV projection as a dense matrix.
++
++    The W4A16 DFlash2 checkpoint uses compressed-tensors for qkv_proj. In
++    vLLM 0.28.0 that layer exposes packed weights rather than ``weight``;
++    context-KV precomputation still needs the dense K/V rows.
++    """
++    qkv = attn.qkv_proj
++    weight = getattr(qkv, "weight", None)
++    if weight is not None and weight.dim() == 2:
++        return weight[attn.q_size :]
++
++    packed, scale = qkv.weight_packed, qkv.weight_scale
++    out_features, in_features = int(packed.shape[0]), int(qkv.input_size)
++    bits = 32 * packed.shape[1] // in_features
++    from compressed_tensors.compressors.pack_quantized.base import unpack_from_int32
++
++    quantized = unpack_from_int32(
++        packed.data,
++        bits,
++        torch.Size([out_features, in_features]),
++        packed_dim=1,
++    )
++    group_size = in_features // scale.shape[1]
++    dense = (
++        quantized.to(torch.float32)
++        .reshape(out_features, in_features // group_size, group_size)
++        * scale.to(torch.float32)[..., None]
++    ).reshape(out_features, in_features)
++    dtype = scale.dtype if scale.dtype.is_floating_point else torch.bfloat16
++    return dense.to(dtype)[attn.q_size :]
+ @support_torch_compile
+ class DFlashQwen3Model(nn.Module):
+     decoder_layer_cls = DFlashQwen3DecoderLayer
+@@ -487,7 +518,7 @@ class DFlashQwen3Model(nn.Module):
+         self._hidden_norm_weight = self.hidden_norm.weight.data
+ 
+         # KV projection weights: [num_layers * 2 * kv_size, hidden_size]
+-        kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
++        kv_weights = [_dense_kv_rows(a) for a in layers_attn]
+         self._fused_kv_weight = torch.cat(kv_weights, dim=0)
+         if has_bias:
+             kv_biases = [a.qkv_proj.bias[a.q_size :] for a in layers_attn]
+diff --git a/model_executor/models/qwen3_dflash.py.orig b/model_executor/models/qwen3_dflash.py.orig
+new file mode 100644
+index 000000000..410204490
+--- /dev/null
++++ b/model_executor/models/qwen3_dflash.py.orig
+@@ -0,0 +1,899 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import io
++from collections.abc import Iterable
++
++import torch
++import torch.nn.functional as F
++from torch import nn
++from transformers import Qwen3Config
++
++from vllm import _custom_ops as ops
++from vllm.compilation.decorators import support_torch_compile
++from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
++from vllm.distributed import (
++    get_tensor_model_parallel_rank,
++    get_tensor_model_parallel_world_size,
++)
++from vllm.logger import init_logger
++from vllm.model_executor.layers.attention import Attention
++from vllm.model_executor.layers.layernorm import RMSNorm
++from vllm.model_executor.layers.linear import (
++    QKVParallelLinear,
++    ReplicatedLinear,
++    RowParallelLinear,
++)
++from vllm.model_executor.layers.logits_processor import LogitsProcessor
++from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
++from vllm.model_executor.layers.rotary_embedding import get_rope
++from vllm.model_executor.layers.vocab_parallel_embedding import (
++    ParallelLMHead,
++    VocabParallelEmbedding,
++)
++from vllm.multimodal.inputs import NestedTensors
++from vllm.transformers_utils.config import set_default_rope_theta
++from vllm.transformers_utils.repo_utils import get_hf_file_bytes
++from vllm.v1.attention.backend import AttentionType
++from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
++    get_eagle3_aux_layers_from_config,
++)
++
++from .qwen2 import Qwen2MLP as Qwen3MLP
++from .qwen3 import Qwen3ForCausalLM
++from .utils import (
++    AutoWeightsLoader,
++    WeightsMapper,
++    get_draft_quant_config,
++    maybe_prefix,
++    process_eagle_weight,
++)
++
++logger = init_logger(__name__)
++
++
++_SLIDING_ATTENTION = "sliding_attention"
++
++
++def _dflash_layer_causal(config: Qwen3Config, layer_idx: int) -> bool:
++    """Resolve explicit causality before falling back to legacy layer defaults."""
++    is_causal = getattr(config, "is_causal", None)
++    if is_causal is not None:
++        return bool(is_causal)
++    override = (getattr(config, "dflash_config", None) or {}).get("causal")
++    if override is not None:
++        return bool(override)
++    layer_types = getattr(config, "layer_types", None)
++    return bool(layer_types) and layer_types[layer_idx] == _SLIDING_ATTENTION
++
++
++def dflash_has_any_non_causal(config: Qwen3Config) -> bool:
++    """Whether the draft needs a non-causal-capable backend, resolved from config
++    (config mirror of the model's ``get_draft_attn_causal``, usable pre-build)."""
++    return not all(
++        _dflash_layer_causal(config, i) for i in range(config.num_hidden_layers)
++    )
++
++
++def dflash_target_rope_is_neox_style(target_model: nn.Module) -> bool | None:
++    """The target's RoPE layout, from its first attention layer.
++
++    A DFlash head must rotate Q/K the way the target it was distilled against
++    does, and a mismatch is silent — acceptance collapses but nothing errors and
++    the output stays correct. Draft checkpoints do not carry this, so take it
++    from the target. None if the target uses no RoPE.
++    """
++    language_model = (
++        target_model.get_language_model()
++        if hasattr(target_model, "get_language_model")
++        else target_model
++    )
++    for module in language_model.modules():
++        style = getattr(module, "is_neox_style", None)
++        if isinstance(style, bool):
++            return style
++    return None
++
++
++def _get_dflash_fc_input_size(vllm_config: VllmConfig) -> int:
++    spec_config = vllm_config.speculative_config
++    config = spec_config.draft_model_config.hf_config
++    aux_layers = get_eagle3_aux_layers_from_config(spec_config)
++    num_features_to_use = len(aux_layers) if aux_layers else config.num_hidden_layers
++    target_hidden_size = (
++        getattr(config, "target_hidden_size", None) or config.hidden_size
++    )
++    return target_hidden_size * num_features_to_use
++
++
++def _resolve_layer_attention(
++    config: Qwen3Config, layer_idx: int
++) -> tuple[int | None, bool]:
++    """Resolve ``(sliding_window, causal)`` for one DFlash draft layer.
++
++    +----------------------+-------------------------+--------------------------------+
++    | Config               | ``layer_type``          | *``causal``                    |
++    +======================+=========================+================================+
++    | ``layer_types``      | SWA if ``use_swa``      | True if ``layer_types[i]=SWA`` |
++    |                      | else ``layer_types[i]`` | else False                     |
++    +----------------------+-------------------------+--------------------------------+
++    | ``layer_types=None`` | SWA                     | False                          |
++    | + ``use_swa=True``   |                         |                                |
++    +----------------------+-------------------------+--------------------------------+
++    | ``layer_types=None`` | Full                    | False                          |
++    | + ``use_swa=False``  |                         |                                |
++    +----------------------+-------------------------+--------------------------------+
++    * If ``dflash_config.causal`` is set, its value overrides ``causal`` for all layers.
++
++    This is to support a varied ecosystem of checkpoints, including:
++    - XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash (sets "use_swa", assumes non-causal)
++    - z-lab/gemma-4-31B-it-DFlash (has mixed layer types, assumes causal only for SWA)
++    - z-lab/Qwen3.5-9B-DFlash ("standard" DFlash, all full attn, assumes non-causal)
++    """
++    dflash_config = getattr(config, "dflash_config", None) or {}
++    layer_types = getattr(config, "layer_types", None)
++    use_swa = dflash_config.get("use_swa", False)
++
++    any_sliding = False
++    if layer_types is not None:
++        num_sliding = sum(lt == _SLIDING_ATTENTION for lt in layer_types)
++        any_sliding = num_sliding > 0
++        # Mixed sliding/full attention needs multiple KV groups (V2 runner only).
++        if (
++            0 < num_sliding < len(layer_types)
++            and not get_current_vllm_config().use_v2_model_runner
++        ):
++            raise NotImplementedError(
++                "DFlash drafters with mixed sliding/full attention require "
++                "the V2 model runner; relaunch with "
++                "VLLM_USE_V2_MODEL_RUNNER=1."
++            )
++
++    # ``use_swa`` forces SWA on every layer, even an all-full ``layer_types``.
++    if layer_types is None or (use_swa and not any_sliding):
++        is_sliding = use_swa
++    else:
++        is_sliding = layer_types[layer_idx] == _SLIDING_ATTENTION
++
++    sliding_window = None
++    if is_sliding:
++        sliding_window = dflash_config.get(
++            "swa_window_size", getattr(config, "sliding_window", None)
++        )
++        if sliding_window is None:
++            raise ValueError(
++                "DFlash sliding attention requires a window size configured in "
++                "dflash_config.swa_window_size or the top-level sliding_window."
++            )
++
++    return sliding_window, _dflash_layer_causal(config, layer_idx)
++
++
++class DFlashQwen3Attention(nn.Module):
++    """Attention for DFlash speculative decoding.
++
++    Context KVs are pre-inserted into the KV cache before the forward pass.
++    This layer handles only query tokens via standard attention.
++    Adapted from Qwen3Attention."""
++
++    def __init__(
++        self,
++        hidden_size: int,
++        num_heads: int,
++        num_kv_heads: int,
++        rope_parameters: dict,
++        max_position: int = 4096 * 32,
++        head_dim: int | None = None,
++        rms_norm_eps: float = 1e-06,
++        attention_bias: bool = False,
++        add_swa_attention_sink_bias: bool = False,
++        sliding_window: int | None = None,
++        causal: bool = False,
++        is_neox_style: bool = True,
++        cache_config: CacheConfig | None = None,
++        quant_config: QuantizationConfig | None = None,
++        prefix: str = "",
++        attn_type: str = AttentionType.DECODER,
++    ) -> None:
++        super().__init__()
++        self.layer_name = prefix
++        self.hidden_size = hidden_size
++        tp_size = get_tensor_model_parallel_world_size()
++        self.total_num_heads = num_heads
++        assert self.total_num_heads % tp_size == 0
++        self.num_heads = self.total_num_heads // tp_size
++        self.total_num_kv_heads = num_kv_heads
++        if self.total_num_kv_heads >= tp_size:
++            assert self.total_num_kv_heads % tp_size == 0
++        else:
++            assert tp_size % self.total_num_kv_heads == 0
++        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
++        self.head_dim = head_dim or hidden_size // self.total_num_heads
++        self.q_size = self.num_heads * self.head_dim
++        self.kv_size = self.num_kv_heads * self.head_dim
++        self.scaling = self.head_dim**-0.5
++
++        self.qkv_proj = QKVParallelLinear(
++            hidden_size,
++            self.head_dim,
++            self.total_num_heads,
++            self.total_num_kv_heads,
++            bias=attention_bias,
++            quant_config=quant_config,
++            prefix=f"{prefix}.qkv_proj",
++        )
++        self.o_proj = RowParallelLinear(
++            self.total_num_heads * self.head_dim,
++            hidden_size,
++            bias=attention_bias,  # DFlash has o_proj bias when using attention bias
++            quant_config=quant_config,
++            prefix=f"{prefix}.o_proj",
++        )
++
++        self.rotary_emb = get_rope(
++            self.head_dim,
++            max_position=max_position,
++            is_neox_style=is_neox_style,
++            rope_parameters=rope_parameters,
++        )
++
++        self.attention_sink_bias = (
++            torch.nn.Parameter(torch.empty(self.num_heads), requires_grad=False)
++            if add_swa_attention_sink_bias
++            else None
++        )
++
++        self.sliding_window = sliding_window
++        self.attn = Attention(
++            self.num_heads,
++            self.head_dim,
++            self.scaling,
++            num_kv_heads=self.num_kv_heads,
++            cache_config=cache_config,
++            quant_config=quant_config,
++            per_layer_sliding_window=sliding_window,
++            prefix=f"{prefix}.attn",
++            attn_type=attn_type,
++            sinks=self.attention_sink_bias,
++        )
++        self.causal = causal
++        self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
++        self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
++
++    def forward(
++        self,
++        positions: torch.Tensor,
++        hidden_states: torch.Tensor,
++    ) -> torch.Tensor:
++        """DFlash attention assumes that the KV cache is already populated
++        with the context K/V from the target model's hidden states. This forward op
++        computes attention for the query tokens only.
++        See also: precompute_and_store_context_kv"""
++        qkv, _ = self.qkv_proj(hidden_states)
++        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
++
++        # Per-head RMSNorm
++        q_shape, k_shape = q.shape, k.shape
++        q = self.q_norm(
++            q.view(*q_shape[:-1], q_shape[-1] // self.head_dim, self.head_dim)
++        ).view(q_shape)
++        k = self.k_norm(
++            k.view(*k_shape[:-1], k_shape[-1] // self.head_dim, self.head_dim)
++        ).view(k_shape)
++
++        q, k = self.rotary_emb(positions, q, k)
++
++        attn_output = self.attn(q, k, v)
++        output, _ = self.o_proj(attn_output)
++        return output
++
++
++class DFlashQwen3DecoderLayer(nn.Module):
++    def __init__(
++        self,
++        vllm_config: VllmConfig,
++        *,
++        config: Qwen3Config,
++        layer_idx: int,
++        cache_config: CacheConfig | None = None,
++        quant_config: QuantizationConfig | None = None,
++        prefix: str = "",
++    ) -> None:
++        super().__init__()
++        self.hidden_size = config.hidden_size
++        set_default_rope_theta(config, default_theta=1000000)
++        attn_type = AttentionType.DECODER
++
++        # DFlash drafts store the sink-bias flag inside dflash_config; fall back
++        # to the top-level attribute used by other (e.g. MiMo) configs.
++        dflash_config = getattr(config, "dflash_config", None) or {}
++        add_swa_attention_sink_bias = dflash_config.get(
++            "attention_sink_bias",
++            getattr(config, "add_swa_attention_sink_bias", False),
++        )
++
++        # Resolve this layer's attention mode (full vs sliding window, causal vs
++        # non-causal) from the draft config.
++        sliding_window, causal = _resolve_layer_attention(config, layer_idx)
++
++        # RoPE layout, copied off the target at load time by the draft loader
++        # (see `dflash_target_rope_is_neox_style`). Checkpoints do not carry it:
++        # a head distilled from an interleaved-RoPE target must rotate the way
++        # that target does, or every drafted Q/K is wrong and acceptance
++        # collapses with no error raised.
++        is_neox_style = getattr(config, "is_neox_style", True)
++
++        self.self_attn = DFlashQwen3Attention(
++            hidden_size=self.hidden_size,
++            num_heads=config.num_attention_heads,
++            max_position=config.max_position_embeddings,
++            num_kv_heads=config.num_key_value_heads,
++            rms_norm_eps=config.rms_norm_eps,
++            attention_bias=getattr(config, "attention_bias", False),
++            add_swa_attention_sink_bias=add_swa_attention_sink_bias,
++            sliding_window=sliding_window,
++            causal=causal,
++            is_neox_style=is_neox_style,
++            head_dim=getattr(config, "head_dim", None),
++            cache_config=cache_config,
++            quant_config=quant_config,
++            rope_parameters=config.rope_parameters,
++            prefix=f"{prefix}.self_attn",
++            attn_type=attn_type,
++        )
++        self.mlp = Qwen3MLP(
++            hidden_size=self.hidden_size,
++            intermediate_size=config.intermediate_size,
++            hidden_act=config.hidden_act,
++            quant_config=quant_config,
++            prefix=f"{prefix}.mlp",
++        )
++        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
++        self.post_attention_layernorm = RMSNorm(
++            config.hidden_size, eps=config.rms_norm_eps
++        )
++
++    def forward(
++        self,
++        positions: torch.Tensor,
++        hidden_states: torch.Tensor,
++        residual: torch.Tensor | None,
++    ) -> tuple[torch.Tensor, torch.Tensor]:
++        if residual is not None:
++            hidden_states, residual = self.input_layernorm(hidden_states, residual)
++        else:
++            residual = hidden_states
++            hidden_states = self.input_layernorm(hidden_states)
++
++        hidden_states = self.self_attn(
++            positions=positions,
++            hidden_states=hidden_states,
++        )
++
++        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
++        hidden_states = self.mlp(hidden_states)
++        return hidden_states, residual
++
++
++@support_torch_compile
++class DFlashQwen3Model(nn.Module):
++    decoder_layer_cls = DFlashQwen3DecoderLayer
++
++    hf_to_vllm_mapper = WeightsMapper(
++        orig_to_new_substr={
++            "midlayer.": "layers.0.",
++            # Muse-Glimmer-30B-assistant names the aux-hidden-state encoder
++            # `encoder.fc` / `encoder.output_norm_enc`; this head calls them
++            # `fc` / `hidden_norm`. Same tensors and shapes, different names.
++            "encoder.output_norm_enc.": "hidden_norm.",
++            "encoder.fc.": "fc.",
++        },
++        orig_to_new_stacked={
++            ".q_proj": (".qkv_proj", "q"),
++            ".k_proj": (".qkv_proj", "k"),
++            ".v_proj": (".qkv_proj", "v"),
++            ".gate_proj": (".gate_up_proj", 0),
++            ".up_proj": (".gate_up_proj", 1),
++        },
++    )
++
++    def __init__(
++        self,
++        *,
++        vllm_config: VllmConfig,
++        start_layer_id: int = 0,
++        prefix: str = "",
++    ) -> None:
++        super().__init__()
++        self.config = vllm_config.speculative_config.draft_model_config.hf_config
++        self.vocab_size = self.config.vocab_size
++        self.quant_config = get_draft_quant_config(vllm_config)
++
++        drafter_config = getattr(self.config, "eagle_config", {})
++        drafter_config.update(getattr(self.config, "dflash_config", {}))
++
++        if drafter_config is not None and "use_aux_hidden_state" in drafter_config:
++            self.use_aux_hidden_state = drafter_config["use_aux_hidden_state"]
++        else:
++            self.use_aux_hidden_state = True
++
++        current_vllm_config = get_current_vllm_config()
++
++        self.embed_tokens = VocabParallelEmbedding(
++            self.config.vocab_size,
++            self.config.hidden_size,
++            prefix=maybe_prefix(prefix, "embed_tokens"),
++        )
++
++        # Masked query slots are fed to the draft as `mask_token_id`. Most DFlash
++        # checkpoints will have the mask embedding in the vocabulary embedding table
++        # at that slot id. Some checkpoints (XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash) ship
++        # with a separate mask embedding tensor to use instead. When present, we load it
++        # and substitute it for embed_tokens[mask_token_id] when computing embeddings.
++        self.mask_token_id = drafter_config.get("mask_token_id")
++        self.mask_embedding = nn.Parameter(
++            torch.zeros(self.config.hidden_size, dtype=vllm_config.model_config.dtype),
++            requires_grad=False,
++        )
++        self.has_separate_mask_embedding = False
++
++        self.layers = nn.ModuleList(
++            [
++                self.decoder_layer_cls(
++                    current_vllm_config,
++                    config=self.config,
++                    layer_idx=layer_idx,
++                    cache_config=current_vllm_config.cache_config,
++                    quant_config=self.quant_config,
++                    prefix=maybe_prefix(prefix, f"layers.{layer_idx + start_layer_id}"),
++                )
++                for layer_idx in range(self.config.num_hidden_layers)
++            ]
++        )
++        if self.use_aux_hidden_state:
++            self.fc = ReplicatedLinear(
++                input_size=_get_dflash_fc_input_size(
++                    vllm_config,
++                ),
++                output_size=self.config.hidden_size,
++                bias=False,
++                params_dtype=vllm_config.model_config.dtype,
++                quant_config=self.quant_config,
++                prefix=maybe_prefix(prefix, "fc"),
++                return_bias=False,
++            )
++        self.hidden_norm = RMSNorm(
++            self.config.hidden_size,
++            eps=self.config.rms_norm_eps,
++        )
++        self.norm = RMSNorm(
++            self.config.hidden_size,
++            eps=self.config.rms_norm_eps,
++        )
++
++    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
++        embeds = self.embed_tokens(input_ids)
++        if self.has_separate_mask_embedding and self.mask_token_id is not None:
++            # Replace masked slots with the dedicated mask embedding.
++            is_mask = (input_ids == self.mask_token_id).unsqueeze(-1)
++            embeds = torch.where(is_mask, self.mask_embedding.to(embeds.dtype), embeds)
++        return embeds
++
++    def _build_context_kv_buffers(
++        self,
++        layers_attn: list[nn.Module],
++        has_bias: bool,
++    ) -> None:
++        self._hidden_norm_weight = self.hidden_norm.weight.data
++
++        # KV projection weights: [num_layers * 2 * kv_size, hidden_size]
++        kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
++        self._fused_kv_weight = torch.cat(kv_weights, dim=0)
++        if has_bias:
++            kv_biases = [a.qkv_proj.bias[a.q_size :] for a in layers_attn]
++            self._fused_kv_bias: torch.Tensor | None = torch.cat(kv_biases, dim=0)
++        else:
++            self._fused_kv_bias = None
++
++        # K-norm weights stacked into one contiguous [num_layers, head_dim]
++        # tensor so the per-layer K-norm runs as a single grouped kernel.
++        self._k_norm_weights = torch.stack(
++            [a.k_norm.weight.data for a in layers_attn], dim=0
++        ).contiguous()
++
++    def _build_fused_kv_buffers(self) -> None:
++        """Build fused weight buffers for precompute_and_store_context_kv.
++
++        Must be called after weights are loaded. Stacks the KV-projection
++        weights, K-norm weights, and RoPE parameters from every attention
++        layer so that precompute_and_store_context_kv can run one fused
++        GEMM for all layers at once. Also aliases the weight of the hidden_norm.
++        """
++        layers_attn = [layer.self_attn for layer in self.layers]
++        attn0 = layers_attn[0]
++        has_bias = attn0.qkv_proj.bias is not None
++
++        self._build_context_kv_buffers(layers_attn, has_bias)
++
++        # RoPE parameters
++        self._rope_head_size = attn0.rotary_emb.head_size
++        self._rope_cos_sin_cache = attn0.rotary_emb.cos_sin_cache
++        self._rope_is_neox = attn0.rotary_emb.is_neox_style
++        # Validation that RoPE params are the same across all layers
++        for attn in layers_attn[1:]:
++            assert (
++                attn.rotary_emb.head_size == self._rope_head_size
++                and attn.rotary_emb.is_neox_style == self._rope_is_neox
++            ), "All layers must have the same RoPE parameters for DFlash precomputation"
++
++        # Layer metadata
++        self._num_attn_layers = len(layers_attn)
++        self._kv_size = attn0.kv_size
++        self._head_dim = attn0.head_dim
++        self._num_kv_heads = attn0.num_kv_heads
++        self._rms_norm_eps = attn0.q_norm.variance_epsilon
++        # Validation that all layers have the same attention config
++        for attn in layers_attn[1:]:
++            assert (
++                attn.kv_size == self._kv_size
++                and attn.head_dim == self._head_dim
++                and attn.num_kv_heads == self._num_kv_heads
++                and attn.q_norm.variance_epsilon == self._rms_norm_eps
++            ), "All layers must have the same attn config for DFlash precomputation"
++
++        # References to inner Attention layers for direct cache writes
++        self._attn_layers = [layer.self_attn.attn for layer in self.layers]
++
++    def _project_context_kv(
++        self,
++        context_states: torch.Tensor,
++        num_ctx: int,
++        num_layers: int,
++        num_kv_heads: int,
++        head_dim: int,
++    ) -> tuple[torch.Tensor, torch.Tensor]:
++        # --- Fused KV projection (one GEMM for all layers) ---
++        normed_context_states = torch.empty_like(context_states)
++        ops.rms_norm(
++            normed_context_states,
++            context_states,
++            self._hidden_norm_weight,
++            self._rms_norm_eps,
++        )
++        all_kv_flat = F.linear(
++            normed_context_states, self._fused_kv_weight, self._fused_kv_bias
++        )
++        # Single contiguous copy that separates K/V and transposes to
++        # layer-major layout.  Result: [2, L, num_ctx, nkv, hd] contiguous.
++        # Indexing dim-0 gives contiguous [L, num_ctx, nkv, hd] for K and V.
++        all_kv = (
++            all_kv_flat.view(num_ctx, num_layers, 2, num_kv_heads, head_dim)
++            .permute(2, 1, 0, 3, 4)
++            .contiguous()
++        )
++        all_k = all_kv[0]  # [L, num_ctx, nkv, hd], contiguous
++        all_v = all_kv[1]  # [L, num_ctx, nkv, hd], contiguous
++        return all_k, all_v
++
++    def _normalize_context_k(self, all_k: torch.Tensor) -> torch.Tensor:
++        # --- Grouped RMSNorm K across all layers ([L, num_ctx, nkv, hd]) ---
++        # The weight is selected per layer by the outermost (layer) index.
++        all_k_normed = torch.empty_like(all_k)
++        ops.rms_norm(
++            all_k_normed,
++            all_k,
++            self._k_norm_weights,
++            self._rms_norm_eps,
++        )
++        return all_k_normed
++
++    def precompute_and_store_context_kv(
++        self,
++        context_states: torch.Tensor,
++        context_positions: torch.Tensor,
++        context_slot_mapping: torch.Tensor | list[torch.Tensor | None] | None = None,
++    ) -> None:
++        """Precompute K/V for context states write them into each layer's KV cache.
++
++        Input context states are projected to K/V, normed, and have RoPE applied.
++        Since the context shape is different than the query shape, we can't rely on the
++        regular forward pass to apply torch.compile and CUDA graphs to this section.
++        As such, this function is optimized to minimize the number of torch ops present:
++        we use fused vLLM kernels for RMSNorm and RoPE, fuse the GEMM into one
++        large projection, and avoid cloning buffers (with .contiguous()) where possible.
++
++        When context_slot_mapping is None (e.g. during dummy_run) only
++        the computation runs, and no K/V is written to cache.
++        """
++        if not hasattr(self, "_num_attn_layers"):
++            logger.warning_once(
++                "DFlash buffer initialization was skipped. If dummy weights are not "
++                "in use, this may indicate an error in weight loading."
++            )
++            self._build_fused_kv_buffers()
++
++        num_ctx = context_states.shape[0]
++        L = self._num_attn_layers
++        kv = self._kv_size
++        hd = self._head_dim
++        nkv = self._num_kv_heads
++
++        all_k, all_v = self._project_context_kv(context_states, num_ctx, L, nkv, hd)
++        all_k_normed = self._normalize_context_k(all_k)
++
++        # --- Fused RoPE across all layers ---
++        # View as [L * num_ctx, kv] so RoPE sees one big batch (no copy).
++        # In-place RoPE: pass K as the "query" arg with key=None.
++        all_k_flat = all_k_normed.view(L * num_ctx, kv)
++        positions_repeated = context_positions.repeat(L)
++        cos_sin_cache = self._rope_cos_sin_cache
++        if cos_sin_cache.dtype != all_k_flat.dtype:
++            cos_sin_cache = cos_sin_cache.to(dtype=all_k_flat.dtype)
++        ops.rotary_embedding(
++            positions_repeated,
++            all_k_flat,
++            None,
++            self._rope_head_size,
++            cos_sin_cache,
++            self._rope_is_neox,
++        )
++
++        if context_slot_mapping is None:
++            return
++
++        # --- Per-layer cache insert ---
++        all_k_final = all_k_flat.view(L, num_ctx, nkv, hd)
++        per_layer = isinstance(context_slot_mapping, (list, tuple))
++        for i in range(L):
++            slot_mapping = (
++                context_slot_mapping[i] if per_layer else context_slot_mapping
++            )
++            if slot_mapping is None:
++                continue  # dummy run: skip cache ops
++            attn = self._attn_layers[i]
++            kv_cache = attn.kv_cache
++            attn.impl.do_kv_cache_update(
++                attn,
++                all_k_final[i],
++                all_v[i],
++                kv_cache,
++                slot_mapping,
++            )
++
++    def forward(
++        self,
++        input_ids: torch.Tensor,
++        positions: torch.Tensor,
++        input_embeds: torch.Tensor | None = None,
++    ) -> torch.Tensor:
++        if input_embeds is None:
++            input_embeds = self.embed_input_ids(input_ids)
++
++        hidden_states = input_embeds
++
++        residual = None
++        for layer in self.layers:
++            hidden_states, residual = layer(
++                positions=positions,
++                hidden_states=hidden_states,
++                residual=residual,
++            )
++        hidden_states, _ = self.norm(hidden_states, residual)
++        return hidden_states
++
++    def _preprocess(
++        self, weights: Iterable[tuple[str, torch.Tensor]]
++    ) -> Iterable[tuple[str, torch.Tensor]]:
++        tp_size = get_tensor_model_parallel_world_size()
++        tp_rank = get_tensor_model_parallel_rank()
++        for name, loaded_weight in weights:
++            if "attention_sink_bias" in name:
++                # Sink bias is per-head; shard it across TP ranks like the
++                # attention heads themselves.
++                heads_per_rank = loaded_weight.shape[0] // tp_size
++                loaded_weight = loaded_weight.narrow(
++                    0, tp_rank * heads_per_rank, heads_per_rank
++                )
++            yield name, loaded_weight
++
++    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
++        loader = AutoWeightsLoader(self)
++        return loader.load_weights(
++            self._preprocess(weights), mapper=self.hf_to_vllm_mapper
++        )
++
++
++class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
++    model_cls = DFlashQwen3Model
++
++    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
++        nn.Module.__init__(self)
++        self.draft_model_config = vllm_config.speculative_config.draft_model_config
++        self.config = self.draft_model_config.hf_config
++        if getattr(self.config, "draft_vocab_size", None) is None:
++            self.config.draft_vocab_size = getattr(self.config, "vocab_size", None)
++        target_layer_num = vllm_config.model_config.get_num_layers(
++            vllm_config.parallel_config
++        )
++        self.model = self.model_cls(
++            vllm_config=vllm_config,
++            prefix=maybe_prefix(prefix, "model"),
++            start_layer_id=target_layer_num,
++        )
++
++        logit_scale = getattr(self.config, "logit_scale", 1.0)
++        self.lm_head = ParallelLMHead(
++            self.config.draft_vocab_size,
++            self.config.hidden_size,
++            prefix=maybe_prefix(prefix, "lm_head"),
++        )
++        self.logits_processor = LogitsProcessor(
++            self.config.draft_vocab_size, scale=logit_scale
++        )
++        target_vocab_size = vllm_config.model_config.get_vocab_size()
++        if self.config.draft_vocab_size != target_vocab_size:
++            self.draft_id_to_target_id = nn.Parameter(
++                torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
++                requires_grad=False,
++            )
++        else:
++            self.draft_id_to_target_id = None
++
++    def embed_input_ids(
++        self,
++        input_ids: torch.Tensor,
++        multimodal_embeddings: NestedTensors | None = None,
++        is_multimodal: torch.Tensor | None = None,
++    ) -> torch.Tensor:
++        return self.model.embed_input_ids(input_ids)
++
++    def forward(
++        self,
++        input_ids: torch.Tensor,
++        positions: torch.Tensor,
++        inputs_embeds: torch.Tensor | None = None,
++    ) -> torch.Tensor:
++        return self.model(input_ids, positions, inputs_embeds)
++
++    def get_draft_kv_cache_layer_names(self) -> list[str]:
++        return [layer.self_attn.attn.layer_name for layer in self.model.layers]
++
++    def get_draft_attn_causal(self) -> list[bool]:
++        """Per-layer attention causality, aligned with
++        get_draft_kv_cache_layer_names."""
++        return [layer.self_attn.causal for layer in self.model.layers]
++
++    def compute_logits(
++        self,
++        hidden_states: torch.Tensor,
++    ) -> torch.Tensor | None:
++        logits = self.logits_processor(self.lm_head, hidden_states)
++        if self.draft_id_to_target_id is None:
++            return logits
++
++        base = torch.arange(self.config.draft_vocab_size, device=logits.device)
++        targets = base + self.draft_id_to_target_id
++        logits_new = logits.new_full(
++            (logits.shape[0], self.config.vocab_size),
++            float("-inf"),
++        )
++        logits_new[:, targets] = logits
++        return logits_new
++
++    def precompute_and_store_context_kv(
++        self,
++        context_states: torch.Tensor,
++        context_positions: torch.Tensor,
++        context_slot_mapping: torch.Tensor | list[torch.Tensor | None] | None = None,
++    ) -> None:
++        """Precompute projected + RoPE'd K/V and write to cache."""
++        self.model.precompute_and_store_context_kv(
++            context_states, context_positions, context_slot_mapping
++        )
++
++    def combine_hidden_states(
++        self,
++        hidden_states: torch.Tensor,
++    ) -> torch.Tensor:
++        if not self.model.use_aux_hidden_state:
++            return hidden_states
++        needs_squeeze = hidden_states.dim() == 1
++        if needs_squeeze:
++            hidden_states = hidden_states.unsqueeze(0)
++        expected = self.model.fc.input_size
++        if hidden_states.shape[-1] != expected:
++            raise ValueError(
++                f"DFlash drafter expects {expected} concatenated aux hidden "
++                f"features but received {hidden_states.shape[-1]}. This usually "
++                "means the draft model's target_layer_ids reference layers that "
++                "do not exist in the target model (incompatible draft/target pair)."
++            )
++        result = self.model.fc(hidden_states)
++        if needs_squeeze:
++            result = result.squeeze(0)
++        return result
++
++    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
++        model_weights = {}
++        includes_draft_id_mapping = False
++        includes_embed_tokens = False
++        for name, loaded_weight in weights:
++            assert "mask_hidden" not in name, (
++                "DFlash embeds masked slots via mask_token_id (optionally "
++                "overridden by a mask_embedding.pt file); it should not ship a "
++                "mask_hidden weight."
++            )
++            if "t2d" in name:
++                continue
++            if "d2t" in name:
++                name = name.replace("d2t", "draft_id_to_target_id")
++                includes_draft_id_mapping = True
++            elif "lm_head" not in name:
++                name = "model." + name
++            if "embed_tokens" in name:
++                includes_embed_tokens = True
++            model_weights[name] = loaded_weight
++            process_eagle_weight(self, name)
++
++        # Route the separately-trained mask embedding (if shipped) through the
++        # standard weight loader alongside the rest of the draft weights.
++        mask_embedding = self._read_mask_embedding()
++        if mask_embedding is not None:
++            model_weights["model.mask_embedding"] = mask_embedding
++            self.model.has_separate_mask_embedding = True
++
++        skip_substrs = []
++        if not includes_draft_id_mapping:
++            skip_substrs.append("draft_id_to_target_id")
++        if not includes_embed_tokens:
++            skip_substrs.append("embed_tokens")
++        if not self.model.use_aux_hidden_state:
++            skip_substrs.append("fc.")
++        if not self.model.has_separate_mask_embedding:
++            skip_substrs.append("mask_embedding")
++        loader = AutoWeightsLoader(
++            self,
++            skip_prefixes=None,
++            skip_substrs=skip_substrs,
++        )
++        loader.load_weights(model_weights.items())
++        self.model._build_fused_kv_buffers()
++
++    def _read_mask_embedding(self) -> torch.Tensor | None:
++        """Checks for an override mask embedding in `mask_embedding.pt` and returns it.
++
++        Some checkpoints ship a separately-trained mask embedding for the mask token,
++        which we use to overwrite the embedding for `mask_token_id`. This helper
++        checks for the file, loads the pytorch tensor, and returns the embedding to use.
++
++        Returns None if the override file is not present.
++        """
++        mask_token_id = self.model.mask_token_id
++        if mask_token_id is None:
++            return None
++
++        MASK_EMBEDDING_FILENAME = "mask_embedding.pt"
++        data = get_hf_file_bytes(
++            MASK_EMBEDDING_FILENAME,
++            self.draft_model_config.model,
++            self.draft_model_config.revision,
++        )
++        if data is None:
++            return None
++
++        state = torch.load(io.BytesIO(data), weights_only=True)
++        if isinstance(state, dict):
++            if state.get("mask_token_id", mask_token_id) != mask_token_id:
++                raise ValueError(
++                    f"{MASK_EMBEDDING_FILENAME} mask_token_id does not match "
++                    f"dflash_config.mask_token_id ({mask_token_id}). "
++                    f"Got {state.get('mask_token_id')}."
++                )
++            state = state["embedding"]
++
++        logger.info(
++            "Loaded DFlash mask embedding for mask_token_id %s from %s",
++            mask_token_id,
++            MASK_EMBEDDING_FILENAME,
++        )
++        return state.reshape(-1)
+diff --git a/model_executor/models/qwen3_dflash2.py b/model_executor/models/qwen3_dflash2.py
+index cb027293f..9aec93037 100644
 --- a/model_executor/models/qwen3_dflash2.py
 +++ b/model_executor/models/qwen3_dflash2.py
-@@ -127,8 +127,15 @@
+@@ -127,8 +127,15 @@ class DFlash2Qwen3DecoderLayer(DFlashQwen3DecoderLayer):
              hidden_size=config.hidden_size,
              taps=int(draft_config["conv_kernel_size"]),
              group_size=int(draft_config["conv_group_size"]),
@@ -24,6 +976,2113 @@ This replaces the pre-0.28 DFlash2 backport: 0.28.0 already ships the native DFl
              params_dtype=vllm_config.model_config.dtype,
          )
          self.attention_conv = DFlashGroupedConv(
+diff --git a/v1/worker/gpu/cudagraph_utils.py b/v1/worker/gpu/cudagraph_utils.py
+index 8e24a0ee0..959929d98 100644
+--- a/v1/worker/gpu/cudagraph_utils.py
++++ b/v1/worker/gpu/cudagraph_utils.py
+@@ -215,6 +215,33 @@ class CudaGraphManager:
+             ]
+         else:
+             decode_query_lens = [self.decode_query_len]
++            # A DFlash drafter whose checkpoint block is shorter than the verify block
++            # (v1/worker/gpu/spec_decode/dflash2/lookup.py fills the rest from the request's
++            # own context) schedules either length, so both need a decode graph. Without
++            # this the short step -- the one taken on ordinary prose -- runs piecewise.
++            import os as _os
++
++            if (
++                speculative_config is not None
++                and _os.environ.get("VLLM_DFLASH2_GRAPH_BOTH", "1") == "1"
++                and _os.environ.get("VLLM_DFLASH2_LOOKUP", "0") == "1"
++            ):
++                _cfg = getattr(
++                    getattr(speculative_config, "draft_model_config", None),
++                    "hf_config",
++                    None,
++                )
++                _block = int((getattr(_cfg, "dflash_config", None) or {}).get("block_size", 0))
++                _short = _block + (
++                    self.decode_query_len - self.vllm_config.num_speculative_tokens - 1
++                )
++                if 0 < _short < self.decode_query_len:
++                    decode_query_lens.append(_short)
++                    logger.info(
++                        "Capturing decode graphs for query lengths %s (the drafter's block "
++                        "and the full verify block).",
++                        decode_query_lens,
++                    )
+ 
+         capture_varlen_decode = (
+             separate_decode_routine and bool(decode_mode) and self.varlen_decode
+diff --git a/v1/worker/gpu/model_runner.py b/v1/worker/gpu/model_runner.py
+index d68666cf4..dff555c2c 100644
+--- a/v1/worker/gpu/model_runner.py
++++ b/v1/worker/gpu/model_runner.py
+@@ -283,6 +283,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+             num_prefill_lookahead=num_prefill_lookahead,
+         )
+         self.adaptive_verification: AdaptiveVerificationManager | None = None
++        if self.speculator is not None and hasattr(self.speculator, "set_req_states"):
++            # Lookup-augmented drafting reads the request token history.
++            self.speculator.set_req_states(self.req_states)
+         self.input_buffers = InputBuffers(
+             max_num_reqs=self.max_num_reqs,
+             max_num_tokens=self.max_num_tokens,
+@@ -416,6 +419,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+                     self.speculative_config,
+                     self.device,
+                 )
++            if self.speculator is not None and hasattr(self.speculator, "set_sampling_states"):
++                # DFlash2 truncates its proposal to the request's top-k/top-p.
++                self.speculator.set_sampling_states(self.sampler.sampling_states)
+             self.prompt_logprobs_worker = PromptLogprobsWorker(
+                 self.max_num_reqs,
+                 logprobs_mode=self.model_config.logprobs_mode,
+@@ -1848,9 +1854,18 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+         if self.num_speculative_steps > 0:
+             # Spec-decode and diffusion LLMs both use draft tokens but the latter does
+             # not have a speculator (i.e. self.speculator is None)
++            num_draft = None
++            if self.speculator is not None and hasattr(
++                self.speculator, "next_num_draft_tokens"
++            ):
++                # Lookup-augmented drafting proposes a long block only while the request
++                # is reproducing its context; the rest of the time it asks the scheduler
++                # to verify the drafter's own (much cheaper) block.
++                num_draft = self.speculator.next_num_draft_tokens()
+             self.draft_tokens_handler.set_draft_tokens(
+                 input_batch,
+                 self.req_states.draft_tokens[input_batch.idx_mapping],
++                num_draft=num_draft,
+             )
+ 
+         # Post-step KV connector related operations.
+diff --git a/v1/worker/gpu/model_runner.py.orig b/v1/worker/gpu/model_runner.py.orig
+new file mode 100644
+index 000000000..d68666cf4
+--- /dev/null
++++ b/v1/worker/gpu/model_runner.py.orig
+@@ -0,0 +1,2018 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""
++NOTE: Coding style guide for this file:
++This model runner is shared by all models: text and multimodal, generative
++and embedding, public and private. As a result, this file must only contain
++code that is common to every model. Model-specific behavior belongs in the
++appropriate model-specific files.
++
++In other words:
++* Be paranoid about changing this file. It should remain stable.
++* Be even more paranoid about adding new lines. It should remain minimal.
++
++Even for shared features (for example, different parallelism modes), keep the
++complexity out of this path. The less common the feature, the more it should be
++hidden. Prefer utility functions defined elsewhere and call them from here,
++instead of embedding feature-specific logic directly.
++"""
++
++import functools
++import gc
++import time
++from copy import deepcopy
++from typing import Any, NamedTuple
++
++import numpy as np
++import torch
++import torch.nn as nn
++
++import vllm.envs as envs
++from vllm.compilation.counter import compilation_counter
++from vllm.config import VllmConfig
++from vllm.config.compilation import CUDAGraphMode
++from vllm.distributed.parallel_state import (
++    get_dcp_group,
++    get_pp_group,
++)
++from vllm.forward_context import BatchDescriptor, set_forward_context
++from vllm.logger import init_logger
++from vllm.model_executor.layers.fused_moe.all2all_utils import get_ep_all2all_manager
++from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
++    RoutedExpertsCapturer,
++    bind_routed_experts_capturer,
++)
++from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
++    initialize_mamba_ssu_backend,
++)
++from vllm.model_executor.model_loader import get_model_loader
++from vllm.model_executor.offloader import (
++    create_offloader,
++    get_offloader,
++    set_offloader,
++)
++from vllm.multimodal import MULTIMODAL_REGISTRY
++from vllm.multimodal.encoder_budget import (
++    MultiModalBudget,
++    get_dummy_encoder_profile_inputs,
++)
++from vllm.sequence import IntermediateTensors
++from vllm.tasks import SupportedTask
++from vllm.utils.math_utils import cdiv
++from vllm.utils.mem_utils import DeviceMemoryProfiler, format_gib
++from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
++from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
++from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
++from vllm.v1.outputs import (
++    DraftTokenIds,
++    ECConnectorOutput,
++    ModelRunnerOutput,
++    RoutedExpertsTensors,
++    make_empty_encoder_model_runner_output,
++)
++from vllm.v1.worker.block_table import get_block_table_width
++from vllm.v1.worker.cp_utils import check_attention_cp_compatibility
++from vllm.v1.worker.gpu import pcp_manager as pcp
++from vllm.v1.worker.gpu.async_utils import (
++    AsyncOutput,
++    AsyncPoolingOutput,
++    StepTimingCollector,
++)
++from vllm.v1.worker.gpu.attn_utils import (
++    build_slot_mappings_by_layer,
++    get_kv_cache_spec,
++    init_attn_backend,
++    init_kv_cache,
++)
++from vllm.v1.worker.gpu.block_table import BlockTables
++from vllm.v1.worker.gpu.buffer_utils import (
++    async_copy_to_gpu,
++    set_default_max_concurrency,
++)
++from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
++from vllm.v1.worker.gpu.cudagraph_utils import (
++    BatchExecutionDescriptor,
++    ModelCudaGraphManager,
++)
++from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
++from vllm.v1.worker.gpu.ec_connector import get_ec_connector
++from vllm.v1.worker.gpu.eplb_utils import EPLBController, step_eplb_after
++from vllm.v1.worker.gpu.input_batch import (
++    InputBatch,
++    InputBuffers,
++    combine_sampled_and_draft_tokens,
++    expand_idx_mapping,
++    post_update,
++    post_update_num_computed_tokens,
++    prepare_pos_seq_lens,
++    prepare_prefill_inputs,
++    set_dummy_context,
++)
++from vllm.v1.worker.gpu.kv_connector import (
++    NO_OP_KV_CONNECTOR,
++    KVConnector,
++    get_kv_connector,
++)
++from vllm.v1.worker.gpu.lora_utils import (
++    LoraState,
++    create_lora_capture_hook,
++    get_lora_capture_cases,
++    get_num_active_loras_for_dispatch,
++)
++from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
++from vllm.v1.worker.gpu.mm.lora import set_active_mm_loras
++from vllm.v1.worker.gpu.model_states import init_model_state
++from vllm.v1.worker.gpu.pool.pooling_runner import PoolingRunner
++from vllm.v1.worker.gpu.pp_utils import PPHandler
++from vllm.v1.worker.gpu.sample.output import SamplerOutput
++from vllm.v1.worker.gpu.sample.prompt_logprob import PromptLogprobsWorker
++from vllm.v1.worker.gpu.sample.sampler import Sampler
++from vllm.v1.worker.gpu.shutdown import free_before_shutdown
++from vllm.v1.worker.gpu.spec_decode import init_speculator
++from vllm.v1.worker.gpu.spec_decode.adaptive_verification import (
++    AdaptiveVerificationManager,
++    maybe_create_adaptive_verification_manager,
++)
++from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
++    set_eagle3_aux_hidden_state_layers,
++)
++from vllm.v1.worker.gpu.spec_decode.rejection_sampler import (
++    RejectionSampler,
++    get_max_chunk_logits,
++)
++from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
++from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
++from vllm.v1.worker.gpu.states import RequestState
++from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
++from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
++from vllm.v1.worker.utils import (
++    KVBlockZeroer,
++    copy_kv_cache_blocks_inplace,
++    get_uniform_decode_token_count,
++)
++from vllm.v1.worker.workspace import use_workspace_lane
++
++logger = init_logger(__name__)
++
++
++class GPUModelRunner(LoRAModelRunnerMixin):
++    def __init__(self, vllm_config: VllmConfig, device: torch.device):
++        self.vllm_config = vllm_config
++        self.model_config = vllm_config.model_config
++        self.cache_config = vllm_config.cache_config
++        self.compilation_config = vllm_config.compilation_config
++        self.lora_config = vllm_config.lora_config
++        self.load_config = vllm_config.load_config
++        self.parallel_config = vllm_config.parallel_config
++        self.scheduler_config = vllm_config.scheduler_config
++        self.speculative_config = vllm_config.speculative_config
++        self._draft_workspace_lane = int(
++            self.speculative_config is not None and self.speculative_config.use_dspark()
++        )
++        self.observability_config = vllm_config.observability_config
++
++        self.device = device
++        self.dtype = self.model_config.dtype
++        self.is_encoder_only = vllm_config.is_encoder_only
++        self.kv_cache_dtype = self.dtype
++        if self.cache_config.cache_dtype != "auto":
++            # Quantized KV cache.
++            self.kv_cache_dtype = STR_DTYPE_TO_TORCH_DTYPE[
++                self.cache_config.cache_dtype
++            ]
++
++        # Lazily initialized in _init_kv_zero_meta() when the KV cache needs
++        # zeroing (e.g. hybrid models with fp8 KV cache).
++        self.kv_block_zeroer: KVBlockZeroer | None = None
++
++        self.vocab_size = self.model_config.get_vocab_size()
++        self.max_model_len = self.model_config.max_model_len
++        self.max_num_tokens = self.scheduler_config.max_num_batched_tokens
++        self.max_num_reqs = self.scheduler_config.max_num_seqs
++        self.is_encoder_decoder = self.model_config.is_encoder_decoder
++
++        self.output_copy_stream = torch.cuda.Stream(self.device)
++
++        # Pipeline parallelism.
++        self.use_pp = self.parallel_config.pipeline_parallel_size > 1
++        self.is_first_pp_rank = get_pp_group().is_first_rank
++        self.is_last_pp_rank = get_pp_group().is_last_rank
++
++        # Size the UVA buffer pools to the max number of concurrent in-flight
++        # steps. Must run before any pooled buffer is constructed
++        set_default_max_concurrency(vllm_config.max_concurrent_batches)
++
++        # PP broadcast/recv helper. Runs the collective on a side stream.
++        self.pp_handler: PPHandler | None = None
++
++        # Persistent buffer for intermediate tensors (non-first PP ranks).
++        self.intermediate_tensors: IntermediateTensors | None = None
++
++        # Data parallelism.
++        self.dp_size = self.parallel_config.data_parallel_size
++        self.dp_rank = self.parallel_config.data_parallel_rank
++
++        # Detect EP all2all peer faults to prevent emitting corrupted output.
++        # Only meaningful for MoE + DP with an FT-capable all2all backend.
++        self.check_ep_fault = False
++        if self.dp_size > 1 and self.model_config.is_moe:
++            self.check_ep_fault = get_ep_all2all_manager().support_fault_tolerance
++
++        # Decode context parallelism.
++        self.dcp_size = self.parallel_config.decode_context_parallel_size
++        self.use_dcp = self.dcp_size > 1
++        self.dcp_rank = get_dcp_group().rank_in_group if self.use_dcp else 0
++        self.cp_interleave = self.parallel_config.cp_kv_cache_interleave_size
++
++        # Multimodal
++        self.mm_registry = MULTIMODAL_REGISTRY
++        self.supports_mm_inputs = self.mm_registry.supports_multimodal_inputs(
++            self.model_config
++        )
++        self.encoder_cache = None
++        if self.supports_mm_inputs and self.is_first_pp_rank:
++            self.encoder_cache = EncoderCache()
++        self.ec_connector = get_ec_connector(vllm_config, self.encoder_cache)
++
++        # Speculative decoding.
++        self.speculator = None
++        self.use_aux_hidden_state_outputs = False
++        self.num_speculative_steps = vllm_config.num_speculative_tokens
++        if self.speculative_config is not None:
++            if self.is_last_pp_rank:
++                self.speculator = init_speculator(self.vllm_config, self.device)
++
++            if self.speculative_config.method in ("eagle3", "dflash", "dspark"):
++                # Drafting may require auxiliary hidden states from target model outputs
++                self.use_aux_hidden_state_outputs = True
++                if self.use_pp:
++                    raise ValueError(
++                        f"{self.speculative_config.method} with pipeline parallel "
++                        "is not supported."
++                    )
++
++        # Draft tokens propagation - for spec-dec + struct outputs.
++        self.draft_tokens_handler = DraftTokensHandler(self.device)
++
++        self.pcp_manager: pcp.PCPManager | None = None
++
++        # Pooling models.
++        self.is_pooling_model = self.model_config.runner_type == "pooling"
++        self.pooling_runner: PoolingRunner | None = None
++
++        # Multi-module MTP feeds its modules the next num_speculative_steps prefill
++        # tokens during chunked prefill. Other speculators only read the immediate
++        # next one.
++        num_prefill_lookahead = (
++            self.num_speculative_steps
++            if self.speculative_config is not None
++            and self.speculative_config.use_multi_module_mtp()
++            else 1
++        )
++
++        self.step_timing = StepTimingCollector()
++
++        # General request states.
++        self.req_states = RequestState(
++            max_num_reqs=self.max_num_reqs,
++            max_model_len=self.max_model_len,
++            max_num_batched_tokens=self.max_num_tokens,
++            num_speculative_steps=self.num_speculative_steps,
++            vocab_size=self.vocab_size,
++            device=self.device,
++            num_prefill_lookahead=num_prefill_lookahead,
++        )
++        self.adaptive_verification: AdaptiveVerificationManager | None = None
++        self.input_buffers = InputBuffers(
++            max_num_reqs=self.max_num_reqs,
++            max_num_tokens=self.max_num_tokens,
++            device=self.device,
++        )
++        if self.use_pp:
++            self.pp_handler = PPHandler(
++                max_num_reqs=self.max_num_reqs,
++                num_speculative_steps=self.num_speculative_steps,
++                device=self.device,
++            )
++
++        # Samplers and decode_query_len created in load_model() after
++        # model_state exists (num_new_sampled_tokens_per_step from ModelState).
++        self.sampler: Sampler | None = None
++        self.rejection_sampler: RejectionSampler | None = None
++        self.prompt_logprobs_worker: PromptLogprobsWorker | None = None
++        self.structured_outputs_worker: StructuredOutputsWorker | None = None
++        self.cudagraph_manager: ModelCudaGraphManager | None = None
++
++        # LoRA-related workers.
++        self.lora_state = LoraState(max_num_reqs=self.max_num_reqs)
++        self.lora_capture_cases = [0]
++        if self.lora_config:
++            self.lora_capture_cases = get_lora_capture_cases(
++                self.lora_config, self.compilation_config
++            )
++
++        # KV Connector if configured.
++        self.kv_connector: KVConnector = NO_OP_KV_CONNECTOR
++
++        # For transferring state from execute_model to subsequent sample_tokens call.
++        self.execute_model_state: ExecuteModelState | None = None
++
++        # Expert parallelism load balancer.
++        self.eplb = EPLBController(self.parallel_config, self.device)
++        self.routed_experts_capturer: RoutedExpertsCapturer | None = None
++
++        set_offloader(create_offloader(self.vllm_config.offload_config))
++
++    def update_max_model_len(self, max_model_len: int) -> None:
++        self.max_model_len = max_model_len
++        self.req_states.max_model_len = max_model_len
++
++    def init_routed_experts_capturer(self) -> None:
++        """Initialize target-model capture on every participating worker."""
++        self.routed_experts_capturer = RoutedExpertsCapturer(
++            max_num_batched_tokens=self.max_num_tokens,
++            vllm_config=self.vllm_config,
++            kv_cache_config=self.kv_cache_config,
++        )
++        bind_routed_experts_capturer(self.model, self.routed_experts_capturer)
++
++    def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
++        tasks: list[SupportedTask] = []
++        if self.model_config.runner_type == "generate":
++            tasks.extend(self.model_state.get_supported_generation_tasks())
++        if self.is_pooling_model:
++            # Do not rely on pooling_runner here, since this information is needed
++            # on the first PP rank, while pooling_runner is only initialized
++            # on the last PP rank.
++            tasks.extend(PoolingRunner.get_supported_tasks(self.model))
++        return tuple(tasks)
++
++    def load_model(self, load_dummy_weights: bool = False, *args, **kwargs) -> None:
++        time_before_load = time.perf_counter()
++        if load_dummy_weights:
++            self.load_config.load_format = "dummy"
++        self.eplb.prepare_load()
++        eplb_models_added = False
++        with DeviceMemoryProfiler() as m:
++            model_loader = get_model_loader(self.vllm_config.load_config)
++            logger.info_once("Loading model from scratch...")
++
++            self.model = model_loader.load_model(
++                vllm_config=self.vllm_config, model_config=self.vllm_config.model_config
++            )
++            if self.lora_config:
++                self.model = self.load_lora_model(
++                    self.model, self.vllm_config, self.device
++                )
++
++            if self.use_aux_hidden_state_outputs:
++                assert self.speculative_config is not None
++                set_eagle3_aux_hidden_state_layers(self.model, self.speculative_config)
++            if isinstance(self.speculator, DraftModelSpeculator):
++                with use_workspace_lane(self._draft_workspace_lane):
++                    self.speculator.load_model(self.model)
++                    eplb_models_added = self.eplb.maybe_register_speculator(
++                        self.speculator, self.speculative_config, load_dummy_weights
++                    )
++        time_after_load = time.perf_counter()
++
++        self.model_memory_usage = m.consumed_memory
++        logger.info(
++            "Model loading took %s GiB memory and %.6f seconds",
++            format_gib(m.consumed_memory),
++            time_after_load - time_before_load,
++        )
++
++        # Initialize the components that require the model.
++        self.model_state = init_model_state(
++            self.vllm_config, self.model, self.encoder_cache, self.device
++        )
++
++        self.decode_query_len = (
++            self.num_speculative_steps
++            + self.model_state.num_new_sampled_tokens_per_step
++        )
++
++        # Initialize samplers. Model states may override via custom_sampler().
++        if self.is_last_pp_rank and not self.is_pooling_model:
++            self.sampler = Sampler(
++                max_num_reqs=self.max_num_reqs,
++                vocab_size=self.vocab_size,
++                device=self.device,
++                req_states=self.req_states,
++                logprobs_mode=self.model_config.logprobs_mode,
++                num_speculative_tokens=self.decode_query_len,
++                use_fp64_gumbel=self.model_config.use_fp64_gumbel,
++                reasoning_config=self.vllm_config.reasoning_config,
++                return_sampling_mask=self.model_config.return_sampling_mask,
++            )
++            custom = self.model_state.custom_sampler(self.sampler)
++
++            if custom:
++                self.sampler, self.rejection_sampler = custom
++            elif self.speculative_config is not None:
++                self.rejection_sampler = RejectionSampler(
++                    self.sampler,
++                    self.speculative_config,
++                    self.device,
++                )
++            self.prompt_logprobs_worker = PromptLogprobsWorker(
++                self.max_num_reqs,
++                logprobs_mode=self.model_config.logprobs_mode,
++            )
++            self.structured_outputs_worker = StructuredOutputsWorker(
++                max_num_logits=self.max_num_reqs * self.decode_query_len,
++                vocab_size=self.vocab_size,
++                device=self.device,
++                mask_stride=self.decode_query_len,
++                num_bonus_tokens=self.model_state.num_new_sampled_tokens_per_step,
++            )
++
++        if self.is_pooling_model and self.is_last_pp_rank:
++            self.pooling_runner = PoolingRunner(self.model, self.vllm_config)
++        eplb_models_added |= self.eplb.maybe_register_model(
++            self.model,
++            self.model_config,
++            load_dummy_weights,
++        )
++        self.eplb.maybe_start_async_loop(eplb_models_added)
++
++        if not self.is_first_pp_rank:
++            # For non-first PP ranks, create intermediate tensors sized
++            # for the max capture size so they can be sliced per batch.
++            # Save as persistent member so runtime can copy received data
++            # into the same addresses that the CUDA graphs captured.
++            self.intermediate_tensors = self.model.make_empty_intermediate_tensors(
++                batch_size=self.max_num_tokens,
++                dtype=self.model_config.dtype,
++                device=self.device,
++            )
++
++        get_offloader().post_init()
++
++    def get_model(self) -> nn.Module:
++        return self.model
++
++    def get_draft_model(self) -> nn.Module | None:
++        speculator = self.speculator
++        if not isinstance(speculator, DraftModelSpeculator):
++            return None
++        return speculator.model
++
++    def reload_weights(self, *args, **kwargs) -> None:
++        # TODO(Wentao): Use full version instead of import when fully migrated to v2
++        from vllm.v1.worker.gpu_model_runner import GPUModelRunner as GPUModelRunnerV1
++
++        GPUModelRunnerV1.reload_weights(self, *args, **kwargs)  # type: ignore[arg-type]
++
++    def update_config(self, *args, **kwargs) -> None:
++        # TODO(Wentao): Use full version instead of import when fully migrated to v2
++        from vllm.v1.worker.gpu_model_runner import GPUModelRunner as GPUModelRunnerV1
++
++        GPUModelRunnerV1.update_config(self, *args, **kwargs)  # type: ignore[arg-type]
++
++        # v2 reads config via self.vllm_config (e.g. in load_model), so keep it
++        # in sync with the attributes the v1 helper just replaced.
++        self.vllm_config.model_config = self.model_config
++        self.vllm_config.load_config = self.load_config
++
++    @functools.cached_property
++    def main_stream(self) -> torch.cuda.Stream:
++        # Cache the default CUDA stream to avoid lookup overhead.
++        return torch.cuda.current_stream(self.device)
++
++    def get_encoder_timing_stats(self) -> dict[str, dict[str, float | int]]:
++        encoder_runner = getattr(self.model_state, "encoder_runner", None)
++        if encoder_runner is None:
++            return {}
++        return encoder_runner.get_encoder_timing_stats()
++
++    def get_kv_cache_spec(self):
++        if self.is_encoder_only:
++            return {}
++        return get_kv_cache_spec(self.vllm_config)
++
++    def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
++        kv_cache_config = deepcopy(kv_cache_config)
++        self.kv_cache_config = kv_cache_config
++
++        block_table_max_model_len = self.max_model_len
++        if self.is_encoder_decoder:
++            # Cross-attention block tables need to index encoder tokens, which
++            # can exceed the decoder's max_model_len.
++            block_table_max_model_len = max(
++                block_table_max_model_len,
++                self.scheduler_config.max_num_encoder_input_tokens,
++                getattr(self.model_config.hf_config, "max_source_positions", 0),
++            )
++
++        block_sizes = []
++        max_num_blocks_per_group = []
++        for kv_cache_group in kv_cache_config.kv_cache_groups:
++            spec = kv_cache_group.kv_cache_spec
++            block_sizes.append(spec.block_size)
++            # When using DCP, each request's KV cache is sharded among different ranks.
++            # As a result, one block on the current rank covers `block_size * cp_size`
++            # tokens in the full, global (unsharded) sequence.
++            max_num_blocks = cdiv(
++                block_table_max_model_len, spec.block_size * self.dcp_size
++            )
++            # For Mamba/Hybrid Model, KVCaches need extra blocks for speculative tokens
++            if isinstance(spec, MambaSpec):
++                max_num_blocks = (
++                    max_num_blocks if self.cache_config.enable_prefix_caching else 1
++                ) + spec.num_speculative_blocks
++                max_num_blocks = get_block_table_width(
++                    max_num_blocks, spec.block_size, token_alignment=None
++                )
++            else:
++                max_num_blocks = get_block_table_width(max_num_blocks, spec.block_size)
++            max_num_blocks_per_group.append(max_num_blocks)
++
++        self.attn_groups, attn_cg_support, self.kernel_block_sizes = init_attn_backend(
++            self.kv_cache_config, self.vllm_config, self.device
++        )
++        attn_cg_support = attn_cg_support.narrow(
++            *self.model_state.get_additional_cg_support()
++        )
++        # The speculator clears the flag at load time when the checkpoint has
++        # no confidence head, so it holds the effective value.
++        self.adaptive_verification = maybe_create_adaptive_verification_manager(
++            enable_adaptive_verification=getattr(
++                self.speculator, "enable_adaptive_verification", False
++            ),
++            attn_groups=self.attn_groups,
++            attn_cg_support=attn_cg_support,
++            req_states=self.req_states,
++            query_start_loc=self.input_buffers.query_start_loc,
++            num_bonus_tokens=self.model_state.num_new_sampled_tokens_per_step,
++            max_total_logits=get_max_chunk_logits(self.vocab_size),
++        )
++
++        self.block_tables = BlockTables(
++            block_sizes=block_sizes,
++            max_num_reqs=self.max_num_reqs,
++            max_num_batched_tokens=self.max_num_tokens,
++            max_num_blocks_per_group=max_num_blocks_per_group,
++            device=self.device,
++            kernel_block_sizes=self.kernel_block_sizes,
++            cp_size=self.dcp_size,
++            cp_rank=self.dcp_rank,
++            cp_interleave=self.cp_interleave,
++        )
++        self.pcp_manager = pcp.maybe_build_pcp_manager(
++            self.vllm_config,
++            self.device,
++            self.supports_mm_inputs,
++            self.req_states,
++            self.block_tables,
++            cls=self.pcp_manager_cls,
++        )
++        initialize_mamba_ssu_backend(
++            self.vllm_config.mamba_config, self.kv_cache_config
++        )
++        if self.adaptive_verification is not None:
++            self.compilation_config.cudagraph_mode = CUDAGraphMode.FULL_AND_PIECEWISE
++        cudagraph_mode = self.compilation_config.resolve_cudagraph_mode_and_sizes(
++            attn_cg_support.min_cg_support,
++            attn_cg_support.min_cg_attn_backend,
++            self.decode_query_len,
++            use_v2_model_runner=True,
++            tensor_parallel_size=self.parallel_config.tensor_parallel_size,
++            kv_cache_config=self.kv_cache_config,
++            max_num_reqs=self.max_num_reqs,
++        )
++        self.cudagraph_manager = ModelCudaGraphManager(
++            self.vllm_config,
++            self.device,
++            cudagraph_mode,
++            decode_query_len=self.decode_query_len,
++            lora_capture_cases=self.lora_capture_cases,
++            varlen_decode=self.adaptive_verification is not None,
++        )
++        check_attention_cp_compatibility(self.vllm_config)
++        if isinstance(self.speculator, DraftModelSpeculator):
++            # HACK(woosuk)
++            self.speculator.set_attn(
++                self.model_state,
++                self.kv_cache_config,
++                self.block_tables,
++                self.input_buffers,
++                self.attn_groups,
++            )
++        if self.speculator is not None:
++            # After set_attn, so the speculator can size its cudagraph mode
++            # to its own attention support.
++            self.speculator.init_cudagraph_manager(cudagraph_mode)
++
++        self.kv_caches: list[torch.Tensor] = []
++        kv_caches_dict = init_kv_cache(
++            self.kv_caches,
++            self.compilation_config.static_forward_context,
++            self.kv_cache_config,
++            self.attn_groups,
++            self.device,
++            self.cache_config.cache_dtype,
++            self.kernel_block_sizes,
++            self.vllm_config,
++        )
++        self.kv_connector = get_kv_connector(self.vllm_config, kv_caches_dict)
++
++    def _init_kv_zero_meta(self) -> None:
++        """Build KV-block zeroing metadata; invoked from gpu_worker."""
++        self.kv_block_zeroer = KVBlockZeroer(
++            self.device,
++            attn_groups_iter=(g for groups in self.attn_groups for g in groups),
++            kernel_block_sizes=self.kernel_block_sizes,
++            cache_dtype=self.cache_config.cache_dtype,
++            static_forward_context=self.compilation_config.static_forward_context,
++        )
++
++    @torch.inference_mode()
++    @step_eplb_after(is_dummy=True)
++    def _dummy_run(
++        self,
++        num_tokens: int,
++        *args,
++        skip_attn: bool = False,
++        uniform_decode: bool = False,
++        context_len: int = 0,
++        skip_eplb: bool = False,
++        is_profile: bool = False,
++        **kwargs,
++    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
++        if self.is_encoder_only:
++            empty = torch.empty(0, device=self.device)
++            return empty, empty
++        if skip_attn and not is_profile:
++            raise ValueError(
++                "skip_attn must only be True for initial memory profiling."
++            )
++
++        # Create a dummy scheduler output.
++        num_reqs = min(num_tokens, self.max_num_reqs)
++        if uniform_decode:
++            # HACK(lucas): for now since the worker is shared between MRV1 and MRV2,
++            # and for spec-decode with MTP we want to make sure the dummy runs use
++            # 1+num_speculative_tokens we use max here, this will likely be eventually
++            # changed in the worker: https://github.com/vllm-project/vllm/pull/35243
++            num_tokens = max(num_tokens, self.decode_query_len)
++            num_reqs = num_tokens // self.decode_query_len
++            assert num_tokens % self.decode_query_len == 0
++        # Distribute the remainder evenly so no dummy request exceeds
++        # ceil(num_tokens / num_reqs) <= max_model_len tokens.
++        num_tokens_per_request = [
++            num_tokens // num_reqs + (i >= num_reqs - num_tokens % num_reqs)
++            for i in range(num_reqs)
++        ]
++
++        assert sum(num_tokens_per_request) == num_tokens
++        num_scheduled_tokens = {
++            f"_dummy_req_{i}": n for i, n in enumerate(num_tokens_per_request)
++        }
++        dummy_scheduler_output = SchedulerOutput.make_empty()
++        dummy_scheduler_output.total_num_scheduled_tokens = num_tokens
++        dummy_scheduler_output.num_scheduled_tokens = num_scheduled_tokens
++
++        # Disable any use of KVConnector for dummy runs.
++        self.kv_connector.set_disabled(True)
++
++        # Get the intermediate tensors for the dummy run.
++        intermediate_tensors = None
++        if not self.is_first_pp_rank:
++            assert self.intermediate_tensors is not None
++            intermediate_tensors = self.intermediate_tensors[:num_tokens]
++
++        max_loras = self.lora_config.max_loras if self.lora_config is not None else 0
++        with self.maybe_dummy_run_with_lora(
++            self.lora_config,
++            num_scheduled_tokens=np.array(num_tokens_per_request, dtype=np.int32),
++            num_sampled_tokens=None,
++            remove_lora=True,
++            num_active_loras=max_loras,
++        ):
++            # Execute the model.
++            self.execute_model(
++                dummy_scheduler_output,
++                intermediate_tensors=intermediate_tensors,
++                dummy_run=True,
++                skip_attn_for_dummy_run=skip_attn,
++                is_profile=is_profile,
++                context_len=context_len,
++            )
++        self.kv_connector.set_disabled(False)
++
++        # Non-last PP ranks don't produce output for sampling.
++        if not self.is_last_pp_rank:
++            return None, None
++
++        assert self.execute_model_state is not None
++        input_batch = self.execute_model_state.input_batch
++        attn_metadata = self.execute_model_state.attn_metadata
++        slot_mappings_by_layer = self.execute_model_state.slot_mappings_by_layer
++        hidden_states = self.execute_model_state.hidden_states
++        aux_hidden_states = self.execute_model_state.aux_hidden_states
++        self.execute_model_state = None
++
++        self.step_timing.forward_end()
++
++        # dummy run the eagle speculator's propose to ensure DP/EP sync.
++        if self.speculator is not None:
++            assert self.sampler is not None
++            self.step_timing.drafter_start()
++            mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None
++            if self.speculator.supports_mm_inputs:
++                mm_inputs = (
++                    [],
++                    torch.zeros(
++                        input_batch.num_tokens,
++                        dtype=torch.bool,
++                        device="cpu",
++                    ),
++                )
++
++            # Let the target override the hidden state fed to the drafter
++            # (e.g. DeepSeek V4 MTP needs the pre-hc_head residual). The
++            # target returns a persistent buffer sized at max_num_batched_tokens;
++            # slice to the active token count that propose() expects.
++            spec_hidden_states = hidden_states
++            if hasattr(self.model, "get_mtp_target_hidden_states"):
++                pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
++                spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
++            with use_workspace_lane(self._draft_workspace_lane):
++                self.speculator.propose(
++                    input_batch=input_batch,
++                    attn_metadata=attn_metadata,
++                    slot_mappings=slot_mappings_by_layer,
++                    last_hidden_states=spec_hidden_states,
++                    aux_hidden_states=aux_hidden_states,
++                    num_sampled=torch.ones(
++                        input_batch.num_reqs, dtype=torch.int32, device=self.device
++                    ),
++                    num_rejected=torch.zeros(
++                        input_batch.num_reqs, dtype=torch.int32, device=self.device
++                    ),
++                    last_sampled=self.req_states.last_sampled_tokens,
++                    next_prefill_tokens=self.req_states.next_prefill_tokens,
++                    temperature=self.sampler.sampling_states.temperature.gpu,
++                    seeds=self.sampler.sampling_states.seeds.gpu,
++                    dummy_run=True,
++                    skip_attn_for_dummy_run=skip_attn,
++                    mm_inputs=mm_inputs,
++                    is_profile=is_profile,
++                )
++            self.step_timing.drafter_end()
++
++        assert hidden_states is not None  # Last PP rank always has hidden_states
++        sample_hidden_states = hidden_states[input_batch.logits_indices]
++        return hidden_states, sample_hidden_states
++
++    @torch.inference_mode()
++    def _dummy_sampler_run(self, hidden_states: torch.Tensor) -> None:
++        num_reqs = hidden_states.shape[0]
++        logits = self.model.compute_logits(hidden_states)
++        dummy_input_batch = InputBatch.make_dummy(
++            num_reqs, num_reqs, self.input_buffers
++        )
++
++        # NOTE(woosuk): During the initial memory profiling, the sampler may skip
++        # top_k, top_p, and logprobs, using less GPU memory than what is possible
++        # during actual execution.
++        assert self.sampler is not None
++        self.sampler(logits, dummy_input_batch)
++
++    @torch.inference_mode()
++    def _dummy_pooler_run(self, hidden_states: torch.Tensor) -> None:
++        assert self.pooling_runner is not None
++        self.pooling_runner.dummy_pooler_run(hidden_states)
++
++    @torch.inference_mode()
++    def profile_run(self) -> None:
++        if self.supports_mm_inputs and self.is_first_pp_rank:
++            mm_config = self.model_config.multimodal_config
++            if mm_config is not None and not mm_config.skip_mm_profiling:
++                mm_budget = MultiModalBudget(
++                    self.vllm_config,
++                    self.mm_registry,
++                    enable_cache=False,
++                )
++                dummy_mm_inputs = get_dummy_encoder_profile_inputs(
++                    self.mm_registry,
++                    mm_budget,
++                )
++                self.model_state.encoder_runner.profile_encoder_cache(
++                    dummy_mm_inputs, mm_budget
++                )
++
++        if self.is_encoder_only:
++            torch.accelerator.synchronize()
++            self.reset_encoder_cache()
++            gc.collect()
++            return
++
++        hidden_states, sample_hidden_states = self._dummy_run(
++            self.max_num_tokens, skip_attn=True, is_profile=True
++        )
++
++        # Only run sampler/pooler on last PP rank (non-last ranks return None).
++        if self.is_last_pp_rank:
++            assert sample_hidden_states is not None
++            if self.pooling_runner is None:
++                self._dummy_sampler_run(sample_hidden_states)
++            else:
++                self._dummy_pooler_run(hidden_states)
++
++        torch.accelerator.synchronize()
++        del hidden_states, sample_hidden_states
++        self.reset_encoder_cache()
++        gc.collect()
++
++    def post_kv_cache_wake_up(self) -> None:
++        self.block_tables.init_block_table_layout_tensors()
++
++    def reset_mm_cache(self) -> None:
++        if self.encoder_cache is not None:
++            self.encoder_cache.reset_mm_cache()
++
++    def reset_encoder_cache(self) -> None:
++        if self.encoder_cache is not None:
++            self.encoder_cache.reset_encoder_cache()
++        if self.pooling_runner is not None:
++            self.pooling_runner.clear()
++
++    def profile_cudagraph_memory(self) -> int:
++        # NOTE(woosuk): It is TBD whether we keep this API or not.
++        return 0
++
++    @torch.inference_mode()
++    def capture_model(self) -> int:
++        if self.is_encoder_only:
++            return 0
++
++        assert self.cudagraph_manager is not None
++        capture_encoder = (
++            self.model_state.supports_mm_inputs
++            and self.model_state.encoder_runner.has_cudagraph()
++        )
++        capture_decoder = self.cudagraph_manager.needs_capture()
++        if not capture_encoder and not capture_decoder:
++            logger.warning(
++                "Skipping encoder and decoder CUDA graph capture. To enable "
++                "encoder capture, ensure `cudagraph_mm_encoder` is enabled; "
++                "to enable decoder capture, ensure `cudagraph_mode` is not `NONE`."
++            )
++            return 0
++
++        compilation_counter.num_gpu_runner_capture_triggers += 1
++
++        start_time = time.perf_counter()
++        gc.collect()
++        torch.accelerator.empty_cache()
++        start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
++
++        with self.maybe_setup_dummy_loras(self.lora_config):
++            if capture_encoder:
++                self.model_state.encoder_runner.capture()
++
++            if capture_decoder:
++                self.cudagraph_manager.capture(
++                    self.model,
++                    self.model_state,
++                    self.input_buffers,
++                    self.intermediate_tensors,
++                    self.block_tables,
++                    self.attn_groups,
++                    self.kv_cache_config,
++                    has_lora=self.lora_config is not None,
++                    use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
++                    lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
++                )
++                if self.speculator is not None:
++                    with use_workspace_lane(self._draft_workspace_lane):
++                        self.speculator.capture()
++                if self.adaptive_verification is not None:
++                    with self.step_timing.collect() as timings:
++                        for batch in self.adaptive_verification.batches_to_profile(
++                            self.cudagraph_manager.captured_token_counts()
++                        ):
++                            self._dummy_run(**batch)
++                    self.adaptive_verification.set_initial_cost_curves(timings)
++
++        end_time = time.perf_counter()
++        end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
++        elapsed_time = end_time - start_time
++        cuda_graph_size = start_free_gpu_memory - end_free_gpu_memory
++        # This usually takes 5~20 seconds.
++        logger.info(
++            "Graph capturing finished in %.0f secs, took %.2f GiB",
++            elapsed_time,
++            cuda_graph_size / (1 << 30),
++        )
++        return cuda_graph_size
++
++    def _remove_request(self, req_id: str) -> bool:
++        # Call model_state.remove_request *before* req_states.remove_request
++        # so the model_state can still look up the slot index.
++        self.model_state.remove_request(req_id)
++        req_idx = self.req_states.remove_request(req_id)
++        if req_idx is None:
++            return False
++        if self.pooling_runner is not None:
++            self.pooling_runner.remove_request(req_idx)
++        if self.pp_handler is not None:
++            self.pp_handler.on_req_idx_freed(req_idx)
++        if self.encoder_cache is not None:
++            self.encoder_cache.remove_request(req_id)
++        if self.prompt_logprobs_worker is not None:
++            self.prompt_logprobs_worker.remove_request(req_id)
++        self.lora_state.remove_request(req_id)
++        return True
++
++    def finish_requests(self, scheduler_output: SchedulerOutput) -> None:
++        finished_req_ids = scheduler_output.finished_req_ids
++        if self.pooling_runner is not None:
++            # Preempted docs keep their query-use reservation until rescheduled.
++            self.pooling_runner.on_requests_finished(finished_req_ids)
++        preempted_req_ids = scheduler_output.preempted_req_ids
++        if preempted_req_ids:
++            finished_req_ids = finished_req_ids.union(preempted_req_ids)
++        for req_id in finished_req_ids:
++            self._remove_request(req_id)
++
++    def free_states(self, scheduler_output: SchedulerOutput) -> None:
++        if self.encoder_cache is not None:
++            for mm_hash in scheduler_output.free_encoder_mm_hashes:
++                self.encoder_cache.free_encoder_cache(mm_hash)
++
++    def update_pp_decode_requests(self):
++        # For non-last PP ranks, update decode requests with sampler output from
++        # the prior step in which they were scheduled (pp_size steps ago).
++        if self.pp_handler is not None:
++            outputs = self.pp_handler.get_prev_sampled_outputs()
++            if outputs is not None:
++                self.postprocess_sampled(**outputs)
++
++    def add_requests(self, scheduler_output: SchedulerOutput) -> None:
++        for new_req_data in scheduler_output.scheduled_new_reqs:
++            assert new_req_data.prompt_token_ids is not None
++            assert new_req_data.prefill_token_ids is not None
++            req_id = new_req_data.req_id
++
++            # Streaming input update: request already exists from a prior
++            # chunk. Remove old state so it can be cleanly re-added below
++            # with the updated prompt_token_ids and mm_features.
++            self._remove_request(req_id)
++
++            prompt_len = len(new_req_data.prompt_token_ids)
++            sampling_params = new_req_data.sampling_params
++            self.req_states.add_request(
++                req_id=req_id,
++                prompt_len=prompt_len,
++                all_token_ids=new_req_data.prefill_token_ids,
++                num_computed_tokens=new_req_data.num_computed_tokens,
++                max_tokens=sampling_params.max_tokens if sampling_params else 1,  # type: ignore[arg-type]
++            )
++            req_index = self.req_states.req_id_to_index[req_id]
++            if self.adaptive_verification is not None:
++                self.adaptive_verification.add_request(req_index)
++
++            if self.pooling_runner is not None:
++                assert new_req_data.pooling_params is not None
++                self.pooling_runner.add_request(
++                    req_id,
++                    req_index,
++                    new_req_data.pooling_params,
++                    new_req_data.prompt_token_ids,
++                )
++
++            if self.encoder_cache is not None:
++                self.encoder_cache.add_request(req_id, new_req_data.mm_features)
++
++            self.model_state.add_request(req_index, new_req_data)
++            self.block_tables.append_block_ids(
++                req_index, new_req_data.block_ids, overwrite=True
++            )
++            self.lora_state.add_request(req_id, req_index, new_req_data.lora_request)
++
++            if self.is_last_pp_rank and new_req_data.sampling_params is not None:
++                assert self.sampler is not None
++                self.sampler.add_request(
++                    req_index, prompt_len, new_req_data.sampling_params
++                )
++                assert self.prompt_logprobs_worker is not None
++                self.prompt_logprobs_worker.add_request(
++                    req_id, req_index, new_req_data.sampling_params
++                )
++
++        if scheduler_output.scheduled_new_reqs:
++            self.req_states.apply_staged_writes()
++            self.model_state.apply_staged_writes()
++        if self.sampler is not None:
++            self.sampler.apply_staged_writes()
++
++    def update_requests(self, scheduler_output: SchedulerOutput) -> None:
++        # Add new blocks and update num_computed_tokens for the existing requests.
++        reqs = scheduler_output.scheduled_cached_reqs
++        num_computed_tokens_np = self.req_states.num_computed_tokens_np
++        for req_id, num_computed_tokens, req_new_block_ids in zip(
++            reqs.req_ids, reqs.num_computed_tokens, reqs.new_block_ids
++        ):
++            req_index = self.req_states.req_id_to_index[req_id]
++            num_computed_tokens_np[req_index] = num_computed_tokens
++            if req_new_block_ids is not None:
++                self.block_tables.append_block_ids(
++                    req_index, req_new_block_ids, overwrite=False
++                )
++
++        # Update CPU num_computed_prefill_tokens.
++        np.minimum(
++            self.req_states.num_computed_tokens_np,
++            self.req_states.prefill_len.np,
++            out=self.req_states.num_computed_prefill_tokens,
++        )
++
++        # Zero GPU memory for freshly allocated cache blocks to prevent
++        # stale NaN/data from corrupting attention or SSM computation.
++        if scheduler_output.new_block_ids_to_zero:
++            assert self.kv_block_zeroer is not None
++            self.kv_block_zeroer.zero_block_ids(scheduler_output.new_block_ids_to_zero)
++
++        # Apply copy-on-write block copies for partial prefix-cache hits, after
++        # zeroing new blocks and before the forward pass reads them.
++        if scheduler_output.kv_cache_block_copies:
++            copy_kv_cache_blocks_inplace(
++                self.kv_caches,
++                self.kv_cache_config.num_blocks,
++                scheduler_output.kv_cache_block_copies,
++            )
++
++    def gather_batch_req_state(
++        self, scheduler_output: SchedulerOutput, dummy_run: bool
++    ) -> tuple["BatchReqState | None", int | None]:
++        """Gather CPU request state for the scheduled batch, in batch order.
++        Returns (batch_state, uniform_decode_token_count)
++        """
++        num_tokens_per_req = scheduler_output.num_scheduled_tokens
++        num_reqs = len(num_tokens_per_req)
++        num_toks = scheduler_output.total_num_scheduled_tokens
++        max_query_len = max(scheduler_output.num_scheduled_tokens.values())
++
++        if dummy_run:
++            # Dummy batches are uniform by construction.
++            return None, get_uniform_decode_token_count(
++                num_reqs, num_toks, max_query_len, has_prefill=False
++            )
++
++        draft_tokens = scheduler_output.scheduled_spec_decode_tokens
++        # batch_idx -> req_id
++        req_ids = sort_batch_req_ids(
++            num_tokens_per_req, draft_tokens, self.decode_query_len
++        )
++
++        numtoks_iter = map(num_tokens_per_req.__getitem__, req_ids)
++        num_scheduled_tokens = np.fromiter(numtoks_iter, dtype=np.int32, count=num_reqs)
++
++        idx_mapping_iter = map(self.req_states.req_id_to_index.__getitem__, req_ids)
++        idx_mapping_np = np.fromiter(idx_mapping_iter, dtype=np.intp, count=num_reqs)
++        prefill_len_np = self.req_states.prefill_len.np[idx_mapping_np]
++        num_computed_prefill_tokens_np = self.req_states.num_computed_prefill_tokens[
++            idx_mapping_np
++        ]
++        is_prefilling_np = num_computed_prefill_tokens_np < prefill_len_np
++
++        if self.adaptive_verification is not None and draft_tokens:
++            num_toks = self.adaptive_verification.get_num_tokens(
++                num_tokens_per_req, draft_tokens
++            )
++
++        batch_state = BatchReqState(
++            req_ids=req_ids,
++            num_scheduled_tokens=num_scheduled_tokens,
++            num_tokens=num_toks,
++            idx_mapping_np=idx_mapping_np,
++            prefill_len_np=prefill_len_np,
++            num_computed_prefill_tokens_np=num_computed_prefill_tokens_np,
++            is_prefilling_np=is_prefilling_np,
++            has_prefill=bool(is_prefilling_np.any()),
++        )
++        return batch_state, get_uniform_decode_token_count(
++            num_reqs, num_toks, max_query_len, batch_state.has_prefill
++        )
++
++    def prepare_inputs(
++        self,
++        scheduler_output: SchedulerOutput,
++        batch_req_state: "BatchReqState",
++        batch_desc: BatchExecutionDescriptor,
++    ) -> InputBatch:
++        num_tokens = batch_req_state.num_tokens
++        num_tokens_after_padding = batch_desc.num_tokens
++        assert num_tokens > 0
++        if envs.VLLM_MOE_SKIP_PADDING:
++            # Mark trailing cudagraph-padding rows so kernels can skip work for
++            # them when supported.
++            is_padding = self.input_buffers.is_padding
++            is_padding[:num_tokens].fill_(False)
++            is_padding[num_tokens:num_tokens_after_padding].fill_(True)
++
++        req_ids = batch_req_state.req_ids
++        num_scheduled_tokens_np = batch_req_state.num_scheduled_tokens
++        idx_mapping_np = batch_req_state.idx_mapping_np
++        idx_mapping = async_copy_to_gpu(idx_mapping_np, device=self.device)
++        num_reqs = len(req_ids)
++
++        # Get the number of draft tokens for each request.
++        draft_tokens = scheduler_output.scheduled_spec_decode_tokens
++        num_draft_tokens_per_req = None
++        if not draft_tokens:
++            # No draft token scheduled (common case).
++            total_num_draft_tokens = 0
++            total_num_logits = num_reqs
++            cu_num_logits_np = np.arange(num_reqs + 1, dtype=np.int32)
++            cu_num_logits = torch.arange(
++                num_reqs + 1, device=self.device, dtype=torch.int32
++            )
++            expanded_idx_mapping = idx_mapping
++            expanded_local_pos = torch.zeros(
++                num_reqs, dtype=torch.int32, device=self.device
++            )
++        else:
++            num_draft_tokens_per_req = np.fromiter(
++                (len(draft_tokens.get(req_id, ())) for req_id in req_ids),
++                dtype=np.int32,
++                count=num_reqs,
++            )
++            num_bonus_tokens = self.model_state.num_new_sampled_tokens_per_step
++            total_num_draft_tokens = int(num_draft_tokens_per_req.sum())
++            total_num_logits = num_reqs * num_bonus_tokens + total_num_draft_tokens
++            num_logits = num_draft_tokens_per_req + num_bonus_tokens
++            cu_num_logits_np = np.empty(num_reqs + 1, dtype=np.int32)
++            cu_num_logits_np[0] = 0
++            np.cumsum(num_logits, out=cu_num_logits_np[1:])
++            cu_num_logits = async_copy_to_gpu(cu_num_logits_np, device=self.device)
++
++        adaptive_verification = (
++            self.adaptive_verification if num_draft_tokens_per_req is not None else None
++        )
++        num_scheduled_tokens_upper_bound = num_scheduled_tokens_np
++        if adaptive_verification is not None:
++            # num_scheduled_tokens represents the draft budget evenly distributed across
++            # all verification requests, `reallocate_drafts` will unevenly assign the
++            # draft budget to requests on the GPU side only.
++            num_scheduled_tokens_np, cu_num_logits_np = (
++                adaptive_verification.compact_batch(
++                    num_draft_tokens_per_req,
++                    num_scheduled_tokens_np,
++                    cu_num_logits_np,
++                )
++            )
++
++        # Get query_start_loc.
++        # num_reqs_padded is None for PIECEWISE graphs (no request padding needed)
++        num_reqs_padded = batch_desc.num_reqs or num_reqs
++        query_start_loc_np = np.empty(self.max_num_reqs + 1, dtype=np.int32)
++        query_start_loc_np[0] = 0
++        np.cumsum(num_scheduled_tokens_np, out=query_start_loc_np[1 : num_reqs + 1])
++        # Pad for full CUDA graph mode.
++        # Some attention backends like FA3 require query_start_loc to be non-decreasing.
++        query_start_loc_np[num_reqs + 1 :] = num_tokens
++        query_start_loc = self.input_buffers.query_start_loc
++        async_copy_to_gpu(query_start_loc_np, out=query_start_loc)
++        if adaptive_verification is not None:
++            cu_num_logits, query_start_loc, total_num_draft_tokens = (
++                adaptive_verification.reallocate_drafts(req_ids, idx_mapping)
++            )
++            total_num_logits = num_reqs * num_bonus_tokens + total_num_draft_tokens
++        if draft_tokens:
++            expanded_idx_mapping, expanded_local_pos = expand_idx_mapping(
++                idx_mapping, total_num_logits, cu_num_logits, self.decode_query_len
++            )
++        query_start_loc_np = query_start_loc_np[: num_reqs_padded + 1]
++        query_start_loc = query_start_loc[: num_reqs_padded + 1]
++
++        # Get prefill tokens if any.
++        if batch_req_state.has_prefill:
++            prepare_prefill_inputs(
++                self.input_buffers.input_ids,
++                self.req_states.next_prefill_tokens,
++                idx_mapping,
++                query_start_loc,
++                self.req_states.all_token_ids.gpu,
++                self.req_states.prefill_len.gpu,
++                self.req_states.num_computed_tokens.gpu,
++            )
++
++        # Prepare positions and seq_lens.
++        prepare_pos_seq_lens(
++            idx_mapping,
++            query_start_loc,
++            self.req_states.num_computed_tokens.gpu,
++            self.input_buffers.positions,
++            self.input_buffers.seq_lens,
++        )
++        seq_lens = self.input_buffers.seq_lens[:num_reqs_padded]
++
++        dcp_local_seq_lens = None
++        if self.use_dcp:
++            # Prepare dcp local seq_lens.
++            prepare_dcp_local_seq_lens(
++                self.input_buffers.dcp_local_seq_lens,
++                self.input_buffers.seq_lens,
++                num_reqs,
++                self.dcp_size,
++                self.dcp_rank,
++                self.cp_interleave,
++            )
++            dcp_local_seq_lens = self.input_buffers.dcp_local_seq_lens[:num_reqs_padded]
++
++        # Some input token ids are directly read from the last sampled tokens
++        # and draft tokens. Also, get the logits indices to sample tokens from.
++        logits_indices = combine_sampled_and_draft_tokens(
++            self.input_buffers.input_ids,
++            idx_mapping,
++            self.req_states.last_sampled_tokens,
++            query_start_loc,
++            seq_lens,
++            self.req_states.prefill_len.gpu,
++            self.req_states.draft_tokens,
++            cu_num_logits,
++            total_num_logits,
++            self.model_state.num_new_sampled_tokens_per_step,
++        )
++
++        # CPU upper bound on seq_lens; padded entries left at zero.
++        num_computed_tokens_np = self.req_states.num_computed_tokens_np[idx_mapping_np]
++        seq_lens_cpu_upper_bound_np = np.zeros(num_reqs_padded, dtype=np.int32)
++        np.add(
++            num_computed_tokens_np,
++            num_scheduled_tokens_upper_bound,
++            out=seq_lens_cpu_upper_bound_np[:num_reqs],
++        )
++        seq_lens_cpu_upper_bound = torch.from_numpy(seq_lens_cpu_upper_bound_np)
++
++        max_seq_len_np = None
++        if self.use_pp:
++            # max_seq_len is only consumed by the PP `compute_need_sampled_mask`
++            max_seq_len_np = self.req_states.max_seq_len[idx_mapping_np]
++
++        prompt_lens = None
++        if self.model_config.rswa_window is not None:
++            # prompt_lens is only used in R-SWA case.
++            prompt_lens = self.req_states.prompt_len.gpu[idx_mapping]
++
++        input_batch = InputBatch(
++            req_ids=req_ids,
++            num_reqs=num_reqs,
++            num_reqs_after_padding=num_reqs_padded,
++            idx_mapping=idx_mapping,
++            idx_mapping_np=idx_mapping_np,
++            expanded_idx_mapping=expanded_idx_mapping,
++            expanded_local_pos=expanded_local_pos,
++            num_scheduled_tokens=num_scheduled_tokens_upper_bound,
++            num_tokens=num_tokens,
++            num_tokens_after_padding=num_tokens_after_padding,
++            num_draft_tokens=total_num_draft_tokens,
++            num_draft_tokens_per_req=num_draft_tokens_per_req,
++            query_start_loc=query_start_loc,
++            query_start_loc_np=query_start_loc_np,
++            seq_lens=seq_lens,
++            seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
++            dcp_local_seq_lens=dcp_local_seq_lens,
++            num_computed_tokens_np=num_computed_tokens_np,
++            prefill_len_np=batch_req_state.prefill_len_np,
++            num_computed_prefill_tokens_np=batch_req_state.num_computed_prefill_tokens_np,
++            is_prefilling_np=batch_req_state.is_prefilling_np,
++            has_prefill=batch_req_state.has_prefill,
++            max_seq_len_np=max_seq_len_np,
++            input_ids=self.input_buffers.input_ids[:num_tokens_after_padding],
++            positions=self.input_buffers.positions[:num_tokens_after_padding],
++            is_padding=self.input_buffers.is_padding[:num_tokens_after_padding],
++            logits_indices=logits_indices,
++            cu_num_logits=cu_num_logits,
++            cu_num_logits_np=cu_num_logits_np,
++            has_structured_output_reqs=scheduler_output.has_structured_output_requests,
++            prompt_lens=prompt_lens,
++            max_query_len=(
++                int(num_scheduled_tokens_upper_bound.max())
++                if adaptive_verification is not None
++                else None
++            ),
++        )
++        return pcp.maybe_partition_pcp_batch(self.pcp_manager, input_batch)
++
++    def prepare_attn(
++        self, input_batch: InputBatch
++    ) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
++        if self.pcp_manager is not None:
++            return self.pcp_manager.prepare_attn(input_batch)
++
++        # Block tables: num_kv_cache_groups x [num_reqs_padded, max_num_blocks].
++        block_tables = self.block_tables.gather_block_tables(
++            input_batch.idx_mapping,
++            num_reqs_padded=input_batch.num_reqs_after_padding,
++        )
++        # Slot mappings: [num_kv_cache_groups, num_tokens_padded].
++        # Kernel pads beyond num_tokens with PAD_SLOT_ID.
++        slot_mappings = self.block_tables.compute_slot_mappings(
++            input_batch.idx_mapping,
++            input_batch.query_start_loc,
++            input_batch.positions,
++            num_tokens_padded=input_batch.num_tokens_after_padding,
++        )
++        return block_tables, slot_mappings
++
++    def prepare_dummy_attn(
++        self, input_batch: InputBatch
++    ) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
++        block_tables = self.block_tables.get_dummy_block_tables(input_batch.num_reqs)
++        slot_mappings = pcp.maybe_get_pcp_dummy_slot_mappings(
++            self.pcp_manager, self.block_tables, input_batch.num_tokens
++        )
++        return block_tables, slot_mappings
++
++    def sample(
++        self,
++        hidden_states: torch.Tensor,
++        input_batch: InputBatch,
++        grammar_output: GrammarOutput | None,
++    ) -> tuple[SamplerOutput, torch.Tensor, torch.Tensor]:
++        sample_hidden_states = hidden_states[input_batch.logits_indices]
++        logits = self.model.compute_logits(sample_hidden_states)
++        if grammar_output is not None:
++            # Apply grammar bitmask to the logits in-place.
++            assert self.structured_outputs_worker is not None
++            self.structured_outputs_worker.apply_grammar_bitmask(
++                logits,
++                input_batch,
++                grammar_output.structured_output_request_ids,
++                grammar_output.grammar_bitmask,
++            )
++
++        if input_batch.num_draft_tokens == 0 or self.rejection_sampler is None:
++            assert self.sampler is not None
++            sampler_output = self.sampler(logits, input_batch)
++        else:
++            # Rejection sampling for spec decoding.
++            assert self.rejection_sampler is not None
++            assert self.speculator is not None
++            sampler_output = self.rejection_sampler(
++                logits,
++                input_batch,
++                # Draft logits are needed for probabilistic rejection sampling.
++                self.speculator.draft_logits,
++            )
++
++        return sampler_output, sampler_output.num_sampled, sampler_output.num_rejected
++
++    def postprocess_sampled(
++        self,
++        idx_mapping: torch.Tensor,  # May include -1 for masked entries
++        sampled_tokens: torch.Tensor,
++        num_sampled: torch.Tensor,
++        num_rejected: torch.Tensor,
++        query_start_loc: torch.Tensor | None = None,
++    ) -> None:
++        # Update the number of computed tokens.
++        if self.is_last_pp_rank:
++            assert self.sampler is not None
++            output_bin_counts = self.sampler.penalties_state.output_bin_counts
++        else:
++            output_bin_counts = None
++        post_update(
++            idx_mapping,
++            self.req_states.num_computed_tokens.gpu,
++            self.req_states.last_sampled_tokens,
++            output_bin_counts,
++            sampled_tokens,
++            num_sampled,
++            num_rejected,
++            query_start_loc,
++            self.req_states.all_token_ids.gpu,
++            self.req_states.total_len.gpu,
++        )
++
++        self.model_state.postprocess_state(
++            idx_mapping, num_sampled, self.req_states.num_computed_tokens.gpu
++        )
++
++    def _merge_ec_connector_no_forward(
++        self, scheduler_output: SchedulerOutput, output: ModelRunnerOutput
++    ) -> ModelRunnerOutput:
++        """Let the EC connector send/recv on a step with no work to run."""
++        return ModelRunnerOutput.with_ec_conn_output(
++            output,
++            self.ec_connector.no_forward(scheduler_output).ec_connector_output,
++        )
++
++    @torch.inference_mode()
++    def execute_model(
++        self,
++        scheduler_output: SchedulerOutput,
++        intermediate_tensors: IntermediateTensors | None = None,
++        dummy_run: bool = False,
++        skip_attn_for_dummy_run: bool = False,
++        is_profile: bool = False,
++        context_len: int = 0,
++    ) -> ModelRunnerOutput | IntermediateTensors | None:
++        if not dummy_run:
++            # Update the request states.
++            self.update_pp_decode_requests()
++            self.finish_requests(scheduler_output)
++            self.free_states(scheduler_output)
++            self.add_requests(scheduler_output)
++            self.update_requests(scheduler_output)
++            self.block_tables.apply_staged_writes()
++            if scheduler_output.total_num_scheduled_tokens == 0:
++                # No need to run the model.
++                empty_output = self.kv_connector.no_forward(scheduler_output)
++                return self._merge_ec_connector_no_forward(
++                    scheduler_output, empty_output
++                )
++
++        # Get batch descriptor and sync across DP ranks.
++        num_reqs = len(scheduler_output.num_scheduled_tokens)
++        num_toks = scheduler_output.total_num_scheduled_tokens
++        max_query_len = max(scheduler_output.num_scheduled_tokens.values())
++        batch_req_state, uniform_tok_count = self.gather_batch_req_state(
++            scheduler_output, dummy_run
++        )
++        if batch_req_state is not None:
++            num_toks = batch_req_state.num_tokens
++
++        num_active_loras = 0
++        if self.lora_config:
++            req_ids = list(scheduler_output.num_scheduled_tokens.keys())
++            num_active_loras = get_num_active_loras_for_dispatch(
++                self.lora_config, self.lora_state, req_ids, dummy_run
++            )
++
++        skip_compiled = False
++        if self.is_encoder_decoder and scheduler_output.scheduled_encoder_inputs:
++            # Encoder-decoder models such as Whisper should run eager/non-compiled
++            # when encoder inputs are scheduled, because this step updates
++            # cross-attention cache with dynamic encoder outputs.
++            skip_compiled = True
++
++        batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
++            self.cudagraph_manager,
++            num_reqs,
++            num_toks,
++            uniform_tok_count,
++            self.dp_size,
++            self.dp_rank,
++            max_query_len=max_query_len,
++            need_eager=is_profile or skip_compiled,
++            num_active_loras=num_active_loras,
++        )
++
++        if batch_desc.num_tokens == 0:
++            # All DP ranks have zero tokens to run.
++            empty_output = self.kv_connector.no_forward(scheduler_output)
++            return self._merge_ec_connector_no_forward(scheduler_output, empty_output)
++
++        if not dummy_run:
++            # Common case.
++            # Prepare all the inputs and copy to the input buffers.
++            assert batch_req_state is not None
++            input_batch = self.prepare_inputs(
++                scheduler_output, batch_req_state, batch_desc
++            )
++            block_tables, slot_mappings = self.prepare_attn(input_batch)
++            # Mamba "align" pre-copy: migrate recurrent state across block
++            # boundaries before the forward. Runs only on real batches, and
++            # before model_state.prepare_attn gathers num_accepted_tokens so the
++            # boundary reset is visible to the attention metadata.
++            self.model_state.preprocess_state(
++                input_batch,
++                block_tables,
++                self.kv_cache_config,
++                self.req_states.num_computed_tokens.gpu,
++            )
++
++            if self.lora_config:
++                # Activate LoRA adapters.
++                lora_inputs = self.lora_state.make_lora_inputs(
++                    input_batch.req_ids,
++                    input_batch.idx_mapping_np,
++                    input_batch.num_scheduled_tokens,
++                )
++                self._set_active_loras(*lora_inputs)
++        else:
++            # No actual tokens to run. A dummy run for DP or memory profiling.
++            dummy_num_reqs = batch_desc.num_reqs or num_reqs
++            input_batch = InputBatch.make_dummy(
++                dummy_num_reqs,
++                batch_desc.num_tokens,
++                self.input_buffers,
++                max_query_len=batch_desc.max_query_len,
++            )
++            if not skip_attn_for_dummy_run:
++                block_tables, slot_mappings = self.prepare_dummy_attn(input_batch)
++                if context_len:
++                    set_dummy_context(
++                        input_batch,
++                        self.block_tables,
++                        context_len,
++                        self.kv_cache_config.num_blocks,
++                        self.max_model_len,
++                    )
++            else:
++                assert batch_desc.cg_mode != CUDAGraphMode.FULL, (
++                    "Attention metadata must be prepared for dummy runs when using "
++                    "FULL cudagraph mode."
++                )
++                block_tables = None
++                slot_mappings = None
++
++        attn_metadata = None
++        slot_mappings_by_layer = None
++        if not (dummy_run and skip_attn_for_dummy_run):
++            assert slot_mappings is not None
++            slot_mappings_by_layer = build_slot_mappings_by_layer(
++                slot_mappings, self.kv_cache_config
++            )
++            assert block_tables is not None
++            attn_metadata = self.model_state.prepare_attn(
++                input_batch,
++                batch_desc.cg_mode,
++                block_tables,
++                slot_mappings,
++                self.attn_groups,
++                self.kv_cache_config,
++                # FULL replay reads capture-time metadata buffers. Re-stage them
++                # from the zeroed dummy block tables instead of retaining state
++                # indices from the previous real batch.
++                for_capture=dummy_run and batch_desc.cg_mode == CUDAGraphMode.FULL,
++            )
++
++        input_ids = input_batch.input_ids
++        inputs_embeds = None
++        ec_connector_output = None
++        if self.supports_mm_inputs and self.is_first_pp_rank:
++            # Run MM encoder (if needed) and get multimodal embeddings.
++            # Only first PP rank prepares multimodal embeddings.
++            if dummy_run:
++                # Obtain mm embeddings of correct shape for compiled model.
++                inputs_embeds = self.model_state.dummy_inputs_embeds(
++                    input_batch.num_tokens_after_padding
++                )
++            else:
++                scheduled_encoder_inputs = scheduler_output.scheduled_encoder_inputs
++                if self.lora_config is not None:
++                    set_active_mm_loras(
++                        model=self.model,
++                        lora_manager=self.lora_manager,
++                        encoder_cache=self.encoder_cache,
++                        req_id_to_index=self.req_states.req_id_to_index,
++                        lora_state=self.lora_state,
++                        scheduled_encoder_inputs=scheduled_encoder_inputs,
++                    )
++                with self.ec_connector.maybe_get_output(
++                    scheduler_output
++                ) as ec_connector_output:
++                    if self.is_encoder_only:
++                        # Encode and publish, nothing else: this instance runs no
++                        # language model, so the gather inside get_mm_embeddings
++                        # would build an inputs_embeds nobody reads -- and it
++                        # raises "Encoder cache miss" for any scheduled item this
++                        # instance did not encode, taking the engine down with it.
++                        self.model_state.execute_mm_encoder(scheduled_encoder_inputs)
++                    else:
++                        inputs_embeds = self.model_state.get_mm_embeddings(
++                            scheduled_encoder_inputs, input_batch, self.req_states
++                        )
++            if inputs_embeds is not None and not self.model.requires_raw_input_tokens:
++                input_ids = None
++
++        if self.is_encoder_only:
++            return ModelRunnerOutput.with_ec_conn_output(
++                make_empty_encoder_model_runner_output(scheduler_output),
++                ec_connector_output,
++            )
++
++        model_inputs = {
++            "input_ids": input_ids,
++            "positions": input_batch.positions,
++            "inputs_embeds": inputs_embeds,
++            "intermediate_tensors": None,
++            # NOTE: Values returned by `prepare_inputs` will override the default
++            # values above.
++            **self.model_state.prepare_inputs(input_batch, self.req_states),
++        }
++        if not self.is_first_pp_rank:
++            # Update for non-first PP ranks.
++            model_inputs["input_ids"] = None
++            model_inputs["inputs_embeds"] = None
++
++            # Prepare the intermediate tensors.
++            assert intermediate_tensors is not None
++            assert self.intermediate_tensors is not None
++            n = input_batch.num_tokens_after_padding
++            new_tensors = {
++                k: v[:n]
++                if dummy_run
++                else v[:n].copy_(intermediate_tensors.tensors[k][:n])
++                for k, v in self.intermediate_tensors.tensors.items()
++            }
++            model_inputs["intermediate_tensors"] = IntermediateTensors(new_tensors)
++            del intermediate_tensors
++
++        # Update the EPLB meta.
++        self.eplb.prepare_forward(self.model_config, input_batch.num_tokens)
++
++        self.step_timing.record_batch(
++            input_batch, batch_desc.cg_mode == CUDAGraphMode.FULL
++        )
++        self.step_timing.forward_start()
++
++        # Run model.
++        if batch_desc.cg_mode == CUDAGraphMode.FULL:
++            # Use explicit cudagraph replay for FULL mode.
++            # NOTE(woosuk): Here, we don't need to pass the input tensors,
++            # because they are already copied to the CUDA graph input buffers.
++            assert self.cudagraph_manager is not None
++            self.kv_connector.pre_forward(scheduler_output)
++            model_output = self.cudagraph_manager.run_fullgraph(batch_desc)
++        else:
++            # For piecewise and eager mode, just call model().
++            batch_descriptor = BatchDescriptor(
++                num_tokens=input_batch.num_tokens_after_padding,
++                has_lora=self.lora_config is not None,
++                num_active_loras=batch_desc.num_active_loras,
++            )
++
++            with set_forward_context(
++                attn_metadata,
++                self.vllm_config,
++                num_tokens=input_batch.num_tokens_after_padding,
++                cudagraph_runtime_mode=batch_desc.cg_mode,
++                num_tokens_across_dp=num_tokens_across_dp,
++                batch_descriptor=batch_descriptor,
++                slot_mapping=slot_mappings_by_layer,
++                skip_compiled=skip_compiled,
++                is_padding=input_batch.is_padding,
++            ):
++                self.kv_connector.pre_forward(scheduler_output)
++                if batch_desc.cg_mode == CUDAGraphMode.PIECEWISE:
++                    # Run the PIECEWISE graph (compiled PW cudagraph or breakable
++                    # cudagraph, chosen inside run_pw_graph). cg_mode is only
++                    # PIECEWISE after the cudagraph manager exists.
++                    assert self.cudagraph_manager is not None
++                    model_output = self.cudagraph_manager.run_pw_graph(
++                        self.model, model_inputs
++                    )
++                else:
++                    # Eager (NONE): call the raw model directly.
++                    model_output = self.model(**model_inputs)
++
++        if self.is_last_pp_rank:
++            if self.use_aux_hidden_state_outputs:
++                assert isinstance(model_output, tuple)
++                hidden_states, aux_hidden_states = model_output
++            else:
++                assert isinstance(model_output, torch.Tensor)
++                hidden_states = model_output
++                aux_hidden_states = None
++            output_intermediate_tensors = None
++        else:
++            assert isinstance(model_output, IntermediateTensors)
++            hidden_states = None
++            aux_hidden_states = None
++            output_intermediate_tensors = model_output
++
++        routed_experts = None
++        if not dummy_run and (capturer := self.routed_experts_capturer) is not None:
++            assert slot_mappings is not None
++            routed_experts = capturer.get_routed_experts(slot_mappings, num_toks)
++
++        finished_req_ids = scheduler_output.finished_req_ids
++        self.execute_model_state = ExecuteModelState(
++            input_batch=input_batch,
++            attn_metadata=attn_metadata,
++            slot_mappings_by_layer=slot_mappings_by_layer,
++            hidden_states=hidden_states,
++            aux_hidden_states=aux_hidden_states,
++            finished_req_ids=finished_req_ids,
++            ec_connector_output=ec_connector_output,
++            routed_experts=routed_experts,
++        )
++
++        if not self.is_last_pp_rank:
++            # Non-last PP rank: return IntermediateTensors for sending.
++            return output_intermediate_tensors
++        return None
++
++    @torch.inference_mode()
++    @step_eplb_after()
++    def sample_tokens(
++        self, grammar_output: GrammarOutput | None
++    ) -> AsyncOutput | ModelRunnerOutput | None:
++        if self.execute_model_state is None:
++            # The prior execute_model call must have failed.
++            return None
++
++        input_batch = self.execute_model_state.input_batch
++        attn_metadata = self.execute_model_state.attn_metadata
++        slot_mappings_by_layer = self.execute_model_state.slot_mappings_by_layer
++        hidden_states = self.execute_model_state.hidden_states
++        aux_hidden_states = self.execute_model_state.aux_hidden_states
++        finished_req_ids = self.execute_model_state.finished_req_ids
++        ec_connector_output = self.execute_model_state.ec_connector_output
++        routed_experts = self.execute_model_state.routed_experts
++        self.execute_model_state = None
++
++        if not self.is_last_pp_rank:
++            # Non-last PP rank: hidden_states is None because this rank produced
++            # IntermediateTensors instead of final hidden states. Receive the
++            # sampled tokens broadcast from the last rank and update local state.
++            assert self.pp_handler is not None
++            all_decode_next = self.pp_handler.receive(input_batch)
++            # Optimistically update num_computed_tokens for entire batch here.
++            # Will be adjusted for rejections if necessary in update_requests.
++            self.postprocess_num_computed_tokens(input_batch)
++            if not all_decode_next:
++                # Might contain non-final prefill chunks, which will be scheduled
++                # in the immediate next step (rather than in pp_size steps).
++                self.model_state.postprocess_state(input_batch.idx_mapping, 0)
++
++            # Post-step KV connector related operations.
++            kv_connector_output = self.kv_connector.post_forward(finished_req_ids)
++            # The first PP rank holds the encoder cache, so pass its EC output on.
++            output = ModelRunnerOutput.with_kv_conn_output_only(kv_connector_output)
++            return ModelRunnerOutput.with_ec_conn_output(output, ec_connector_output)
++
++        # Last rank: sample tokens
++        hidden_states, input_batch = pcp.maybe_restore_pcp_for_sampling(
++            self.pcp_manager, hidden_states, input_batch
++        )
++
++        sampler_output, num_sampled, num_rejected = self.sample(
++            hidden_states, input_batch, grammar_output
++        )
++
++        if self.pp_handler is not None:
++            # Broadcast to non-last PP ranks (handles spec decode multi-token).
++            self.pp_handler.broadcast(
++                sampler_output.sampled_token_ids,
++                num_sampled,
++                num_rejected,
++                input_batch,
++            )
++
++        assert self.prompt_logprobs_worker is not None
++        prompt_logprobs_dict = self.prompt_logprobs_worker.compute_prompt_logprobs(
++            self.model.compute_logits,
++            hidden_states,
++            input_batch,
++            self.req_states.all_token_ids.gpu,
++            self.req_states.num_computed_tokens.gpu,
++            self.req_states.prompt_len.np,
++        )
++
++        # Prepare the model runner output.
++        model_runner_output = ModelRunnerOutput(
++            req_ids=input_batch.req_ids,
++            # NOTE(woosuk): req_id_to_index is unused in this model runner.
++            # Only for compatibility with the existing model runner and scheduler.
++            req_id_to_index={req_id: i for i, req_id in enumerate(input_batch.req_ids)},
++            sampled_token_ids=None,  # type: ignore
++            prompt_logprobs_dict=prompt_logprobs_dict,  # type: ignore[arg-type]
++        )
++        # Start async output copy here so that it can overlap with speculator proposal.
++        async_output = AsyncOutput(
++            model_runner_output=model_runner_output,
++            sampler_output=sampler_output,
++            num_sampled_tokens=num_sampled,
++            main_stream=self.main_stream,
++            copy_stream=self.output_copy_stream,
++            check_ep_fault=self.check_ep_fault,
++            routed_experts=routed_experts,
++        )
++
++        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None
++        if self.speculator is not None and self.speculator.supports_mm_inputs:
++            # Get cached multimodal embeddings for draft forward.
++            # NOTE: This is done here because postprocess updates
++            # num_computed_prefill_tokens.
++            # The EAGLE/MTP drafter reads one position ahead of the target.
++            # TODO(TheEpicDolphin): Gather MM embeddings for all speculative
++            # steps during multi-module MTP.
++            mm_inputs = self.model_state.gather_mm_embeddings(
++                input_batch, draft_lookahead=1
++            )
++
++        # Postprocess results and update request states.
++        # NOTE: This is intentionally done after creating the AsyncOutput,
++        # ensuring that `copy_event` is recorded before calling postprocess.
++        # This sequencing may slightly reduce latency as async D2H copy does not
++        # need to wait for the postprocess to finish.
++        self.postprocess_sampled(
++            input_batch.idx_mapping,
++            sampler_output.sampled_token_ids,
++            num_sampled,
++            num_rejected,
++            input_batch.query_start_loc,
++        )
++
++        if self.speculator is not None:
++            assert self.sampler is not None
++            # Let the target override the hidden state fed to the drafter
++            # (e.g. DeepSeek V4 MTP needs the pre-hc_head residual). The
++            # target returns a persistent buffer sized at max_num_batched_tokens;
++            # slice to the active token count that propose() expects.
++            spec_hidden_states = hidden_states
++            if hasattr(self.model, "get_mtp_target_hidden_states"):
++                pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
++                spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
++            with use_workspace_lane(self._draft_workspace_lane):
++                draft_tokens = self.speculator.propose(
++                    input_batch,
++                    attn_metadata,
++                    slot_mappings_by_layer,
++                    spec_hidden_states,
++                    aux_hidden_states,
++                    num_sampled,
++                    num_rejected,
++                    self.req_states.last_sampled_tokens,
++                    self.req_states.next_prefill_tokens,
++                    self.sampler.sampling_states.temperature.gpu,
++                    self.sampler.sampling_states.seeds.gpu,
++                    mm_inputs=mm_inputs,
++                )
++            self.req_states.draft_tokens[input_batch.idx_mapping] = draft_tokens
++            if self.adaptive_verification is not None:
++                self.adaptive_verification.record_confidences(
++                    self.speculator.draft_token_confidence_probs, input_batch
++                )
++
++        if self.num_speculative_steps > 0:
++            # Spec-decode and diffusion LLMs both use draft tokens but the latter does
++            # not have a speculator (i.e. self.speculator is None)
++            self.draft_tokens_handler.set_draft_tokens(
++                input_batch,
++                self.req_states.draft_tokens[input_batch.idx_mapping],
++            )
++
++        # Post-step KV connector related operations.
++        kv_connector_output = self.kv_connector.post_forward(finished_req_ids)
++        model_runner_output.kv_connector_output = kv_connector_output
++        model_runner_output.ec_connector_output = ec_connector_output
++
++        return async_output
++
++    def take_draft_token_ids(self) -> DraftTokenIds | None:
++        return self.draft_tokens_handler.get_draft_tokens()
++
++    @torch.inference_mode()
++    @step_eplb_after()
++    def pool(self) -> AsyncPoolingOutput | ModelRunnerOutput | None:
++        if self.execute_model_state is None:
++            # The prior execute_model call must have failed.
++            return None
++
++        input_batch = self.execute_model_state.input_batch
++        hidden_states = self.execute_model_state.hidden_states
++        finished_req_ids = self.execute_model_state.finished_req_ids
++        ec_connector_output = self.execute_model_state.ec_connector_output
++        self.execute_model_state = None
++
++        # Post-step KV connector related operations.
++        kv_connector_output = self.kv_connector.post_forward(finished_req_ids)
++
++        if not self.is_last_pp_rank:
++            self.postprocess_num_computed_tokens(input_batch)
++            output = ModelRunnerOutput.with_kv_conn_output_only(kv_connector_output)
++            return ModelRunnerOutput.with_ec_conn_output(output, ec_connector_output)
++
++        assert self.pooling_runner is not None
++        pooler_output, finished_mask = self.pooling_runner.pool(
++            hidden_states, input_batch, self.req_states
++        )
++
++        # Build the model runner output.
++        model_runner_output = ModelRunnerOutput(
++            req_ids=input_batch.req_ids,
++            req_id_to_index={req_id: i for i, req_id in enumerate(input_batch.req_ids)},
++            kv_connector_output=kv_connector_output,
++            ec_connector_output=ec_connector_output,
++        )
++        async_output = AsyncPoolingOutput(
++            model_runner_output=model_runner_output,
++            pooler_output=pooler_output,
++            finished_mask=finished_mask,
++            main_stream=self.main_stream,
++            copy_stream=self.output_copy_stream,
++        )
++
++        self.postprocess_num_computed_tokens(input_batch)
++        return async_output
++
++    def postprocess_num_computed_tokens(self, input_batch: InputBatch) -> None:
++        # Update the number of computed tokens.
++        post_update_num_computed_tokens(
++            input_batch.idx_mapping,
++            self.req_states.num_computed_tokens.gpu,
++            input_batch.query_start_loc,
++        )
++
++    def shutdown(self) -> None:
++        """Release GPU tensors (model weights, KV caches, workspace) so that
++        memory is reclaimable when running in the same process."""
++        torch.accelerator.synchronize()
++        self.cudagraph_manager = None
++        if hasattr(self, "kv_caches"):
++            self.kv_caches.clear()
++        if hasattr(self, "attn_groups"):
++            self.attn_groups.clear()
++        if hasattr(self, "kv_cache_config"):
++            del self.kv_cache_config
++        if hasattr(self, "model_state") and self.model_state.supports_mm_inputs:
++            self.model_state.encoder_runner.clear()
++        free_before_shutdown(self.vllm_config)
++        if hasattr(self, "model_state"):
++            del self.model_state
++        if getattr(self, "speculator", None) is not None:
++            self.speculator = None
++        if hasattr(self, "model"):
++            del self.model
++
++        gc.collect()
++        torch.accelerator.empty_cache()
++        logger.debug("Cleaned up model weights, KV caches, and workspace")
++
++    ########### EPLB methods start ###########
++    @property
++    def eplb_state(self):
++        return self.eplb.state
++
++    @eplb_state.setter
++    def eplb_state(self, state) -> None:
++        self.eplb.state = state
++
++    @property
++    def eep_eplb_suppressed(self) -> bool:
++        return self.eplb.suppressed
++
++    @eep_eplb_suppressed.setter
++    def eep_eplb_suppressed(self, suppressed: bool) -> None:
++        self.eplb.suppressed = suppressed
++
++    def setup_eplb_from_mapping(
++        self,
++        expanded_physical_to_logical: torch.Tensor,
++        old_num_physical_experts: int,
++    ) -> None:
++        self.eplb.setup_from_mapping(
++            self.model,
++            self.model_config,
++            expanded_physical_to_logical,
++            old_num_physical_experts,
++        )
++
++    ########### EPLB methods end ###########
++
++    # Out-of-tree hardware runners can select a PCP manager class.
++    @property
++    def pcp_manager_cls(self) -> type[pcp.PCPManager]:
++        return pcp.PCPManager
++
++
++class ExecuteModelState(NamedTuple):
++    input_batch: InputBatch
++    attn_metadata: dict[str, Any] | None
++    slot_mappings_by_layer: dict[str, torch.Tensor] | None
++    hidden_states: torch.Tensor | None
++    aux_hidden_states: list[torch.Tensor] | None
++    finished_req_ids: set[str]
++    ec_connector_output: ECConnectorOutput | None
++    routed_experts: RoutedExpertsTensors | None
++
++
++class BatchReqState(NamedTuple):
++    """CPU request state for a scheduled batch, in batch (sorted) order."""
++
++    req_ids: list[str]
++    num_scheduled_tokens: np.ndarray  # [num_reqs]
++    # May be less than scheduler_output.total_num_scheduled_tokens:
++    # adaptive verification trims the draft budget before running.
++    num_tokens: int
++    idx_mapping_np: np.ndarray  # [num_reqs]
++    prefill_len_np: np.ndarray  # [num_reqs]
++    num_computed_prefill_tokens_np: np.ndarray  # [num_reqs]
++    is_prefilling_np: np.ndarray  # [num_reqs]
++    has_prefill: bool
++
++
++def sort_batch_req_ids(
++    num_tokens_per_req: dict[str, int],
++    draft_tokens: dict[str, list[int]],
++    decode_query_len: int,
++) -> list[str]:
++    # Order verification/decode -> short_extend -> prefill;
++    # split_decodes_and_prefills relies on decode-like requests leading.
++    key = lambda r: (
++        not draft_tokens.get(r),
++        (num := num_tokens_per_req[r]) != decode_query_len,
++        num,
++    )
++    return sorted(num_tokens_per_req, key=key)
+diff --git a/v1/worker/gpu/spec_decode/dflash/speculator.py b/v1/worker/gpu/spec_decode/dflash/speculator.py
+index eb5dc470b..4ad1b10ba 100644
 --- a/v1/worker/gpu/spec_decode/dflash/speculator.py
 +++ b/v1/worker/gpu/spec_decode/dflash/speculator.py
 @@ -1,5 +1,6 @@
@@ -33,11 +3092,10 @@ This replaces the pre-0.28 DFlash2 backport: 0.28.0 already ships the native DFl
  from collections.abc import Mapping
  from typing import Any
  
-@@ -41,9 +42,37 @@
- 
+@@ -42,8 +43,36 @@ class DFlashSpeculator(DraftModelSpeculator):
          # Multimodal inputs not currently supported.
          self.supports_mm_inputs = False
-+
+ 
 +        # The drafter emits the block it was trained for (dflash_config.block_size - 1);
 +        # the *verify* block may be longer than that, with the extra positions filled from
 +        # the request's own context (dflash2/lookup.py). Everything describing the draft
@@ -65,14 +3123,14 @@ This replaces the pre-0.28 DFlash2 backport: 0.28.0 already ships the native DFl
 +                self.num_speculative_steps - self.draft_block,
 +                self.num_speculative_steps,
 +            )
- 
++
          # Each request emits exactly (bonus + N mask) query tokens per step.
 -        self.num_query_per_req = 1 + self.num_speculative_steps
 +        self.num_query_per_req = 1 + self.draft_block
  
          self.parallel_drafting_token_id = get_parallel_drafting_token_id(
              self.draft_model_config.hf_config
-@@ -77,7 +106,7 @@
+@@ -77,7 +106,7 @@ class DFlashSpeculator(DraftModelSpeculator):
          )
  
          # Per-mask-token sampling buffers. Flattened from (num_reqs, num_spec_tokens).
@@ -81,7 +3139,7 @@ This replaces the pre-0.28 DFlash2 backport: 0.28.0 already ships the native DFl
          self.sample_indices = torch.zeros(
              max_num_sampled_tokens, dtype=torch.int64, device=device
          )
-@@ -93,7 +122,7 @@
+@@ -93,7 +122,7 @@ class DFlashSpeculator(DraftModelSpeculator):
          # [0, 1, ..., N-1, 0, 1, ..., N-1, ...] -> the per-token column index into
          # draft_logits[req, step, :].
          self.sample_col = torch.arange(
@@ -90,7 +3148,7 @@ This replaces the pre-0.28 DFlash2 backport: 0.28.0 already ships the native DFl
          ).repeat(self.max_num_reqs)
  
          self.query_cudagraph_manager: DFlashCudaGraphManager | None = None
-@@ -258,7 +287,7 @@
+@@ -258,7 +287,7 @@ class DFlashSpeculator(DraftModelSpeculator):
              num_tokens_across_dp,
              cudagraph_runtime_mode,
          )
@@ -99,7 +3157,7 @@ This replaces the pre-0.28 DFlash2 backport: 0.28.0 already ships the native DFl
          sample_hidden_states = last_hidden_states[self.sample_indices[:num_sample]]
          # sample_pos is the predicted token's position Q; verification keys
          # Gumbel by the predecessor (Q-1). sample_draft adds +1, so pass Q-2.
-@@ -271,8 +300,8 @@
+@@ -271,8 +300,8 @@ class DFlashSpeculator(DraftModelSpeculator):
              self.sample_col[:num_sample],
              self.draft_logits,
          )
@@ -110,7 +3168,7 @@ This replaces the pre-0.28 DFlash2 backport: 0.28.0 already ships the native DFl
          )
  
      def _build_draft_attn_metadata(
-@@ -329,6 +358,11 @@
+@@ -329,6 +358,11 @@ class DFlashSpeculator(DraftModelSpeculator):
          is_profile: bool = False,
      ) -> torch.Tensor:
          num_reqs = input_batch.num_reqs
@@ -122,7 +3180,7 @@ This replaces the pre-0.28 DFlash2 backport: 0.28.0 already ships the native DFl
          num_target_tokens = input_batch.num_tokens
          num_query_tokens = num_reqs * self.num_query_per_req
          max_seq_len = input_batch.seq_lens_cpu_upper_bound[:num_reqs].max().item()
-@@ -395,7 +429,7 @@
+@@ -395,7 +429,7 @@ class DFlashSpeculator(DraftModelSpeculator):
                  self.block_tables.kernel_block_sizes[gid],
                  self.parallel_drafting_token_id,
                  self.num_query_per_req,
@@ -131,458 +3189,9 @@ This replaces the pre-0.28 DFlash2 backport: 0.28.0 already ships the native DFl
                  self.max_num_reqs,
                  self.max_num_tokens,
                  self.max_model_len,
---- a/v1/worker/gpu/spec_decode/dflash2/speculator.py
-+++ b/v1/worker/gpu/spec_decode/dflash2/speculator.py
-@@ -1,17 +1,26 @@
- # SPDX-License-Identifier: Apache-2.0
- # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
- 
-+import os
- from typing import Any
- 
- import torch
- 
--from vllm.config import VllmConfig
- from vllm.config.compilation import CUDAGraphMode
-+from vllm.config import VllmConfig
-+from vllm.logger import init_logger
- from vllm.triton_utils import tl, triton
- from vllm.v1.worker.gpu.sample.gumbel import gumbel_noised_argmax
- from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
- 
-+logger = init_logger(__name__)
-+from vllm.v1.worker.gpu.spec_decode.dflash2.lookup import (
-+    _point_mass_draft_logits_kernel,
-+    fuse_draft,
-+    suffix_lookup,
-+)
- 
-+
- @triton.jit
- def _selector_walk_kernel(
-     scores_ptr,
-@@ -22,11 +31,14 @@
-     seeds_ptr,
-     tokens_ptr,
-     realized_scores_ptr,
-+    req_top_p_ptr,
-+    req_top_k_ptr,
-     num_steps: tl.constexpr,
-     top_k: tl.constexpr,
-     BLOCK_K: tl.constexpr,
-     SAMPLE_PROBABILISTIC: tl.constexpr,
-     USE_FP64: tl.constexpr,
-+    TRUNCATE: tl.constexpr,
- ):
-     row = tl.program_id(0)
-     offsets = tl.arange(0, BLOCK_K)
-@@ -35,6 +47,9 @@
-     valid = req_state >= 0
-     temperature = tl.load(temperature_ptr + req_state, mask=valid, other=0.0)
-     seed = tl.load(seeds_ptr + req_state, mask=valid, other=0)
-+    if TRUNCATE:
-+        req_top_p = tl.load(req_top_p_ptr + req_state, mask=valid, other=1.0)
-+        req_top_k = tl.load(req_top_k_ptr + req_state, mask=valid, other=BLOCK_K)
-     previous = 0
-     for step in range(num_steps):
-         flat = row * num_steps + step
-@@ -43,7 +58,7 @@
-             scores_ptr + score_base + offsets,
-             mask=mask & valid,
-             other=float("-inf"),
--        ).to(tl.float64 if USE_FP64 else tl.float32)
-+        ).to(tl.float32)
-         candidate_base = flat * top_k
-         candidates = tl.load(
-             candidate_ptr + candidate_base + offsets,
-@@ -51,7 +66,20 @@
-             other=0,
-         )
- 
--        # Candidate ids key the noise, matching the target's own sampling.
-+        if SAMPLE_PROBABILISTIC and temperature != 0.0 and TRUNCATE:
-+            # Apply the request's top-k/top-p to the proposal distribution over the
-+            # candidates. The rejection sampler consumes pre-temperature logits, so keep
-+            # the original scores and use -inf to represent the truncated support.
-+            scaled_scores = scores / temperature
-+            mx = tl.max(scaled_scores, axis=0)
-+            probs = tl.exp(scaled_scores - mx)
-+            probs = probs / tl.sum(probs, axis=0)
-+            greater = scaled_scores[None, :] > scaled_scores[:, None]
-+            rank = tl.sum(greater.to(tl.int32), axis=1)
-+            mass_before = tl.sum(tl.where(greater, probs[None, :], 0.0), axis=1)
-+            keep = mask & (rank < req_top_k) & (mass_before < req_top_p)
-+            scores = tl.where(keep, scores, -float("inf"))
-+
-         position = tl.load(sample_pos_ptr + flat) - 1
-         _, index = gumbel_noised_argmax(
-             scores,
-@@ -62,10 +90,12 @@
-             temperature if SAMPLE_PROBABILISTIC else 0.0,
-             USE_FP64=USE_FP64,
-         )
--
-+        # vLLM 0.28.0's rejection sampler expects pre-temperature logits. With TRUNCATE
-+        # the cached row is the truncated proposal (-inf outside the kept support).
-+        realized = scores
-         tl.store(
-             realized_scores_ptr + candidate_base + offsets,
--            scores,
-+            realized,
-             mask=mask & valid,
-         )
-         token = tl.load(candidate_ptr + candidate_base + index, mask=valid, other=0)
-@@ -83,6 +113,7 @@
-     draft_logits_stride_0,
-     draft_logits_stride_1,
-     num_steps: tl.constexpr,
-+    cache_steps: tl.constexpr,
-     top_k: tl.constexpr,
-     BLOCK_K: tl.constexpr,
- ):
-@@ -92,7 +123,9 @@
-     offsets = tl.arange(0, BLOCK_K)
-     mask = (req_state >= 0) & (offsets < top_k)
-     candidate_base = flat * top_k
--    cache_base = (req_state * num_steps + step) * top_k
-+    # The candidate cache spans the whole verify block, of which the drafter fills the
-+    # first num_steps rows (dflash2/lookup.py fills the rest).
-+    cache_base = (req_state * cache_steps + step) * top_k
-     old_token_ids = tl.load(cached_candidate_ptr + cache_base + offsets, mask=mask)
-     logits_base = (
-         draft_logits_ptr
-@@ -107,6 +140,9 @@
- 
- 
- class DFlash2Speculator(DFlashSpeculator):
-+    """DFlash2 = DFlash + local convolutions + candidate selector, optionally with
-+    lookup-augmented drafting (VLLM_DFLASH2_LOOKUP=1)."""
-+
-     _speculator_name = "DFlash2"
- 
-     def __init__(self, vllm_config: VllmConfig, device: torch.device):
-@@ -117,23 +153,180 @@
-             torch.arange(self.max_num_reqs, dtype=torch.int64, device=device)
-             * self.num_query_per_req
-         )
-+        self._selector_tokens = torch.empty(
-+            (self.max_num_reqs, self.draft_block),
-+            dtype=self.draft_tokens.dtype,
-+            device=device,
-+        )
-         self._selector_scores = torch.empty(
-             self.max_num_reqs,
--            self.num_speculative_steps,
-+            self.draft_block,
-             self.selector_top_k,
-             dtype=torch.float32,
-             device=device,
-         )
-         self._cached_candidate_ids = torch.zeros(
--            self._selector_scores.shape, dtype=torch.int64, device=device
-+            (self.max_num_reqs, self.num_speculative_steps, self.selector_top_k),
-+            dtype=torch.int64,
-+            device=device,
-         )
-+        # Request top_p/top_k buffers ([max_num_reqs], indexed by request state), handed
-+        # over by the model runner; VLLM_DFLASH2_DRAFT_TOPK_TOPP=0 disables the truncation.
-+        self._req_top_p: torch.Tensor | None = None
-+        self._req_top_k: torch.Tensor | None = None
-+        self._truncate = os.environ.get("VLLM_DFLASH2_DRAFT_TOPK_TOPP", "1") == "1"
-+        # Lookup-augmented block drafting: propose the continuation of an earlier
-+        # occurrence of the current suffix instead of the model's guess (lookup.py).
-+        self._lookup = os.environ.get("VLLM_DFLASH2_LOOKUP", "0") == "1"
-+        # Three separate questions, three thresholds (dflash2/lookup.py):
-+        #  NMIN/NSTRONG/AGREE   when to let the lookup replace a token the drafter proposed
-+        #  NMIN_TAIL            when to fill the positions the drafter never proposed
-+        #  LONGMIN              when the long verify block is worth its step time
-+        self._lookup_nmin = int(os.environ.get("VLLM_DFLASH2_LOOKUP_NMIN", "6"))
-+        # 12, not 32: the kernel picks the longest match and breaks ties by recency, and a
-+        # longer cap makes it prefer an older long match over a newer short one. On
-+        # quote-and-explain work the newer one is the better predictor (3.21 vs 2.69 tokens
-+        # per step), and copies match well past 12 either way.
-+        self._lookup_nmax = int(os.environ.get("VLLM_DFLASH2_LOOKUP_NMAX", "12"))
-+        # NSTRONG = NMIN and AGREE = 0 means "take any match of NMIN or more" for the
-+        # positions the drafter also proposed. Measured better at C1 (3.33 vs 3.27 tokens
-+        # per step) than requiring drafter agreement for medium matches.
-+        self._lookup_nstrong = int(os.environ.get("VLLM_DFLASH2_LOOKUP_NSTRONG", "6"))
-+        self._lookup_agree = int(os.environ.get("VLLM_DFLASH2_LOOKUP_AGREE", "0"))
-+        self._lookup_nmin_tail = int(os.environ.get("VLLM_DFLASH2_LOOKUP_NMIN_TAIL", "4"))
-+        self._lookup_long_min = int(os.environ.get("VLLM_DFLASH2_LOOKUP_LONGMIN", "6"))
-+        # Below this many tokens of context the long block is taken unconditionally, on the
-+        # theory that an extra verify position is nearly free there. Off by default: it
-+        # measured +8% at C1 under one memory configuration and -13% under the one that
-+        # ships (4 request slots, 56k), because what the extra positions cost depends on the
-+        # paged-attention layout as much as on the KV length.
-+        self._lookup_cheap_ctx = int(os.environ.get("VLLM_DFLASH2_LOOKUP_CHEAP_CTX", "0"))
-+        self._lookup_search = int(os.environ.get("VLLM_DFLASH2_LOOKUP_SEARCH", str(1 << 30)))
-+        self._req_states = None
-+        self._lookup_tokens = torch.zeros(
-+            (self.max_num_reqs, self.num_speculative_steps), dtype=torch.int32, device=device
-+        )
-+        self._lookup_len = torch.zeros(self.max_num_reqs, dtype=torch.int32, device=device)
-+        self._lookup_valid = torch.zeros(self.max_num_reqs, dtype=torch.int32, device=device)
-+        # Which draft positions came from the lookup, per request: what the point-mass
-+        # rewrite of the draft distribution applies to.
-+        self._lookup_use = torch.zeros(
-+            (self.max_num_reqs, self.num_speculative_steps), dtype=torch.int32, device=device
-+        )
-+        self._lookup_hits = torch.zeros((), dtype=torch.int64, device=device)
-+        # Adaptive verify length: a long block only pays for itself while the request is
-+        # reproducing its context, so the scheduler is asked for the drafter's own block
-+        # otherwise. The signal is the previous step's lookup decision, read from a pinned
-+        # copy -- one step stale by construction, which costs at most one step at each end
-+        # of a copy run and never needs a synchronise.
-+        self._adaptive = (
-+            os.environ.get("VLLM_DFLASH2_LOOKUP_ADAPTIVE", "1") == "1"
-+            and self.draft_block < self.num_speculative_steps
-+        )
-+        self._take_flags = torch.zeros(
-+            self.max_num_reqs, dtype=torch.int32, device=device
-+        )
-+        self._last_num_reqs = 0
-+        self._flags_cpu = torch.zeros(
-+            self.max_num_reqs, dtype=torch.int32, device="cpu"
-+        ).pin_memory()
-+        self._flags_n = 0
-+        self._prev_want = False
-+        # Entering the long block takes two qualifying steps in a row and leaving it took
-+        # one, so a single step where the flag dropped out mid-copy cost three. It drops out
-+        # for reasons that have nothing to do with the copy ending -- a line the lookup
-+        # cannot match, or a flag copy that had not landed yet -- and the same server then
-+        # measured 13.76, 13.92, 13.92, 13.92 and 13.92 tokens per step on consecutive runs
-+        # of one prompt against 14.97 on the first. STICKY holds the long block for that
-+        # many steps after the flag goes out, which makes it 15.21 every time.
-+        #
-+        # Gating the hold on "the request is still emitting a full block a step" -- which
-+        # should distinguish a late flag from a finished copy -- removes the whole effect
-+        # (13.92 again): by the time the flag drops the step it describes was not saturated
-+        # either, so the two are not independent evidence.
-+        #
-+        # It only applies with one request in flight, and that restriction is not caution.
-+        # This counter is one number for the whole batch, and unlike the entry condition it
-+        # keeps the long block on through steps where the flags say no -- so with several
-+        # requests, which block length a copying request gets starts to depend on when the
-+        # others arrived. Different block length, different rounding, different greedy text:
-+        # bench/labd_soak.py caught a verbatim copy coming out differently in two rounds of
-+        # an otherwise identical 4-way batch, and reproducibly did not with STICKY=0.
-+        self._lookup_sticky = int(os.environ.get("VLLM_DFLASH2_LOOKUP_STICKY", "3"))
-+        self._sticky = 0
- 
--    def draft_logits_spec(self, vllm_config: VllmConfig) -> tuple[torch.dtype, float]:
--        # fp32 so the walk and the rejection that checks it read the same
--        # distribution; -inf because the cache kernel writes only the K
--        # candidates.
-+        if self._lookup:
-+            logger.info(
-+                "DFlash2 lookup-augmented drafting on (k=%d nmin=%d nmax=%d nstrong=%d "
-+                "agree=%d nmin_tail=%d longmin=%d search=%d)",
-+                self.num_speculative_steps, self._lookup_nmin, self._lookup_nmax,
-+                self._lookup_nstrong, self._lookup_agree, self._lookup_nmin_tail,
-+                self._lookup_long_min, self._lookup_search,
-+            )
-+
-+    def next_num_draft_tokens(self) -> int | None:
-+        """How many of the proposed tokens the scheduler should put up for verification next
-+        step (None = all of them).
-+
-+        This runs on the host once per step, which is why the decision lives here and not in
-+        `_apply_lookup`: the draft pass is replayed from a captured CUDA graph, so anything
-+        Python does in there runs at capture time only. The two inputs are the per-request
-+        flag the (replayed) fuse kernel writes -- "there is something to put in the tail" --
-+        and what the step that just finished emitted. A long block costs step time on every
-+        request in the batch whether or not its tail is accepted, so it takes both, and
-+        unanimity across the batch. Below CHEAP_CTX tokens of context an extra verify
-+        position is nearly free (+6% per step at 1.5k against +27% at 25k), so there the
-+        flag alone is enough."""
-+        if not self._adaptive:
-+            return None
-+        emitted = getattr(self, "last_num_emitted", None)
-+        if emitted is None:
-+            return self.draft_block
-+        if self.draft_max_seq_len <= self._lookup_cheap_ctx:
-+            # An extra verify position costs attention proportional to the KV length: +6%
-+            # per step at 1.5k of context against +27% at 25k. Below the threshold it is
-+            # cheap enough that taking the long block unconditionally wins (+8% at C1),
-+            # even on the steps where the lookup has nothing to put in it.
-+            return self.num_speculative_steps
-+        num_reqs = emitted.shape[0]
-+        # Read the decision that landed from the previous step and start the copy for the
-+        # next one. Reading it synchronously (`.item()`) is a device synchronise on every
-+        # decode step and measured 5% -- more than the long block itself is worth on most
-+        # work. One step of staleness costs a short step at the start of a copy run and a
-+        # long one at its end.
-+        want = bool(self._flags_n and self._flags_cpu[: self._flags_n].all())
-+        fused = (self._take_flags[:num_reqs] > 0) & (emitted >= 1 + self.draft_block)
-+        self._flags_cpu[:num_reqs].copy_(fused, non_blocking=True)
-+        self._flags_n = num_reqs
-+        # Two qualifying steps in a row, not one: a single saturated step happens in the
-+        # middle of ordinary prose (a quoted phrase, a repeated list marker) and the long
-+        # block it buys is then wasted. Waiting for the second one costs the first step of
-+        # a copy and removes the loss on quote-and-explain work.
-+        if want and self._prev_want:
-+            long_block = True
-+            self._sticky = self._lookup_sticky if num_reqs == 1 else 0
-+        elif self._sticky > 0 and num_reqs == 1:
-+            # Coasting: re-entry costs two steps, so a run that has already earned the long
-+            # block twice gets the benefit of the doubt for a few more.
-+            long_block, self._sticky = True, self._sticky - 1
-+        else:
-+            long_block, self._sticky = False, 0
-+        self._prev_want = want
-+        return self.num_speculative_steps if long_block else self.draft_block
-+
-+    def set_req_states(self, req_states) -> None:
-+        """The token history the lookup matches against (set by the model runner)."""
-+        self._req_states = req_states
-+
-+    def draft_logits_spec(self, vllm_config: VllmConfig) -> tuple[torch.dtype, float]:
-+        # The v0.28 rejection sampler divides cached logits by temperature itself.
-+        # -inf is required because the sparse cache kernel only writes the K candidates.
-         return torch.float32, -float("inf")
- 
-+    def set_sampling_states(self, sampling_states) -> None:
-+        self._req_top_p = sampling_states.top_p.gpu
-+        self._req_top_k = sampling_states.top_k.gpu
-+
-     def _sample_path(
-         self,
-         candidate_ids: torch.Tensor,
-@@ -141,6 +334,7 @@
-         num_reqs: int,
-     ) -> None:
-         block_k = triton.next_power_of_2(self.selector_top_k)
-+        truncate = self._truncate and self._req_top_p is not None
-         _selector_walk_kernel[(num_reqs,)](
-             scores.contiguous(),
-             candidate_ids.contiguous(),
-@@ -148,19 +342,25 @@
-             self.sample_idx_mapping,
-             self.temperature,
-             self.seeds,
--            self.draft_tokens,
-+            self._selector_tokens,
-             self._selector_scores,
--            num_steps=self.num_speculative_steps,
-+            self._req_top_p if truncate else self.temperature,
-+            self._req_top_k if truncate else self.sample_idx_mapping,
-+            num_steps=self.draft_block,
-             top_k=self.selector_top_k,
-             BLOCK_K=block_k,
-             SAMPLE_PROBABILISTIC=self.draft_logits is not None,
-             USE_FP64=self.use_fp64_gumbel,
-+            TRUNCATE=truncate,
-             num_warps=1,
-         )
- 
-     def _cache_draft_logits(self, candidate_ids: torch.Tensor, num_sample: int) -> None:
-         draft_logits = self.draft_logits
--        assert draft_logits is not None
-+        if draft_logits is None:
-+            # Greedy rejection sampling never reads q; the token fusion above is still
-+            # useful because it supplies the proposal handed to the target.
-+            return
-         block_k = triton.next_power_of_2(self.selector_top_k)
-         _cache_draft_logits_kernel[(num_sample,)](
-             draft_logits,
-@@ -170,7 +370,8 @@
-             self.sample_idx_mapping,
-             draft_logits.stride(0),
-             draft_logits.stride(1),
--            num_steps=self.num_speculative_steps,
-+            num_steps=self.draft_block,
-+            cache_steps=self.num_speculative_steps,
-             top_k=self.selector_top_k,
-             BLOCK_K=block_k,
-             num_warps=1,
-@@ -192,15 +393,15 @@
-             num_tokens_across_dp,
-             cudagraph_runtime_mode,
-         )
--        num_sample = num_reqs * self.num_speculative_steps
-+        num_sample = num_reqs * self.draft_block
-         hidden_states = last_hidden_states[self.sample_indices[:num_sample]].view(
--            num_reqs, self.num_speculative_steps, -1
-+            num_reqs, self.draft_block, -1
-         )
-         candidate_ids, unary_logits = self.model.compute_candidates(
-             hidden_states.flatten(0, 1)
-         )
-         candidate_ids = candidate_ids.view(
--            num_reqs, self.num_speculative_steps, self.selector_top_k
-+            num_reqs, self.draft_block, self.selector_top_k
-         )
-         unary_logits = unary_logits.view_as(candidate_ids)
-         anchor_token_ids = self.input_buffers.input_ids[self._anchor_indices[:num_reqs]]
-@@ -213,3 +414,68 @@
-         self._sample_path(candidate_ids, scores, num_reqs)
-         if self.draft_logits is not None:
-             self._cache_draft_logits(candidate_ids, num_sample)
-+        self.draft_tokens[:num_reqs, : self.draft_block].copy_(
-+            self._selector_tokens[:num_reqs]
-+        )
-+        self._apply_lookup(num_reqs)
-+
-+    def _apply_lookup(self, num_reqs: int) -> None:
-+        """Fuse the drafted block with the continuation of an earlier occurrence of the
-+        current suffix, where one exists (see dflash2/lookup.py), and fill the verify
-+        positions past the drafter's own block. The draft distribution for every position
-+        the lookup supplied becomes a point mass on the proposed token, which keeps vLLM's
-+        rejection sampling exact."""
-+        if not self._lookup or self._req_states is None:
-+            return
-+        tokens, match_len, valid = suffix_lookup(
-+            self._req_states.all_token_ids.gpu,
-+            self._req_states.total_len.gpu,
-+            self.sample_idx_mapping,
-+            num_reqs,
-+            self.num_speculative_steps,
-+            idx_mapping_stride=self.draft_block,
-+            nmax=self._lookup_nmax,
-+            nmin=self._lookup_nmin,
-+            search_max=self._lookup_search,
-+            out_tokens=self._lookup_tokens[:num_reqs],
-+            out_len=self._lookup_len[:num_reqs],
-+            out_valid=self._lookup_valid[:num_reqs],
-+        )
-+        fuse_draft(
-+            self.draft_tokens[:num_reqs],
-+            tokens,
-+            match_len,
-+            valid,
-+            self._lookup_use[:num_reqs],
-+            self.sample_idx_mapping,
-+            self._lookup_hits,
-+            num_reqs,
-+            self.num_speculative_steps,
-+            draft_block=self.draft_block,
-+            idx_mapping_stride=self.draft_block,
-+            nmin=self._lookup_nmin,
-+            nstrong=self._lookup_nstrong,
-+            agree_min=self._lookup_agree,
-+            nmin_tail=self._lookup_nmin_tail,
-+            long_min=self._lookup_long_min,
-+            take_flags=self._take_flags[:num_reqs],
-+        )
-+        draft_logits = self.draft_logits
-+        if draft_logits is None:
-+            return
-+        block_k = triton.next_power_of_2(self.selector_top_k)
-+        _point_mass_draft_logits_kernel[(num_reqs * self.num_speculative_steps,)](
-+            draft_logits,
-+            self._cached_candidate_ids,
-+            self.draft_tokens,
-+            self.draft_tokens.stride(0),
-+            self._lookup_use,
-+            self.sample_idx_mapping,
-+            self.draft_block,
-+            draft_logits.stride(0),
-+            draft_logits.stride(1),
-+            num_steps=self.num_speculative_steps,
-+            top_k=self.selector_top_k,
-+            BLOCK_K=block_k,
-+            num_warps=1,
-+        )
+diff --git a/v1/worker/gpu/spec_decode/dflash2/lookup.py b/v1/worker/gpu/spec_decode/dflash2/lookup.py
+new file mode 100644
+index 000000000..0315b6ecb
 --- /dev/null
 +++ b/v1/worker/gpu/spec_decode/dflash2/lookup.py
 @@ -0,0 +1,330 @@
@@ -916,9 +3525,463 @@ This replaces the pre-0.28 DFlash2 backport: 0.28.0 already ships the native DFl
 +        BLOCK_KT=triton.next_power_of_2(k),
 +        num_warps=1,
 +    )
+diff --git a/v1/worker/gpu/spec_decode/dflash2/speculator.py b/v1/worker/gpu/spec_decode/dflash2/speculator.py
+index 621afc38c..9d299de5a 100644
+--- a/v1/worker/gpu/spec_decode/dflash2/speculator.py
++++ b/v1/worker/gpu/spec_decode/dflash2/speculator.py
+@@ -1,16 +1,25 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++import os
+ from typing import Any
+ 
+ import torch
+ 
+-from vllm.config import VllmConfig
+ from vllm.config.compilation import CUDAGraphMode
++from vllm.config import VllmConfig
++from vllm.logger import init_logger
+ from vllm.triton_utils import tl, triton
+ from vllm.v1.worker.gpu.sample.gumbel import gumbel_noised_argmax
+ from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
+ 
++logger = init_logger(__name__)
++from vllm.v1.worker.gpu.spec_decode.dflash2.lookup import (
++    _point_mass_draft_logits_kernel,
++    fuse_draft,
++    suffix_lookup,
++)
++
+ 
+ @triton.jit
+ def _selector_walk_kernel(
+@@ -22,11 +31,14 @@ def _selector_walk_kernel(
+     seeds_ptr,
+     tokens_ptr,
+     realized_scores_ptr,
++    req_top_p_ptr,
++    req_top_k_ptr,
+     num_steps: tl.constexpr,
+     top_k: tl.constexpr,
+     BLOCK_K: tl.constexpr,
+     SAMPLE_PROBABILISTIC: tl.constexpr,
+     USE_FP64: tl.constexpr,
++    TRUNCATE: tl.constexpr,
+ ):
+     row = tl.program_id(0)
+     offsets = tl.arange(0, BLOCK_K)
+@@ -35,6 +47,9 @@ def _selector_walk_kernel(
+     valid = req_state >= 0
+     temperature = tl.load(temperature_ptr + req_state, mask=valid, other=0.0)
+     seed = tl.load(seeds_ptr + req_state, mask=valid, other=0)
++    if TRUNCATE:
++        req_top_p = tl.load(req_top_p_ptr + req_state, mask=valid, other=1.0)
++        req_top_k = tl.load(req_top_k_ptr + req_state, mask=valid, other=BLOCK_K)
+     previous = 0
+     for step in range(num_steps):
+         flat = row * num_steps + step
+@@ -43,7 +58,7 @@ def _selector_walk_kernel(
+             scores_ptr + score_base + offsets,
+             mask=mask & valid,
+             other=float("-inf"),
+-        ).to(tl.float64 if USE_FP64 else tl.float32)
++        ).to(tl.float32)
+         candidate_base = flat * top_k
+         candidates = tl.load(
+             candidate_ptr + candidate_base + offsets,
+@@ -51,7 +66,20 @@ def _selector_walk_kernel(
+             other=0,
+         )
+ 
+-        # Candidate ids key the noise, matching the target's own sampling.
++        if SAMPLE_PROBABILISTIC and temperature != 0.0 and TRUNCATE:
++            # Apply the request's top-k/top-p to the proposal distribution over the
++            # candidates. The rejection sampler consumes pre-temperature logits, so keep
++            # the original scores and use -inf to represent the truncated support.
++            scaled_scores = scores / temperature
++            mx = tl.max(scaled_scores, axis=0)
++            probs = tl.exp(scaled_scores - mx)
++            probs = probs / tl.sum(probs, axis=0)
++            greater = scaled_scores[None, :] > scaled_scores[:, None]
++            rank = tl.sum(greater.to(tl.int32), axis=1)
++            mass_before = tl.sum(tl.where(greater, probs[None, :], 0.0), axis=1)
++            keep = mask & (rank < req_top_k) & (mass_before < req_top_p)
++            scores = tl.where(keep, scores, -float("inf"))
++
+         position = tl.load(sample_pos_ptr + flat) - 1
+         _, index = gumbel_noised_argmax(
+             scores,
+@@ -62,10 +90,12 @@ def _selector_walk_kernel(
+             temperature if SAMPLE_PROBABILISTIC else 0.0,
+             USE_FP64=USE_FP64,
+         )
+-
++        # vLLM 0.28.0's rejection sampler expects pre-temperature logits. With TRUNCATE
++        # the cached row is the truncated proposal (-inf outside the kept support).
++        realized = scores
+         tl.store(
+             realized_scores_ptr + candidate_base + offsets,
+-            scores,
++            realized,
+             mask=mask & valid,
+         )
+         token = tl.load(candidate_ptr + candidate_base + index, mask=valid, other=0)
+@@ -83,6 +113,7 @@ def _cache_draft_logits_kernel(
+     draft_logits_stride_0,
+     draft_logits_stride_1,
+     num_steps: tl.constexpr,
++    cache_steps: tl.constexpr,
+     top_k: tl.constexpr,
+     BLOCK_K: tl.constexpr,
+ ):
+@@ -92,7 +123,9 @@ def _cache_draft_logits_kernel(
+     offsets = tl.arange(0, BLOCK_K)
+     mask = (req_state >= 0) & (offsets < top_k)
+     candidate_base = flat * top_k
+-    cache_base = (req_state * num_steps + step) * top_k
++    # The candidate cache spans the whole verify block, of which the drafter fills the
++    # first num_steps rows (dflash2/lookup.py fills the rest).
++    cache_base = (req_state * cache_steps + step) * top_k
+     old_token_ids = tl.load(cached_candidate_ptr + cache_base + offsets, mask=mask)
+     logits_base = (
+         draft_logits_ptr
+@@ -107,6 +140,9 @@ def _cache_draft_logits_kernel(
+ 
+ 
+ class DFlash2Speculator(DFlashSpeculator):
++    """DFlash2 = DFlash + local convolutions + candidate selector, optionally with
++    lookup-augmented drafting (VLLM_DFLASH2_LOOKUP=1)."""
++
+     _speculator_name = "DFlash2"
+ 
+     def __init__(self, vllm_config: VllmConfig, device: torch.device):
+@@ -117,23 +153,180 @@ class DFlash2Speculator(DFlashSpeculator):
+             torch.arange(self.max_num_reqs, dtype=torch.int64, device=device)
+             * self.num_query_per_req
+         )
++        self._selector_tokens = torch.empty(
++            (self.max_num_reqs, self.draft_block),
++            dtype=self.draft_tokens.dtype,
++            device=device,
++        )
+         self._selector_scores = torch.empty(
+             self.max_num_reqs,
+-            self.num_speculative_steps,
++            self.draft_block,
+             self.selector_top_k,
+             dtype=torch.float32,
+             device=device,
+         )
+         self._cached_candidate_ids = torch.zeros(
+-            self._selector_scores.shape, dtype=torch.int64, device=device
++            (self.max_num_reqs, self.num_speculative_steps, self.selector_top_k),
++            dtype=torch.int64,
++            device=device,
+         )
++        # Request top_p/top_k buffers ([max_num_reqs], indexed by request state), handed
++        # over by the model runner; VLLM_DFLASH2_DRAFT_TOPK_TOPP=0 disables the truncation.
++        self._req_top_p: torch.Tensor | None = None
++        self._req_top_k: torch.Tensor | None = None
++        self._truncate = os.environ.get("VLLM_DFLASH2_DRAFT_TOPK_TOPP", "1") == "1"
++        # Lookup-augmented block drafting: propose the continuation of an earlier
++        # occurrence of the current suffix instead of the model's guess (lookup.py).
++        self._lookup = os.environ.get("VLLM_DFLASH2_LOOKUP", "0") == "1"
++        # Three separate questions, three thresholds (dflash2/lookup.py):
++        #  NMIN/NSTRONG/AGREE   when to let the lookup replace a token the drafter proposed
++        #  NMIN_TAIL            when to fill the positions the drafter never proposed
++        #  LONGMIN              when the long verify block is worth its step time
++        self._lookup_nmin = int(os.environ.get("VLLM_DFLASH2_LOOKUP_NMIN", "6"))
++        # 12, not 32: the kernel picks the longest match and breaks ties by recency, and a
++        # longer cap makes it prefer an older long match over a newer short one. On
++        # quote-and-explain work the newer one is the better predictor (3.21 vs 2.69 tokens
++        # per step), and copies match well past 12 either way.
++        self._lookup_nmax = int(os.environ.get("VLLM_DFLASH2_LOOKUP_NMAX", "12"))
++        # NSTRONG = NMIN and AGREE = 0 means "take any match of NMIN or more" for the
++        # positions the drafter also proposed. Measured better at C1 (3.33 vs 3.27 tokens
++        # per step) than requiring drafter agreement for medium matches.
++        self._lookup_nstrong = int(os.environ.get("VLLM_DFLASH2_LOOKUP_NSTRONG", "6"))
++        self._lookup_agree = int(os.environ.get("VLLM_DFLASH2_LOOKUP_AGREE", "0"))
++        self._lookup_nmin_tail = int(os.environ.get("VLLM_DFLASH2_LOOKUP_NMIN_TAIL", "4"))
++        self._lookup_long_min = int(os.environ.get("VLLM_DFLASH2_LOOKUP_LONGMIN", "6"))
++        # Below this many tokens of context the long block is taken unconditionally, on the
++        # theory that an extra verify position is nearly free there. Off by default: it
++        # measured +8% at C1 under one memory configuration and -13% under the one that
++        # ships (4 request slots, 56k), because what the extra positions cost depends on the
++        # paged-attention layout as much as on the KV length.
++        self._lookup_cheap_ctx = int(os.environ.get("VLLM_DFLASH2_LOOKUP_CHEAP_CTX", "0"))
++        self._lookup_search = int(os.environ.get("VLLM_DFLASH2_LOOKUP_SEARCH", str(1 << 30)))
++        self._req_states = None
++        self._lookup_tokens = torch.zeros(
++            (self.max_num_reqs, self.num_speculative_steps), dtype=torch.int32, device=device
++        )
++        self._lookup_len = torch.zeros(self.max_num_reqs, dtype=torch.int32, device=device)
++        self._lookup_valid = torch.zeros(self.max_num_reqs, dtype=torch.int32, device=device)
++        # Which draft positions came from the lookup, per request: what the point-mass
++        # rewrite of the draft distribution applies to.
++        self._lookup_use = torch.zeros(
++            (self.max_num_reqs, self.num_speculative_steps), dtype=torch.int32, device=device
++        )
++        self._lookup_hits = torch.zeros((), dtype=torch.int64, device=device)
++        # Adaptive verify length: a long block only pays for itself while the request is
++        # reproducing its context, so the scheduler is asked for the drafter's own block
++        # otherwise. The signal is the previous step's lookup decision, read from a pinned
++        # copy -- one step stale by construction, which costs at most one step at each end
++        # of a copy run and never needs a synchronise.
++        self._adaptive = (
++            os.environ.get("VLLM_DFLASH2_LOOKUP_ADAPTIVE", "1") == "1"
++            and self.draft_block < self.num_speculative_steps
++        )
++        self._take_flags = torch.zeros(
++            self.max_num_reqs, dtype=torch.int32, device=device
++        )
++        self._last_num_reqs = 0
++        self._flags_cpu = torch.zeros(
++            self.max_num_reqs, dtype=torch.int32, device="cpu"
++        ).pin_memory()
++        self._flags_n = 0
++        self._prev_want = False
++        # Entering the long block takes two qualifying steps in a row and leaving it took
++        # one, so a single step where the flag dropped out mid-copy cost three. It drops out
++        # for reasons that have nothing to do with the copy ending -- a line the lookup
++        # cannot match, or a flag copy that had not landed yet -- and the same server then
++        # measured 13.76, 13.92, 13.92, 13.92 and 13.92 tokens per step on consecutive runs
++        # of one prompt against 14.97 on the first. STICKY holds the long block for that
++        # many steps after the flag goes out, which makes it 15.21 every time.
++        #
++        # Gating the hold on "the request is still emitting a full block a step" -- which
++        # should distinguish a late flag from a finished copy -- removes the whole effect
++        # (13.92 again): by the time the flag drops the step it describes was not saturated
++        # either, so the two are not independent evidence.
++        #
++        # It only applies with one request in flight, and that restriction is not caution.
++        # This counter is one number for the whole batch, and unlike the entry condition it
++        # keeps the long block on through steps where the flags say no -- so with several
++        # requests, which block length a copying request gets starts to depend on when the
++        # others arrived. Different block length, different rounding, different greedy text:
++        # bench/labd_soak.py caught a verbatim copy coming out differently in two rounds of
++        # an otherwise identical 4-way batch, and reproducibly did not with STICKY=0.
++        self._lookup_sticky = int(os.environ.get("VLLM_DFLASH2_LOOKUP_STICKY", "3"))
++        self._sticky = 0
++
++        if self._lookup:
++            logger.info(
++                "DFlash2 lookup-augmented drafting on (k=%d nmin=%d nmax=%d nstrong=%d "
++                "agree=%d nmin_tail=%d longmin=%d search=%d)",
++                self.num_speculative_steps, self._lookup_nmin, self._lookup_nmax,
++                self._lookup_nstrong, self._lookup_agree, self._lookup_nmin_tail,
++                self._lookup_long_min, self._lookup_search,
++            )
++
++    def next_num_draft_tokens(self) -> int | None:
++        """How many of the proposed tokens the scheduler should put up for verification next
++        step (None = all of them).
++
++        This runs on the host once per step, which is why the decision lives here and not in
++        `_apply_lookup`: the draft pass is replayed from a captured CUDA graph, so anything
++        Python does in there runs at capture time only. The two inputs are the per-request
++        flag the (replayed) fuse kernel writes -- "there is something to put in the tail" --
++        and what the step that just finished emitted. A long block costs step time on every
++        request in the batch whether or not its tail is accepted, so it takes both, and
++        unanimity across the batch. Below CHEAP_CTX tokens of context an extra verify
++        position is nearly free (+6% per step at 1.5k against +27% at 25k), so there the
++        flag alone is enough."""
++        if not self._adaptive:
++            return None
++        emitted = getattr(self, "last_num_emitted", None)
++        if emitted is None:
++            return self.draft_block
++        if self.draft_max_seq_len <= self._lookup_cheap_ctx:
++            # An extra verify position costs attention proportional to the KV length: +6%
++            # per step at 1.5k of context against +27% at 25k. Below the threshold it is
++            # cheap enough that taking the long block unconditionally wins (+8% at C1),
++            # even on the steps where the lookup has nothing to put in it.
++            return self.num_speculative_steps
++        num_reqs = emitted.shape[0]
++        # Read the decision that landed from the previous step and start the copy for the
++        # next one. Reading it synchronously (`.item()`) is a device synchronise on every
++        # decode step and measured 5% -- more than the long block itself is worth on most
++        # work. One step of staleness costs a short step at the start of a copy run and a
++        # long one at its end.
++        want = bool(self._flags_n and self._flags_cpu[: self._flags_n].all())
++        fused = (self._take_flags[:num_reqs] > 0) & (emitted >= 1 + self.draft_block)
++        self._flags_cpu[:num_reqs].copy_(fused, non_blocking=True)
++        self._flags_n = num_reqs
++        # Two qualifying steps in a row, not one: a single saturated step happens in the
++        # middle of ordinary prose (a quoted phrase, a repeated list marker) and the long
++        # block it buys is then wasted. Waiting for the second one costs the first step of
++        # a copy and removes the loss on quote-and-explain work.
++        if want and self._prev_want:
++            long_block = True
++            self._sticky = self._lookup_sticky if num_reqs == 1 else 0
++        elif self._sticky > 0 and num_reqs == 1:
++            # Coasting: re-entry costs two steps, so a run that has already earned the long
++            # block twice gets the benefit of the doubt for a few more.
++            long_block, self._sticky = True, self._sticky - 1
++        else:
++            long_block, self._sticky = False, 0
++        self._prev_want = want
++        return self.num_speculative_steps if long_block else self.draft_block
++
++    def set_req_states(self, req_states) -> None:
++        """The token history the lookup matches against (set by the model runner)."""
++        self._req_states = req_states
+ 
+     def draft_logits_spec(self, vllm_config: VllmConfig) -> tuple[torch.dtype, float]:
+-        # fp32 so the walk and the rejection that checks it read the same
+-        # distribution; -inf because the cache kernel writes only the K
+-        # candidates.
++        # The v0.28 rejection sampler divides cached logits by temperature itself.
++        # -inf is required because the sparse cache kernel only writes the K candidates.
+         return torch.float32, -float("inf")
+ 
++    def set_sampling_states(self, sampling_states) -> None:
++        self._req_top_p = sampling_states.top_p.gpu
++        self._req_top_k = sampling_states.top_k.gpu
++
+     def _sample_path(
+         self,
+         candidate_ids: torch.Tensor,
+@@ -141,6 +334,7 @@ class DFlash2Speculator(DFlashSpeculator):
+         num_reqs: int,
+     ) -> None:
+         block_k = triton.next_power_of_2(self.selector_top_k)
++        truncate = self._truncate and self._req_top_p is not None
+         _selector_walk_kernel[(num_reqs,)](
+             scores.contiguous(),
+             candidate_ids.contiguous(),
+@@ -148,19 +342,25 @@ class DFlash2Speculator(DFlashSpeculator):
+             self.sample_idx_mapping,
+             self.temperature,
+             self.seeds,
+-            self.draft_tokens,
++            self._selector_tokens,
+             self._selector_scores,
+-            num_steps=self.num_speculative_steps,
++            self._req_top_p if truncate else self.temperature,
++            self._req_top_k if truncate else self.sample_idx_mapping,
++            num_steps=self.draft_block,
+             top_k=self.selector_top_k,
+             BLOCK_K=block_k,
+             SAMPLE_PROBABILISTIC=self.draft_logits is not None,
+             USE_FP64=self.use_fp64_gumbel,
++            TRUNCATE=truncate,
+             num_warps=1,
+         )
+ 
+     def _cache_draft_logits(self, candidate_ids: torch.Tensor, num_sample: int) -> None:
+         draft_logits = self.draft_logits
+-        assert draft_logits is not None
++        if draft_logits is None:
++            # Greedy rejection sampling never reads q; the token fusion above is still
++            # useful because it supplies the proposal handed to the target.
++            return
+         block_k = triton.next_power_of_2(self.selector_top_k)
+         _cache_draft_logits_kernel[(num_sample,)](
+             draft_logits,
+@@ -170,7 +370,8 @@ class DFlash2Speculator(DFlashSpeculator):
+             self.sample_idx_mapping,
+             draft_logits.stride(0),
+             draft_logits.stride(1),
+-            num_steps=self.num_speculative_steps,
++            num_steps=self.draft_block,
++            cache_steps=self.num_speculative_steps,
+             top_k=self.selector_top_k,
+             BLOCK_K=block_k,
+             num_warps=1,
+@@ -192,15 +393,15 @@ class DFlash2Speculator(DFlashSpeculator):
+             num_tokens_across_dp,
+             cudagraph_runtime_mode,
+         )
+-        num_sample = num_reqs * self.num_speculative_steps
++        num_sample = num_reqs * self.draft_block
+         hidden_states = last_hidden_states[self.sample_indices[:num_sample]].view(
+-            num_reqs, self.num_speculative_steps, -1
++            num_reqs, self.draft_block, -1
+         )
+         candidate_ids, unary_logits = self.model.compute_candidates(
+             hidden_states.flatten(0, 1)
+         )
+         candidate_ids = candidate_ids.view(
+-            num_reqs, self.num_speculative_steps, self.selector_top_k
++            num_reqs, self.draft_block, self.selector_top_k
+         )
+         unary_logits = unary_logits.view_as(candidate_ids)
+         anchor_token_ids = self.input_buffers.input_ids[self._anchor_indices[:num_reqs]]
+@@ -213,3 +414,68 @@ class DFlash2Speculator(DFlashSpeculator):
+         self._sample_path(candidate_ids, scores, num_reqs)
+         if self.draft_logits is not None:
+             self._cache_draft_logits(candidate_ids, num_sample)
++        self.draft_tokens[:num_reqs, : self.draft_block].copy_(
++            self._selector_tokens[:num_reqs]
++        )
++        self._apply_lookup(num_reqs)
++
++    def _apply_lookup(self, num_reqs: int) -> None:
++        """Fuse the drafted block with the continuation of an earlier occurrence of the
++        current suffix, where one exists (see dflash2/lookup.py), and fill the verify
++        positions past the drafter's own block. The draft distribution for every position
++        the lookup supplied becomes a point mass on the proposed token, which keeps vLLM's
++        rejection sampling exact."""
++        if not self._lookup or self._req_states is None:
++            return
++        tokens, match_len, valid = suffix_lookup(
++            self._req_states.all_token_ids.gpu,
++            self._req_states.total_len.gpu,
++            self.sample_idx_mapping,
++            num_reqs,
++            self.num_speculative_steps,
++            idx_mapping_stride=self.draft_block,
++            nmax=self._lookup_nmax,
++            nmin=self._lookup_nmin,
++            search_max=self._lookup_search,
++            out_tokens=self._lookup_tokens[:num_reqs],
++            out_len=self._lookup_len[:num_reqs],
++            out_valid=self._lookup_valid[:num_reqs],
++        )
++        fuse_draft(
++            self.draft_tokens[:num_reqs],
++            tokens,
++            match_len,
++            valid,
++            self._lookup_use[:num_reqs],
++            self.sample_idx_mapping,
++            self._lookup_hits,
++            num_reqs,
++            self.num_speculative_steps,
++            draft_block=self.draft_block,
++            idx_mapping_stride=self.draft_block,
++            nmin=self._lookup_nmin,
++            nstrong=self._lookup_nstrong,
++            agree_min=self._lookup_agree,
++            nmin_tail=self._lookup_nmin_tail,
++            long_min=self._lookup_long_min,
++            take_flags=self._take_flags[:num_reqs],
++        )
++        draft_logits = self.draft_logits
++        if draft_logits is None:
++            return
++        block_k = triton.next_power_of_2(self.selector_top_k)
++        _point_mass_draft_logits_kernel[(num_reqs * self.num_speculative_steps,)](
++            draft_logits,
++            self._cached_candidate_ids,
++            self.draft_tokens,
++            self.draft_tokens.stride(0),
++            self._lookup_use,
++            self.sample_idx_mapping,
++            self.draft_block,
++            draft_logits.stride(0),
++            draft_logits.stride(1),
++            num_steps=self.num_speculative_steps,
++            top_k=self.selector_top_k,
++            BLOCK_K=block_k,
++            num_warps=1,
++        )
+diff --git a/v1/worker/gpu/spec_decode/utils.py b/v1/worker/gpu/spec_decode/utils.py
+index e25672e95..1f712a07d 100644
 --- a/v1/worker/gpu/spec_decode/utils.py
 +++ b/v1/worker/gpu/spec_decode/utils.py
-@@ -20,10 +20,16 @@
+@@ -20,10 +20,16 @@ class DraftTokensHandler:
          self.num_draft_tokens: int = 0
  
      def set_draft_tokens(
@@ -937,129 +4000,3 @@ This replaces the pre-0.28 DFlash2 backport: 0.28.0 already ships the native DFl
          if not input_batch.has_structured_output_reqs:
              # No draft token validation needs to be performed by
              # the scheduler for this batch.
---- a/v1/worker/gpu/cudagraph_utils.py
-+++ b/v1/worker/gpu/cudagraph_utils.py
-@@ -215,7 +215,34 @@
-             ]
-         else:
-             decode_query_lens = [self.decode_query_len]
-+            # A DFlash drafter whose checkpoint block is shorter than the verify block
-+            # (v1/worker/gpu/spec_decode/dflash2/lookup.py fills the rest from the request's
-+            # own context) schedules either length, so both need a decode graph. Without
-+            # this the short step -- the one taken on ordinary prose -- runs piecewise.
-+            import os as _os
- 
-+            if (
-+                speculative_config is not None
-+                and _os.environ.get("VLLM_DFLASH2_GRAPH_BOTH", "1") == "1"
-+                and _os.environ.get("VLLM_DFLASH2_LOOKUP", "0") == "1"
-+            ):
-+                _cfg = getattr(
-+                    getattr(speculative_config, "draft_model_config", None),
-+                    "hf_config",
-+                    None,
-+                )
-+                _block = int((getattr(_cfg, "dflash_config", None) or {}).get("block_size", 0))
-+                _short = _block + (
-+                    self.decode_query_len - self.vllm_config.num_speculative_tokens - 1
-+                )
-+                if 0 < _short < self.decode_query_len:
-+                    decode_query_lens.append(_short)
-+                    logger.info(
-+                        "Capturing decode graphs for query lengths %s (the drafter's block "
-+                        "and the full verify block).",
-+                        decode_query_lens,
-+                    )
-+
-         capture_varlen_decode = (
-             separate_decode_routine and bool(decode_mode) and self.varlen_decode
-         )
---- a/v1/worker/gpu/model_runner.py
-+++ b/v1/worker/gpu/model_runner.py
-@@ -284,6 +284,9 @@
-             num_prefill_lookahead=num_prefill_lookahead,
-         )
-         self.adaptive_verification: AdaptiveVerificationManager | None = None
-+        if self.speculator is not None and hasattr(self.speculator, "set_req_states"):
-+            # Lookup-augmented drafting reads the request token history.
-+            self.speculator.set_req_states(self.req_states)
-         self.input_buffers = InputBuffers(
-             max_num_reqs=self.max_num_reqs,
-             max_num_tokens=self.max_num_tokens,
-@@ -417,6 +420,9 @@
-                     self.speculative_config,
-                     self.device,
-                 )
-+            if self.speculator is not None and hasattr(self.speculator, "set_sampling_states"):
-+                # DFlash2 truncates its proposal to the request's top-k/top-p.
-+                self.speculator.set_sampling_states(self.sampler.sampling_states)
-             self.prompt_logprobs_worker = PromptLogprobsWorker(
-                 self.max_num_reqs,
-                 logprobs_mode=self.model_config.logprobs_mode,
-@@ -1862,9 +1868,18 @@
-         if self.num_speculative_steps > 0:
-             # Spec-decode and diffusion LLMs both use draft tokens but the latter does
-             # not have a speculator (i.e. self.speculator is None)
-+            num_draft = None
-+            if self.speculator is not None and hasattr(
-+                self.speculator, "next_num_draft_tokens"
-+            ):
-+                # Lookup-augmented drafting proposes a long block only while the request
-+                # is reproducing its context; the rest of the time it asks the scheduler
-+                # to verify the drafter's own (much cheaper) block.
-+                num_draft = self.speculator.next_num_draft_tokens()
-             self.draft_tokens_handler.set_draft_tokens(
-                 input_batch,
-                 self.req_states.draft_tokens[input_batch.idx_mapping],
-+                num_draft=num_draft,
-             )
- 
-             # Post-step KV connector related operations.
-
---- a/model_executor/models/qwen3_dflash.py
-+++ b/model_executor/models/qwen3_dflash.py
-@@ -375,5 +375,36 @@
-         return hidden_states, residual
-
-
-+def _dense_kv_rows(attn: nn.Module) -> torch.Tensor:
-+    """Return the K/V rows of a QKV projection as a dense matrix.
-+
-+    The W4A16 DFlash2 checkpoint uses compressed-tensors for qkv_proj. In
-+    vLLM 0.28.0 that layer exposes packed weights rather than ``weight``;
-+    context-KV precomputation still needs the dense K/V rows.
-+    """
-+    qkv = attn.qkv_proj
-+    weight = getattr(qkv, "weight", None)
-+    if weight is not None and weight.dim() == 2:
-+        return weight[attn.q_size :]
-+
-+    packed, scale = qkv.weight_packed, qkv.weight_scale
-+    out_features, in_features = int(packed.shape[0]), int(qkv.input_size)
-+    bits = 32 * packed.shape[1] // in_features
-+    from compressed_tensors.compressors.pack_quantized.base import unpack_from_int32
-+
-+    quantized = unpack_from_int32(
-+        packed.data,
-+        bits,
-+        torch.Size([out_features, in_features]),
-+        packed_dim=1,
-+    )
-+    group_size = in_features // scale.shape[1]
-+    dense = (
-+        quantized.to(torch.float32)
-+        .reshape(out_features, in_features // group_size, group_size)
-+        * scale.to(torch.float32)[..., None]
-+    ).reshape(out_features, in_features)
-+    dtype = scale.dtype if scale.dtype.is_floating_point else torch.bfloat16
-+    return dense.to(dtype)[attn.q_size :]
-
-
-@@ -487,7 +518,7 @@
-         self._hidden_norm_weight = self.hidden_norm.weight.data
-
-         # KV projection weights: [num_layers * 2 * kv_size, hidden_size]
--        kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
-+        kv_weights = [_dense_kv_rows(a) for a in layers_attn]
-         self._fused_kv_weight = torch.cat(kv_weights, dim=0)
-         if has_bias:

--- a/patches/dflash2-lookup-drafting.patch
+++ b/patches/dflash2-lookup-drafting.patch
@@ -110,7 +110,7 @@ This replaces the pre-0.28 DFlash2 backport: 0.28.0 already ships the native DFl
          )
  
      def _build_draft_attn_metadata(
-@@ -329,6 +358,11 @@
+@@ -329,6 +358,10 @@
          is_profile: bool = False,
      ) -> torch.Tensor:
          num_reqs = input_batch.num_reqs

--- a/patches/dflash2-lookup-drafting.patch
+++ b/patches/dflash2-lookup-drafting.patch
@@ -110,14 +110,15 @@ This replaces the pre-0.28 DFlash2 backport: 0.28.0 already ships the native DFl
          )
  
      def _build_draft_attn_metadata(
-@@ -329,6 +358,10 @@
+@@ -329,6 +358,11 @@
          is_profile: bool = False,
      ) -> torch.Tensor:
          num_reqs = input_batch.num_reqs
-+        # vLLM's rejection sampler returns num_sampled as the accepted/emitted
-+        # token count; num_rejected is only discarded verify positions. Keep
-+        # the accepted count for adaptive verify-length scheduling.
-+        self.last_num_emitted = num_sampled if num_sampled is not None else None
++        # What the step that just ran actually produced per request: num_sampled counts the
++        # sampling slots it was given (bonus + drafts), num_rejected how many of those were
++        # thrown away, so the difference is the tokens it emitted. dflash2/lookup.py decides
++        # the next block length from it.
++        self.last_num_emitted = (num_sampled - num_rejected) if num_sampled is not None else None
          num_target_tokens = input_batch.num_tokens
          num_query_tokens = num_reqs * self.num_query_per_req
          max_seq_len = input_batch.seq_lens_cpu_upper_bound[:num_reqs].max().item()

--- a/patches/dflash2-lookup-drafting.patch
+++ b/patches/dflash2-lookup-drafting.patch
@@ -1014,4 +1014,52 @@ This replaces the pre-0.28 DFlash2 backport: 0.28.0 already ships the native DFl
 +                num_draft=num_draft,
              )
  
-         # Post-step KV connector related operations.
+             # Post-step KV connector related operations.
+
+--- a/model_executor/models/qwen3_dflash.py
++++ b/model_executor/models/qwen3_dflash.py
+@@ -375,5 +375,36 @@
+         return hidden_states, residual
+
+
++def _dense_kv_rows(attn: nn.Module) -> torch.Tensor:
++    """Return the K/V rows of a QKV projection as a dense matrix.
++
++    The W4A16 DFlash2 checkpoint uses compressed-tensors for qkv_proj. In
++    vLLM 0.28.0 that layer exposes packed weights rather than ``weight``;
++    context-KV precomputation still needs the dense K/V rows.
++    """
++    qkv = attn.qkv_proj
++    weight = getattr(qkv, "weight", None)
++    if weight is not None and weight.dim() == 2:
++        return weight[attn.q_size :]
++
++    packed, scale = qkv.weight_packed, qkv.weight_scale
++    out_features, in_features = int(packed.shape[0]), int(qkv.input_size)
++    bits = 32 * packed.shape[1] // in_features
++    from compressed_tensors.compressors.pack_quantized.base import unpack_from_int32
++
++    quantized = unpack_from_int32(
++        packed.data,
++        bits,
++        torch.Size([out_features, in_features]),
++        packed_dim=1,
++    )
++    group_size = in_features // scale.shape[1]
++    dense = (
++        quantized.to(torch.float32)
++        .reshape(out_features, in_features // group_size, group_size)
++        * scale.to(torch.float32)[..., None]
++    ).reshape(out_features, in_features)
++    dtype = scale.dtype if scale.dtype.is_floating_point else torch.bfloat16
++    return dense.to(dtype)[attn.q_size :]
+
+
+@@ -487,7 +518,7 @@
+         self._hidden_norm_weight = self.hidden_norm.weight.data
+
+         # KV projection weights: [num_layers * 2 * kv_size, hidden_size]
+-        kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
++        kv_weights = [_dense_kv_rows(a) for a in layers_attn]
+         self._fused_kv_weight = torch.cat(kv_weights, dim=0)
+         if has_bias:

--- a/patches/dflash2-lookup-drafting.patch
+++ b/patches/dflash2-lookup-drafting.patch
@@ -114,11 +114,10 @@ This replaces the pre-0.28 DFlash2 backport: 0.28.0 already ships the native DFl
          is_profile: bool = False,
      ) -> torch.Tensor:
          num_reqs = input_batch.num_reqs
-+        # What the step that just ran actually produced per request: num_sampled counts the
-+        # sampling slots it was given (bonus + drafts), num_rejected how many of those were
-+        # thrown away, so the difference is the tokens it emitted. dflash2/lookup.py decides
-+        # the next block length from it.
-+        self.last_num_emitted = (num_sampled - num_rejected) if num_sampled is not None else None
++        # vLLM's rejection sampler returns num_sampled as the accepted/emitted
++        # token count; num_rejected is only discarded verify positions. Keep
++        # the accepted count for adaptive verify-length scheduling.
++        self.last_num_emitted = num_sampled if num_sampled is not None else None
          num_target_tokens = input_batch.num_tokens
          num_query_tokens = num_reqs * self.num_query_per_req
          max_seq_len = input_batch.seq_lens_cpu_upper_bound[:num_reqs].max().item()

--- a/patches/dflash2-lookup-drafting.patch
+++ b/patches/dflash2-lookup-drafting.patch
@@ -1,68 +1,12 @@
-Lookup-augmented block drafting (LABD) for DFlash2: draft from the context, not from the
-drafter, when the context already contains the answer -- and let the verify block be longer
-than the drafter's when it does.
+DFlash2 candidate-head quantization and lookup drafting ported to vLLM 0.28.0.
 
-A block drafter guesses the next 7 tokens from a 2,048-token attention window. When the model
-is quoting, listing, editing or otherwise reproducing something it was given -- which is most
-of what a long-context assistant does -- those tokens are already sitting verbatim in the
-prompt, tens of thousands of tokens back, where the drafter cannot see them. This finds them:
-one Triton program per request scans the request's own token history (the int32 buffer vLLM
-already maintains, `req_states.all_token_ids`) for the most recent occurrence of the longest
-suffix (nmin..nmax tokens) of what has been generated, and proposes the tokens that followed
-it. An nmin-token reject test runs before any candidate is extended, so the scan costs a
-fraction of a millisecond whatever the batch size.
+This replaces the pre-0.28 DFlash2 backport: 0.28.0 already ships the native DFlash2 model and selector, so this patch layers the repo's quantized candidate selection, trained draft-block sizing, lookup augmentation, and runner wiring on top.
 
-Four things decide what that is worth.
+--- generated against the v0.28.0 source after the non-DFlash patches ---
 
-1. The verify block is decoupled from the drafter's block. `dflash_config.block_size` is a
-   property of the checkpoint (8 = 1 anchor + 7 mask tokens), and vLLM made it the target's
-   verify length as well, so a verbatim copy could never exceed 8 tokens per step -- and it
-   sat on that ceiling (7.83 of 8 accepted while reproducing a document's first 60 lines).
-   `DFlashSpeculator.draft_block` now describes the draft model's own query layout while
-   `num_speculative_tokens` describes the proposal handed to the target; the positions in
-   between are filled by the lookup. They cost the drafter nothing: no extra mask tokens, no
-   extra pass of the candidate head.
-
-2. The long block is only scheduled while the lookup is firing. Extra verify positions cost
-   about 1 ms of attention each at 25k context, so `DFlash2Speculator.next_num_draft_tokens`
-   tells the model runner how many of the proposals the scheduler should put up for
-   verification next step: the drafter's 7 normally, the whole block when the lookup has a
-   match (VLLM_DFLASH2_LOOKUP_ADAPTIVE=0 always asks for the whole block). Reading the
-   per-request match flags costs one small device-to-host read per step -- an async copy
-   into pinned memory would avoid the synchronise, but measured as not delivering the flags
-   in time on this path, and a long block that is never scheduled is worth much less than a
-   few percent of a step.
-   NOTE: vLLM only feeds draft token ids back to the scheduler on the synchronous scheduling
-   path, so this needs --no-async-scheduling (single-user/start_qwen.sh sets it; measured
-   cost at batch 1 is under 1%).
-
-3. The proposal is fused with the drafter's rather than substituted for it: a match of at
-   least VLLM_DFLASH2_LOOKUP_NSTRONG tokens is taken on its own, a shorter one only if the
-   drafter independently proposed the same first VLLM_DFLASH2_LOOKUP_AGREE tokens. Two
-   independent sources agreeing is a cheap confidence signal -- the drafter looked at the
-   hidden state, the lookup looked at the text.
-
-4. A match may overlap the suffix it matched, so a repeating pattern (a list marker, an
-   indent, a fence) is proposed from its own period instead of missed.
-
-The proposal stays lossless. For greedy requests the draft distribution is never read. For
-sampling requests every position the lookup filled gets a point mass on the proposed token,
-which is a legal proposal distribution for vLLM's rejection sampler: the acceptance
-probability becomes p(x) and the residual (p - q)+ is computed from the same buffer, so the
-output distribution is unchanged. The rewrite keeps the sparse draft-logit cache's invariant
-(every finite entry of a row is listed in `_cached_candidate_ids`, so the next step erases
-it) and reads the token back from `draft_tokens`, so q always describes what is verified.
-
-Requires patches/dflash2-backport.patch, and patches/spec-decode-attn.patch for a verify
-block longer than 10 query tokens (FlashAttention-2 does not split the KV sequence for
-multi-query decode; falling back to it doubles the step at 25k context).
-Apply from the installed vllm package directory:
-  patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/dflash2-lookup-drafting.patch
-
-Written against vLLM 0.27.1.
 --- a/model_executor/models/qwen3_dflash2.py
 +++ b/model_executor/models/qwen3_dflash2.py
-@@ -182,8 +182,15 @@
+@@ -127,8 +127,15 @@
              hidden_size=config.hidden_size,
              taps=int(draft_config["conv_kernel_size"]),
              group_size=int(draft_config["conv_group_size"]),
@@ -89,10 +33,11 @@ Written against vLLM 0.27.1.
  from collections.abc import Mapping
  from typing import Any
  
-@@ -42,8 +43,36 @@
+@@ -41,9 +42,37 @@
+ 
          # Multimodal inputs not currently supported.
          self.supports_mm_inputs = False
- 
++
 +        # The drafter emits the block it was trained for (dflash_config.block_size - 1);
 +        # the *verify* block may be longer than that, with the extra positions filled from
 +        # the request's own context (dflash2/lookup.py). Everything describing the draft
@@ -120,7 +65,7 @@ Written against vLLM 0.27.1.
 +                self.num_speculative_steps - self.draft_block,
 +                self.num_speculative_steps,
 +            )
-+
+ 
          # Each request emits exactly (bonus + N mask) query tokens per step.
 -        self.num_query_per_req = 1 + self.num_speculative_steps
 +        self.num_query_per_req = 1 + self.draft_block
@@ -136,7 +81,7 @@ Written against vLLM 0.27.1.
          self.sample_indices = torch.zeros(
              max_num_sampled_tokens, dtype=torch.int64, device=device
          )
-@@ -91,7 +120,7 @@
+@@ -93,7 +122,7 @@
          # [0, 1, ..., N-1, 0, 1, ..., N-1, ...] -> the per-token column index into
          # draft_logits[req, step, :].
          self.sample_col = torch.arange(
@@ -146,9 +91,9 @@ Written against vLLM 0.27.1.
  
          self.query_cudagraph_manager: DFlashCudaGraphManager | None = None
 @@ -258,7 +287,7 @@
+             num_tokens_across_dp,
              cudagraph_runtime_mode,
          )
- 
 -        num_sample = num_reqs * self.num_speculative_steps
 +        num_sample = num_reqs * self.draft_block
          sample_hidden_states = last_hidden_states[self.sample_indices[:num_sample]]
@@ -188,14 +133,21 @@ Written against vLLM 0.27.1.
                  self.max_model_len,
 --- a/v1/worker/gpu/spec_decode/dflash2/speculator.py
 +++ b/v1/worker/gpu/spec_decode/dflash2/speculator.py
-@@ -7,11 +7,19 @@
+@@ -1,17 +1,26 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++import os
+ from typing import Any
+ 
  import torch
  
- from vllm.config import VllmConfig
-+from vllm.logger import init_logger
+-from vllm.config import VllmConfig
  from vllm.config.compilation import CUDAGraphMode
- from vllm.triton_utils import tl, tldevice, triton
- from vllm.v1.worker.gpu.sample.gumbel import tl_rand32, tl_rand64
++from vllm.config import VllmConfig
++from vllm.logger import init_logger
+ from vllm.triton_utils import tl, triton
+ from vllm.v1.worker.gpu.sample.gumbel import gumbel_noised_argmax
  from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
  
 +logger = init_logger(__name__)
@@ -204,11 +156,83 @@ Written against vLLM 0.27.1.
 +    fuse_draft,
 +    suffix_lookup,
 +)
-+
  
++
  @triton.jit
  def _selector_walk_kernel(
-@@ -113,6 +121,7 @@
+     scores_ptr,
+@@ -22,11 +31,14 @@
+     seeds_ptr,
+     tokens_ptr,
+     realized_scores_ptr,
++    req_top_p_ptr,
++    req_top_k_ptr,
+     num_steps: tl.constexpr,
+     top_k: tl.constexpr,
+     BLOCK_K: tl.constexpr,
+     SAMPLE_PROBABILISTIC: tl.constexpr,
+     USE_FP64: tl.constexpr,
++    TRUNCATE: tl.constexpr,
+ ):
+     row = tl.program_id(0)
+     offsets = tl.arange(0, BLOCK_K)
+@@ -35,6 +47,9 @@
+     valid = req_state >= 0
+     temperature = tl.load(temperature_ptr + req_state, mask=valid, other=0.0)
+     seed = tl.load(seeds_ptr + req_state, mask=valid, other=0)
++    if TRUNCATE:
++        req_top_p = tl.load(req_top_p_ptr + req_state, mask=valid, other=1.0)
++        req_top_k = tl.load(req_top_k_ptr + req_state, mask=valid, other=BLOCK_K)
+     previous = 0
+     for step in range(num_steps):
+         flat = row * num_steps + step
+@@ -43,7 +58,7 @@
+             scores_ptr + score_base + offsets,
+             mask=mask & valid,
+             other=float("-inf"),
+-        ).to(tl.float64 if USE_FP64 else tl.float32)
++        ).to(tl.float32)
+         candidate_base = flat * top_k
+         candidates = tl.load(
+             candidate_ptr + candidate_base + offsets,
+@@ -51,7 +66,20 @@
+             other=0,
+         )
+ 
+-        # Candidate ids key the noise, matching the target's own sampling.
++        if SAMPLE_PROBABILISTIC and temperature != 0.0 and TRUNCATE:
++            # Apply the request's top-k/top-p to the proposal distribution over the
++            # candidates. The rejection sampler consumes pre-temperature logits, so keep
++            # the original scores and use -inf to represent the truncated support.
++            scaled_scores = scores / temperature
++            mx = tl.max(scaled_scores, axis=0)
++            probs = tl.exp(scaled_scores - mx)
++            probs = probs / tl.sum(probs, axis=0)
++            greater = scaled_scores[None, :] > scaled_scores[:, None]
++            rank = tl.sum(greater.to(tl.int32), axis=1)
++            mass_before = tl.sum(tl.where(greater, probs[None, :], 0.0), axis=1)
++            keep = mask & (rank < req_top_k) & (mass_before < req_top_p)
++            scores = tl.where(keep, scores, -float("inf"))
++
+         position = tl.load(sample_pos_ptr + flat) - 1
+         _, index = gumbel_noised_argmax(
+             scores,
+@@ -62,10 +90,12 @@
+             temperature if SAMPLE_PROBABILISTIC else 0.0,
+             USE_FP64=USE_FP64,
+         )
+-
++        # vLLM 0.28.0's rejection sampler expects pre-temperature logits. With TRUNCATE
++        # the cached row is the truncated proposal (-inf outside the kept support).
++        realized = scores
+         tl.store(
+             realized_scores_ptr + candidate_base + offsets,
+-            scores,
++            realized,
+             mask=mask & valid,
+         )
+         token = tl.load(candidate_ptr + candidate_base + index, mask=valid, other=0)
+@@ -83,6 +113,7 @@
      draft_logits_stride_0,
      draft_logits_stride_1,
      num_steps: tl.constexpr,
@@ -216,7 +240,7 @@ Written against vLLM 0.27.1.
      top_k: tl.constexpr,
      BLOCK_K: tl.constexpr,
  ):
-@@ -122,7 +131,9 @@
+@@ -92,7 +123,9 @@
      offsets = tl.arange(0, BLOCK_K)
      mask = (req_state >= 0) & (offsets < top_k)
      candidate_base = flat * top_k
@@ -227,7 +251,7 @@ Written against vLLM 0.27.1.
      old_token_ids = tl.load(cached_candidate_ptr + cache_base + offsets, mask=mask)
      logits_base = (
          draft_logits_ptr
-@@ -137,6 +148,9 @@
+@@ -107,6 +140,9 @@
  
  
  class DFlash2Speculator(DFlashSpeculator):
@@ -237,11 +261,10 @@ Written against vLLM 0.27.1.
      _speculator_name = "DFlash2"
  
      def __init__(self, vllm_config: VllmConfig, device: torch.device):
-@@ -147,10 +161,14 @@
+@@ -117,23 +153,180 @@
              torch.arange(self.max_num_reqs, dtype=torch.int64, device=device)
              * self.num_query_per_req
          )
--        self._selector_tokens = torch.empty_like(self.draft_tokens)
 +        self._selector_tokens = torch.empty(
 +            (self.max_num_reqs, self.draft_block),
 +            dtype=self.draft_tokens.dtype,
@@ -254,23 +277,18 @@ Written against vLLM 0.27.1.
              self.selector_top_k,
              dtype=torch.float32,
              device=device,
-@@ -167,14 +185,160 @@
-             dtype=torch.float32,
-             device=device,
          )
-+        # Spans the verify block: the point-mass rewrite keeps the same erase invariant
-+        # for the positions the lookup fills beyond the drafter's own block.
          self._cached_candidate_ids = torch.zeros(
 -            self._selector_scores.shape, dtype=torch.int64, device=device
 +            (self.max_num_reqs, self.num_speculative_steps, self.selector_top_k),
 +            dtype=torch.int64,
 +            device=device,
          )
-         # Request top_p/top_k buffers ([max_num_reqs], indexed by request state), handed
-         # over by the model runner; VLLM_DFLASH2_DRAFT_TOPK_TOPP=0 disables the truncation.
-         self._req_top_p: torch.Tensor | None = None
-         self._req_top_k: torch.Tensor | None = None
-         self._truncate = os.environ.get("VLLM_DFLASH2_DRAFT_TOPK_TOPP", "1") == "1"
++        # Request top_p/top_k buffers ([max_num_reqs], indexed by request state), handed
++        # over by the model runner; VLLM_DFLASH2_DRAFT_TOPK_TOPP=0 disables the truncation.
++        self._req_top_p: torch.Tensor | None = None
++        self._req_top_k: torch.Tensor | None = None
++        self._truncate = os.environ.get("VLLM_DFLASH2_DRAFT_TOPK_TOPP", "1") == "1"
 +        # Lookup-augmented block drafting: propose the continuation of an earlier
 +        # occurrence of the current suffix instead of the model's guess (lookup.py).
 +        self._lookup = os.environ.get("VLLM_DFLASH2_LOOKUP", "0") == "1"
@@ -350,7 +368,11 @@ Written against vLLM 0.27.1.
 +        # an otherwise identical 4-way batch, and reproducibly did not with STICKY=0.
 +        self._lookup_sticky = int(os.environ.get("VLLM_DFLASH2_LOOKUP_STICKY", "3"))
 +        self._sticky = 0
-+
+ 
+-    def draft_logits_spec(self, vllm_config: VllmConfig) -> tuple[torch.dtype, float]:
+-        # fp32 so the walk and the rejection that checks it read the same
+-        # distribution; -inf because the cache kernel writes only the K
+-        # candidates.
 +        if self._lookup:
 +            logger.info(
 +                "DFlash2 lookup-augmented drafting on (k=%d nmin=%d nmax=%d nstrong=%d "
@@ -413,19 +435,57 @@ Written against vLLM 0.27.1.
 +    def set_req_states(self, req_states) -> None:
 +        """The token history the lookup matches against (set by the model runner)."""
 +        self._req_states = req_states
++
++    def draft_logits_spec(self, vllm_config: VllmConfig) -> tuple[torch.dtype, float]:
++        # The v0.28 rejection sampler divides cached logits by temperature itself.
++        # -inf is required because the sparse cache kernel only writes the K candidates.
+         return torch.float32, -float("inf")
  
-     def set_sampling_states(self, sampling_states) -> None:
-         self._req_top_p = sampling_states.top_p.gpu
-@@ -199,7 +363,7 @@
++    def set_sampling_states(self, sampling_states) -> None:
++        self._req_top_p = sampling_states.top_p.gpu
++        self._req_top_k = sampling_states.top_k.gpu
++
+     def _sample_path(
+         self,
+         candidate_ids: torch.Tensor,
+@@ -141,6 +334,7 @@
+         num_reqs: int,
+     ) -> None:
+         block_k = triton.next_power_of_2(self.selector_top_k)
++        truncate = self._truncate and self._req_top_p is not None
+         _selector_walk_kernel[(num_reqs,)](
+             scores.contiguous(),
+             candidate_ids.contiguous(),
+@@ -148,19 +342,25 @@
+             self.sample_idx_mapping,
+             self.temperature,
+             self.seeds,
+-            self.draft_tokens,
++            self._selector_tokens,
              self._selector_scores,
-             self._req_top_p if truncate else self.temperature,
-             self._req_top_k if truncate else self.sample_idx_mapping,
 -            num_steps=self.num_speculative_steps,
++            self._req_top_p if truncate else self.temperature,
++            self._req_top_k if truncate else self.sample_idx_mapping,
 +            num_steps=self.draft_block,
              top_k=self.selector_top_k,
              BLOCK_K=block_k,
+             SAMPLE_PROBABILISTIC=self.draft_logits is not None,
              USE_FP64=self.use_fp64_gumbel,
-@@ -219,7 +383,8 @@
++            TRUNCATE=truncate,
+             num_warps=1,
+         )
+ 
+     def _cache_draft_logits(self, candidate_ids: torch.Tensor, num_sample: int) -> None:
+         draft_logits = self.draft_logits
+-        assert draft_logits is not None
++        if draft_logits is None:
++            # Greedy rejection sampling never reads q; the token fusion above is still
++            # useful because it supplies the proposal handed to the target.
++            return
+         block_k = triton.next_power_of_2(self.selector_top_k)
+         _cache_draft_logits_kernel[(num_sample,)](
+             draft_logits,
+@@ -170,7 +370,8 @@
              self.sample_idx_mapping,
              draft_logits.stride(0),
              draft_logits.stride(1),
@@ -435,7 +495,7 @@ Written against vLLM 0.27.1.
              top_k=self.selector_top_k,
              BLOCK_K=block_k,
              num_warps=1,
-@@ -241,15 +406,15 @@
+@@ -192,15 +393,15 @@
              num_tokens_across_dp,
              cudagraph_runtime_mode,
          )
@@ -454,11 +514,10 @@ Written against vLLM 0.27.1.
          )
          unary_logits = unary_logits.view_as(candidate_ids)
          anchor_token_ids = self.input_buffers.input_ids[self._anchor_indices[:num_reqs]]
-@@ -261,4 +426,67 @@
-         )
+@@ -213,3 +414,68 @@
          self._sample_path(candidate_ids, scores, num_reqs)
-         self._cache_draft_logits(candidate_ids, num_sample)
--        self.draft_tokens[:num_reqs].copy_(self._selector_tokens[:num_reqs])
+         if self.draft_logits is not None:
+             self._cache_draft_logits(candidate_ids, num_sample)
 +        self.draft_tokens[:num_reqs, : self.draft_block].copy_(
 +            self._selector_tokens[:num_reqs]
 +        )
@@ -506,7 +565,8 @@ Written against vLLM 0.27.1.
 +            take_flags=self._take_flags[:num_reqs],
 +        )
 +        draft_logits = self.draft_logits
-+        assert draft_logits is not None
++        if draft_logits is None:
++            return
 +        block_k = triton.next_power_of_2(self.selector_top_k)
 +        _point_mass_draft_logits_kernel[(num_reqs * self.num_speculative_steps,)](
 +            draft_logits,
@@ -523,7 +583,7 @@ Written against vLLM 0.27.1.
 +            BLOCK_K=block_k,
 +            num_warps=1,
 +        )
---- a/v1/worker/gpu/spec_decode/dflash2/lookup.py
+--- /dev/null
 +++ b/v1/worker/gpu/spec_decode/dflash2/lookup.py
 @@ -0,0 +1,330 @@
 +"""Lookup-augmented block drafting (LABD).
@@ -877,40 +937,9 @@ Written against vLLM 0.27.1.
          if not input_batch.has_structured_output_reqs:
              # No draft token validation needs to be performed by
              # the scheduler for this batch.
---- a/v1/worker/gpu/model_runner.py
-+++ b/v1/worker/gpu/model_runner.py
-@@ -244,6 +244,9 @@
-             device=self.device,
-             num_prefill_lookahead=num_prefill_lookahead,
-         )
-+        if self.speculator is not None and hasattr(self.speculator, "set_req_states"):
-+            # Lookup-augmented drafting reads the request token history.
-+            self.speculator.set_req_states(self.req_states)
-         self.input_buffers = InputBuffers(
-             max_num_reqs=self.max_num_reqs,
-             max_num_tokens=self.max_num_tokens,
-@@ -1605,9 +1608,18 @@
-         if self.num_speculative_steps > 0:
-             # Spec-decode and diffusion LLMs both use draft tokens but the latter does
-             # not have a speculator (i.e. self.speculator is None)
-+            num_draft = None
-+            if self.speculator is not None and hasattr(
-+                self.speculator, "next_num_draft_tokens"
-+            ):
-+                # Lookup-augmented drafting proposes a long block only while the request
-+                # is reproducing its context; the rest of the time it asks the scheduler
-+                # to verify the drafter's own (much cheaper) block.
-+                num_draft = self.speculator.next_num_draft_tokens()
-             self.draft_tokens_handler.set_draft_tokens(
-                 input_batch,
-                 self.req_states.draft_tokens[input_batch.idx_mapping],
-+                num_draft=num_draft,
-             )
- 
-         # Post-step KV connector related operations.
 --- a/v1/worker/gpu/cudagraph_utils.py
 +++ b/v1/worker/gpu/cudagraph_utils.py
-@@ -219,7 +219,34 @@
+@@ -215,7 +215,34 @@
              ]
          else:
              decode_query_lens = [self.decode_query_len]
@@ -919,7 +948,7 @@ Written against vLLM 0.27.1.
 +            # own context) schedules either length, so both need a decode graph. Without
 +            # this the short step -- the one taken on ordinary prose -- runs piecewise.
 +            import os as _os
-+
+ 
 +            if (
 +                speculative_config is not None
 +                and _os.environ.get("VLLM_DFLASH2_GRAPH_BOTH", "1") == "1"
@@ -941,7 +970,48 @@ Written against vLLM 0.27.1.
 +                        "and the full verify block).",
 +                        decode_query_lens,
 +                    )
++
+         capture_varlen_decode = (
+             separate_decode_routine and bool(decode_mode) and self.varlen_decode
+         )
+--- a/v1/worker/gpu/model_runner.py
++++ b/v1/worker/gpu/model_runner.py
+@@ -284,6 +284,9 @@
+             num_prefill_lookahead=num_prefill_lookahead,
+         )
+         self.adaptive_verification: AdaptiveVerificationManager | None = None
++        if self.speculator is not None and hasattr(self.speculator, "set_req_states"):
++            # Lookup-augmented drafting reads the request token history.
++            self.speculator.set_req_states(self.req_states)
+         self.input_buffers = InputBuffers(
+             max_num_reqs=self.max_num_reqs,
+             max_num_tokens=self.max_num_tokens,
+@@ -417,6 +420,9 @@
+                     self.speculative_config,
+                     self.device,
+                 )
++            if self.speculator is not None and hasattr(self.speculator, "set_sampling_states"):
++                # DFlash2 truncates its proposal to the request's top-k/top-p.
++                self.speculator.set_sampling_states(self.sampler.sampling_states)
+             self.prompt_logprobs_worker = PromptLogprobsWorker(
+                 self.max_num_reqs,
+                 logprobs_mode=self.model_config.logprobs_mode,
+@@ -1862,9 +1868,18 @@
+         if self.num_speculative_steps > 0:
+             # Spec-decode and diffusion LLMs both use draft tokens but the latter does
+             # not have a speculator (i.e. self.speculator is None)
++            num_draft = None
++            if self.speculator is not None and hasattr(
++                self.speculator, "next_num_draft_tokens"
++            ):
++                # Lookup-augmented drafting proposes a long block only while the request
++                # is reproducing its context; the rest of the time it asks the scheduler
++                # to verify the drafter's own (much cheaper) block.
++                num_draft = self.speculator.next_num_draft_tokens()
+             self.draft_tokens_handler.set_draft_tokens(
+                 input_batch,
+                 self.req_states.draft_tokens[input_batch.idx_mapping],
++                num_draft=num_draft,
+             )
  
-         for num_tokens, num_active_loras in product(
-             capture_sizes, self.lora_capture_cases
-         ):
+         # Post-step KV connector related operations.

--- a/patches/dflash2-ngram-chains.patch
+++ b/patches/dflash2-ngram-chains.patch
@@ -243,8 +243,11 @@ The native 0.28 DFlash2 runner is extended by the lookup patch first; this patch
 +        self.draft_max_seq_len = min(
 +            max_seq_len + self.num_query_per_req, self.max_model_len
 +        )
++        # vLLM's rejection sampler returns num_sampled as the accepted/emitted
++        # token count; num_rejected is only discarded verify positions.
++        # Keep the accepted count for adaptive verify-length scheduling.
 +        self.last_num_emitted = (
-+            (num_sampled - num_rejected) if num_sampled is not None else None
++            num_sampled if num_sampled is not None else None
 +        )
 +
 +        if aux_hidden_states:

--- a/patches/dflash2-ngram-chains.patch
+++ b/patches/dflash2-ngram-chains.patch
@@ -1,67 +1,9 @@
-Drafter-free n-gram chains for DFlash2 (VLLM_DFLASH2_CHAIN=1, default off).
+Drafter-free n-gram chains for DFlash2 (VLLM_DFLASH2_CHAIN=1, default off), ported to vLLM 0.28.0.
 
-While a request keeps reproducing its own context, whole verify blocks are
-proposed from its history alone — context-KV insert + suffix lookup +
-point-mass rewrite, a handful of small eager kernels — and the draft model's
-forward AND its CUDA-graph replay are skipped entirely, until the first
-rejected token ends the chain. The proposal stays lossless: every position's
-draft distribution is a point mass on the proposed token, a legal q for
-vLLM's rejection sampler; positions past the match's continuation hold token
-0 and get rejected, which is exactly the exit signal.
+The native 0.28 DFlash2 runner is extended by the lookup patch first; this patch then adds the host-side chain state machine and eager context-only proposal path.
 
-Ported from Dmtrii-tesla/dflash2-ngram-vllm (Apache-2.0), offered for
-cherry-pick in issue #38 by its author, who independently rebuilt this
-repo's lookup lane and added this layer on top. Their three load-bearing
-design calls are preserved:
+--- generated against the v0.28.0 lookup tree ---
 
-  - the entry/exit state machine lives in propose(), on the host, once per
-    step -- under FULL cudagraphs any Python inside _generate_draft runs at
-    capture time only (their v1 died exactly there);
-  - the one value crossing GPU->host is a captured D2H memcpy of a
-    per-request flag into pinned memory, replayed by the graph every step,
-    read one step stale -- the same pattern the sticky/adaptive controllers
-    already use;
-  - entry evidence is the lookup's match_len (reaches nmax), not its valid
-    count (clamped to k; keying on it can never fire).
-
-Adaptations to this tree: propose() composes the chain decision ahead of
-the existing wrapper (which carries the dormant dflash3 extension
-machinery) instead of replacing the method, and _chain_generate mirrors
-this tree's current prepare_dflash_inputs signature. Constraints: single
-request in the batch, dp_size == 1, no mm inputs -- one shared decision
-per batch, like the sticky long block. While a chain is active,
-next_num_draft_tokens pins the full verify block so the tail is not
-thrown away.
-
-Envs: VLLM_DFLASH2_CHAIN (off), VLLM_DFLASH2_CHAIN_MINMATCH (8, tokens of
-longest context match required to enter), VLLM_DFLASH2_CHAIN_LOG_SEC (30,
-period of the "chain: N/M steps engaged" line; 0 silences). Requires
-VLLM_DFLASH2_LOOKUP=1; warns and disables itself otherwise. No compiled or
-captured shape depends on any of them (chain steps run eagerly), so they
-stay out of the compile-cache key by construction.
-
-Measured on this card (1x 3090 @ 250 W, CTX=fast, DFLASH_TOKENS=7,
-bench/labd_bench.py --ctx 20000 + run_benchmarks single, chain on vs off):
-
-  copy (25k ctx, greedy)   256.9 -> 274.8 tok/s (+7.0%), reproduced twice
-  six-task labd total      99.9 -> 99.2-101.4 (flat)
-  C1 chat greedy           137.6/137.9 -> 135.3 (within spread)
-  C1 chat T=default        129.7/126.6 -> 117.6 UNGATED (-8%); with the
-                           greedy-only gate chains never engage there and
-                           the cell reads 123.5, inside the sampling band
-  engage rate              ~6% of steps on the mixed suite
-  correctness              bench/verbatim.py all shapes; tool-calling round
-                           trip; scheduler sees a legal q every step
-
-Why the temperature gate: a point-mass q accepts with probability p(token),
-so under sampling the chain's context copy displaces the drafter's
-distribution-aware proposals on exactly the steps it wins under greedy.
-Greedy requests keep the whole win; sampled requests keep the drafter.
-
-Off-state: pool byte-identical (68,605 tokens), bench within run-to-run
-spread of the pre-port baseline.
-
---- generated hunks below ---
 --- a/v1/worker/gpu/spec_decode/dflash2/speculator.py
 +++ b/v1/worker/gpu/spec_decode/dflash2/speculator.py
 @@ -2,6 +2,7 @@
@@ -73,9 +15,9 @@ spread of the pre-port baseline.
  
  import torch
 @@ -11,7 +12,10 @@
- from vllm.config.compilation import CUDAGraphMode
- from vllm.triton_utils import tl, tldevice, triton
- from vllm.v1.worker.gpu.sample.gumbel import tl_rand32, tl_rand64
+ from vllm.logger import init_logger
+ from vllm.triton_utils import tl, triton
+ from vllm.v1.worker.gpu.sample.gumbel import gumbel_noised_argmax
 -from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
 +from vllm.v1.worker.gpu.spec_decode.dflash.speculator import (
 +    DFlashSpeculator,
@@ -84,10 +26,11 @@ spread of the pre-port baseline.
  
  logger = init_logger(__name__)
  from vllm.v1.worker.gpu.spec_decode.dflash2.lookup import (
-@@ -277,6 +281,54 @@
+@@ -254,6 +258,54 @@
+         # an otherwise identical 4-way batch, and reproducibly did not with STICKY=0.
          self._lookup_sticky = int(os.environ.get("VLLM_DFLASH2_LOOKUP_STICKY", "3"))
          self._sticky = 0
- 
++
 +        # --- drafter-free chains (VLLM_DFLASH2_CHAIN=1), ported from
 +        # Dmtrii-tesla/dflash2-ngram-vllm (#38) -------------------------------
 +        # While a request keeps reproducing its own context, whole verify
@@ -135,11 +78,10 @@ spread of the pre-port baseline.
 +            self._chain_steps_engaged = 0
 +            self._chain_last_log = time.monotonic()
 +            logger.info("DFlash2 chains on (minmatch=%d)", self._chain_minmatch)
-+
+ 
          if self._lookup:
              logger.info(
-                 "DFlash2 lookup-augmented drafting on (k=%d nmin=%d nmax=%d nstrong=%d "
-@@ -299,6 +351,11 @@
+@@ -277,6 +329,11 @@
          unanimity across the batch. Below CHEAP_CTX tokens of context an extra verify
          position is nearly free (+6% per step at 1.5k against +27% at 25k), so there the
          flag alone is enough."""
@@ -151,10 +93,11 @@ spread of the pre-port baseline.
          if not self._adaptive:
              return None
          emitted = getattr(self, "last_num_emitted", None)
-@@ -336,6 +393,249 @@
+@@ -313,7 +370,252 @@
+             long_block, self._sticky = False, 0
          self._prev_want = want
          return self.num_speculative_steps if long_block else self.draft_block
- 
++
 +    def propose(
 +        self,
 +        input_batch,
@@ -251,7 +194,7 @@ spread of the pre-port baseline.
 +            mm_inputs=mm_inputs,
 +            is_profile=is_profile,
 +        )
-+
+ 
 +    def _chain_should_engage(self, prev_missed: bool) -> bool:
 +        """Host-side chain state machine. Entry: the last NORMAL step's longest
 +        match reached minmatch (read from pinned memory; one step stale like
@@ -379,7 +322,9 @@ spread of the pre-port baseline.
 +        self._lookup_use[:num_reqs].fill_(1)
 +        self.draft_tokens[:num_reqs].copy_(tokens)
 +        draft_logits = self.draft_logits
-+        assert draft_logits is not None
++        if draft_logits is None:
++            # Greedy rejection sampling does not consume a proposal distribution.
++            return self.draft_tokens[:num_reqs]
 +        block_k = triton.next_power_of_2(self.selector_top_k)
 +        _point_mass_draft_logits_kernel[(num_reqs * k,)](
 +            draft_logits,
@@ -401,7 +346,7 @@ spread of the pre-port baseline.
      def set_req_states(self, req_states) -> None:
          """The token history the lookup matches against (set by the model runner)."""
          self._req_states = req_states
-@@ -343,6 +643,10 @@
+@@ -326,6 +628,10 @@
      def set_sampling_states(self, sampling_states) -> None:
          self._req_top_p = sampling_states.top_p.gpu
          self._req_top_k = sampling_states.top_k.gpu
@@ -412,7 +357,7 @@ spread of the pre-port baseline.
  
      def _sample_path(
          self,
-@@ -490,3 +794,16 @@
+@@ -479,3 +785,16 @@
              BLOCK_K=block_k,
              num_warps=1,
          )

--- a/patches/dflash2-ngram-chains.patch
+++ b/patches/dflash2-ngram-chains.patch
@@ -93,7 +93,7 @@ The native 0.28 DFlash2 runner is extended by the lookup patch first; this patch
          if not self._adaptive:
              return None
          emitted = getattr(self, "last_num_emitted", None)
-@@ -313,7 +370,252 @@
+@@ -313,7 +370,253 @@
              long_block, self._sticky = False, 0
          self._prev_want = want
          return self.num_speculative_steps if long_block else self.draft_block

--- a/patches/dflash2-ngram-chains.patch
+++ b/patches/dflash2-ngram-chains.patch
@@ -93,7 +93,7 @@ The native 0.28 DFlash2 runner is extended by the lookup patch first; this patch
          if not self._adaptive:
              return None
          emitted = getattr(self, "last_num_emitted", None)
-@@ -313,7 +370,253 @@
+@@ -313,7 +370,252 @@
              long_block, self._sticky = False, 0
          self._prev_want = want
          return self.num_speculative_steps if long_block else self.draft_block
@@ -243,11 +243,8 @@ The native 0.28 DFlash2 runner is extended by the lookup patch first; this patch
 +        self.draft_max_seq_len = min(
 +            max_seq_len + self.num_query_per_req, self.max_model_len
 +        )
-+        # vLLM's rejection sampler returns num_sampled as the accepted/emitted
-+        # token count; num_rejected is only discarded verify positions.
-+        # Keep the accepted count for adaptive verify-length scheduling.
 +        self.last_num_emitted = (
-+            num_sampled if num_sampled is not None else None
++            (num_sampled - num_rejected) if num_sampled is not None else None
 +        )
 +
 +        if aux_hidden_states:

--- a/patches/dflash2-ngram-chains.patch
+++ b/patches/dflash2-ngram-chains.patch
@@ -1,9 +1,5 @@
-Drafter-free n-gram chains for DFlash2 (VLLM_DFLASH2_CHAIN=1, default off), ported to vLLM 0.28.0.
-
-The native 0.28 DFlash2 runner is extended by the lookup patch first; this patch then adds the host-side chain state machine and eager context-only proposal path.
-
---- generated against the v0.28.0 lookup tree ---
-
+diff --git a/v1/worker/gpu/spec_decode/dflash2/speculator.py b/v1/worker/gpu/spec_decode/dflash2/speculator.py
+index 9d299de5a..1371aab30 100644
 --- a/v1/worker/gpu/spec_decode/dflash2/speculator.py
 +++ b/v1/worker/gpu/spec_decode/dflash2/speculator.py
 @@ -2,6 +2,7 @@
@@ -14,7 +10,7 @@ The native 0.28 DFlash2 runner is extended by the lookup patch first; this patch
  from typing import Any
  
  import torch
-@@ -11,7 +12,10 @@
+@@ -11,7 +12,10 @@ from vllm.config import VllmConfig
  from vllm.logger import init_logger
  from vllm.triton_utils import tl, triton
  from vllm.v1.worker.gpu.sample.gumbel import gumbel_noised_argmax
@@ -26,11 +22,10 @@ The native 0.28 DFlash2 runner is extended by the lookup patch first; this patch
  
  logger = init_logger(__name__)
  from vllm.v1.worker.gpu.spec_decode.dflash2.lookup import (
-@@ -254,6 +258,54 @@
-         # an otherwise identical 4-way batch, and reproducibly did not with STICKY=0.
+@@ -255,6 +259,54 @@ class DFlash2Speculator(DFlashSpeculator):
          self._lookup_sticky = int(os.environ.get("VLLM_DFLASH2_LOOKUP_STICKY", "3"))
          self._sticky = 0
-+
+ 
 +        # --- drafter-free chains (VLLM_DFLASH2_CHAIN=1), ported from
 +        # Dmtrii-tesla/dflash2-ngram-vllm (#38) -------------------------------
 +        # While a request keeps reproducing its own context, whole verify
@@ -78,10 +73,11 @@ The native 0.28 DFlash2 runner is extended by the lookup patch first; this patch
 +            self._chain_steps_engaged = 0
 +            self._chain_last_log = time.monotonic()
 +            logger.info("DFlash2 chains on (minmatch=%d)", self._chain_minmatch)
- 
++
          if self._lookup:
              logger.info(
-@@ -277,6 +329,11 @@
+                 "DFlash2 lookup-augmented drafting on (k=%d nmin=%d nmax=%d nstrong=%d "
+@@ -277,6 +329,11 @@ class DFlash2Speculator(DFlashSpeculator):
          unanimity across the batch. Below CHEAP_CTX tokens of context an extra verify
          position is nearly free (+6% per step at 1.5k against +27% at 25k), so there the
          flag alone is enough."""
@@ -93,11 +89,10 @@ The native 0.28 DFlash2 runner is extended by the lookup patch first; this patch
          if not self._adaptive:
              return None
          emitted = getattr(self, "last_num_emitted", None)
-@@ -313,7 +370,252 @@
-             long_block, self._sticky = False, 0
+@@ -314,6 +371,251 @@ class DFlash2Speculator(DFlashSpeculator):
          self._prev_want = want
          return self.num_speculative_steps if long_block else self.draft_block
-+
+ 
 +    def propose(
 +        self,
 +        input_batch,
@@ -194,7 +189,7 @@ The native 0.28 DFlash2 runner is extended by the lookup patch first; this patch
 +            mm_inputs=mm_inputs,
 +            is_profile=is_profile,
 +        )
- 
++
 +    def _chain_should_engage(self, prev_missed: bool) -> bool:
 +        """Host-side chain state machine. Entry: the last NORMAL step's longest
 +        match reached minmatch (read from pinned memory; one step stale like
@@ -346,7 +341,7 @@ The native 0.28 DFlash2 runner is extended by the lookup patch first; this patch
      def set_req_states(self, req_states) -> None:
          """The token history the lookup matches against (set by the model runner)."""
          self._req_states = req_states
-@@ -326,6 +628,10 @@
+@@ -326,6 +628,10 @@ class DFlash2Speculator(DFlashSpeculator):
      def set_sampling_states(self, sampling_states) -> None:
          self._req_top_p = sampling_states.top_p.gpu
          self._req_top_k = sampling_states.top_k.gpu
@@ -357,7 +352,7 @@ The native 0.28 DFlash2 runner is extended by the lookup patch first; this patch
  
      def _sample_path(
          self,
-@@ -479,3 +785,16 @@
+@@ -479,3 +785,16 @@ class DFlash2Speculator(DFlashSpeculator):
              BLOCK_K=block_k,
              num_warps=1,
          )

--- a/patches/dflash2-prewarm.patch
+++ b/patches/dflash2-prewarm.patch
@@ -1,29 +1,8 @@
-DFlash2: pre-compile every _prepare_dflash_inputs_kernel variant at boot (#48).
-
-The kernel's Triton variant ladder is BLOCK_SIZE = min(256, next_pow2(
-max_target_query_len + num_query_per_req)). Decode steps only ever produce the
-small variants -- the capture-phase dummy runs are decode-shaped -- so the
-FIRST large chunked-prefill CONTINUATION after a fresh boot is the first time
-BLOCK_SIZE=256 exists, and it JIT-compiled mid-request: the jit_monitor
-warning issue #48 captured seconds before every wedge on that WSL2 box, and a
-multi-hundred-ms latency spike everywhere else.
-
-The wrapper now compiles every reachable variant the first time through
-(during the capture dummies, before serving): one grid row per missing
-BLOCK_SIZE against the same buffers as the real launch that follows, which
-then overwrites everything the warm rows wrote. Cost: ~4 extra compiles at
-boot, nothing at serving time. Keyed per (device, query layout), so the
-DFLASH_TOKENS=15 dual-length deployments warm both layouts as each appears.
-
-Verified on the reference 3090: fresh boot, SPEC=dflash2 CTX=huge, one ~30k
-first request -- _prepare_dflash_inputs_kernel no longer appears in
-jit_monitor at all (it did on every boot before).
-
-Apply with the patches/ set (alphabetical: after the dflash2 trio).
-
+diff --git a/v1/worker/gpu/spec_decode/dflash/speculator.py b/v1/worker/gpu/spec_decode/dflash/speculator.py
+index 4ad1b10ba..1bd78be21 100644
 --- a/v1/worker/gpu/spec_decode/dflash/speculator.py
 +++ b/v1/worker/gpu/spec_decode/dflash/speculator.py
-@@ -684,6 +684,9 @@
+@@ -689,6 +689,9 @@ def _prepare_dflash_inputs_kernel(
                  tl.store(out_query_slot_mapping_ptr + block, PAD_SLOT_ID, mask=mask)
  
  
@@ -33,7 +12,7 @@ Apply with the patches/ set (alphabetical: after the dflash2 trio).
  def prepare_dflash_inputs(
      input_buffers: InputBuffers,
      query_slot_mapping: torch.Tensor,
-@@ -726,38 +729,59 @@
+@@ -731,38 +734,59 @@ def prepare_dflash_inputs(
      max_tokens_per_req = max_target_query_len + num_query_per_req
      BLOCK_SIZE = min(256, triton.next_power_of_2(max(1, max_tokens_per_req)))
      num_blocks = triton.cdiv(max_tokens_per_req, BLOCK_SIZE)
@@ -128,3 +107,777 @@ Apply with the patches/ set (alphabetical: after the dflash2 trio).
 +            PAD_SLOT_ID=PAD_SLOT_ID,
 +            BLOCK_SIZE=_bs,
 +        )
+diff --git a/v1/worker/gpu/spec_decode/dflash/speculator.py.orig b/v1/worker/gpu/spec_decode/dflash/speculator.py.orig
+new file mode 100644
+index 000000000..4ad1b10ba
+--- /dev/null
++++ b/v1/worker/gpu/spec_decode/dflash/speculator.py.orig
+@@ -0,0 +1,768 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++import os
++from collections.abc import Mapping
++from typing import Any
++
++import numpy as np
++import torch
++import torch.nn as nn
++
++from vllm.config import VllmConfig, replace
++from vllm.config.compilation import CUDAGraphMode
++from vllm.forward_context import BatchDescriptor, set_forward_context
++from vllm.logger import init_logger
++from vllm.triton_utils import tl, triton
++from vllm.v1.attention.backend import AttentionCGSupport
++from vllm.v1.attention.backends.utils import PAD_SLOT_ID
++from vllm.v1.kv_cache_interface import KVCacheConfig
++from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
++from vllm.v1.worker.gpu.block_table import BlockTables
++from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
++from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
++from vllm.v1.worker.gpu.model_states.interface import ModelState
++from vllm.v1.worker.gpu.spec_decode.dflash.cudagraph import DFlashCudaGraphManager
++from vllm.v1.worker.gpu.spec_decode.dflash.utils import load_dflash_model
++from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
++from vllm.v1.worker.gpu.spec_decode.utils import get_parallel_drafting_token_id
++from vllm.v1.worker.utils import AttentionGroup
++
++logger = init_logger(__name__)
++
++
++class DFlashSpeculator(DraftModelSpeculator):
++    _speculator_name = "DFlash"  # For logging, so we can share methods with subclasses
++
++    def __init__(self, vllm_config: VllmConfig, device: torch.device):
++        super().__init__(vllm_config, device)
++
++        self.hidden_states = torch.zeros(
++            self.max_num_tokens, self.hidden_size, dtype=self.dtype, device=device
++        )
++
++        # Multimodal inputs not currently supported.
++        self.supports_mm_inputs = False
++
++        # The drafter emits the block it was trained for (dflash_config.block_size - 1);
++        # the *verify* block may be longer than that, with the extra positions filled from
++        # the request's own context (dflash2/lookup.py). Everything describing the draft
++        # model's own query layout uses draft_block, everything describing the proposal
++        # handed to the target uses num_speculative_steps.
++        trained_block = (
++            int(
++                (getattr(self.draft_model_config.hf_config, "dflash_config", None) or {}).get(
++                    "block_size", 0
++                )
++            )
++            - 1
++        )
++        self.draft_block = self.num_speculative_steps
++        # Only the lookup can fill the extra positions, so without it the drafter keeps
++        # being asked for the whole (longer) block, which is also the honest A/B control.
++        lookup_on = os.environ.get("VLLM_DFLASH2_LOOKUP", "0") == "1"
++        if lookup_on and 0 < trained_block < self.num_speculative_steps:
++            self.draft_block = trained_block
++            logger.info(
++                "%s: drafting %d tokens per step (the block the checkpoint was trained "
++                "for); the remaining %d of %d verify positions are filled from context.",
++                self._speculator_name,
++                self.draft_block,
++                self.num_speculative_steps - self.draft_block,
++                self.num_speculative_steps,
++            )
++
++        # Each request emits exactly (bonus + N mask) query tokens per step.
++        self.num_query_per_req = 1 + self.draft_block
++
++        self.parallel_drafting_token_id = get_parallel_drafting_token_id(
++            self.draft_model_config.hf_config
++        )
++
++        from vllm.model_executor.models.qwen3_dflash import dflash_has_any_non_causal
++
++        self.requires_non_causal = dflash_has_any_non_causal(
++            self.draft_model_config.hf_config
++        )
++
++        # Whether the anchor query position is itself a prediction. DFlash default uses
++        # the anchor as the bonus token (only mask tokens predict); DSpark samples from
++        # the anchor and the N-1 mask token positions. See _prepare_dflash_inputs_kernel
++        dflash_config = (
++            getattr(self.draft_model_config.hf_config, "dflash_config", None) or {}
++        )
++        if dflash_config.get("sample_from_anchor", False):
++            raise ValueError(
++                "sample_from_anchor=True is not supported for DFlash. "
++                "DFlash uses a fixed 1+N query layout where the anchor "
++                "is the bonus token."
++            )
++        self.sample_from_anchor = False
++
++        # Context positions for the K/V precompute. Populated by
++        # prepare_dflash_inputs, and processed by the model's
++        # precompute_and_store_context_kv method. NOT captured by CUDA graphs.
++        self.context_positions = torch.zeros(
++            self.max_num_tokens, dtype=torch.int64, device=device
++        )
++
++        # Per-mask-token sampling buffers. Flattened from (num_reqs, num_spec_tokens).
++        max_num_sampled_tokens = self.max_num_reqs * self.draft_block
++        self.sample_indices = torch.zeros(
++            max_num_sampled_tokens, dtype=torch.int64, device=device
++        )
++        self.sample_pos = torch.zeros(
++            max_num_sampled_tokens, dtype=torch.int64, device=device
++        )
++        # -1 marks an inert sampling row. CUDA graph capture can execute the
++        # full buffer before a real batch has populated it, so zero would make
++        # every padding row scatter into request slot 0.
++        self.sample_idx_mapping = torch.full(
++            (max_num_sampled_tokens,), -1, dtype=torch.int32, device=device
++        )
++        # [0, 1, ..., N-1, 0, 1, ..., N-1, ...] -> the per-token column index into
++        # draft_logits[req, step, :].
++        self.sample_col = torch.arange(
++            self.draft_block, dtype=torch.int32, device=device
++        ).repeat(self.max_num_reqs)
++
++        self.query_cudagraph_manager: DFlashCudaGraphManager | None = None
++        self.draft_kv_cache_group_id: int = -1
++
++    @property
++    def attn_vllm_config(self) -> VllmConfig:
++        # The draft's attention differs from the target's in causality.
++        return replace(
++            self.vllm_config,
++            attention_config=replace(
++                self.vllm_config.attention_config,
++                use_non_causal=self.requires_non_causal,
++            ),
++        )
++
++    def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
++        wants_full = cudagraph_mode.decode_mode() == CUDAGraphMode.FULL
++        supports_full = (
++            self.attn_cg_support.min_cg_support.value
++            >= AttentionCGSupport.UNIFORM_BATCH.value
++        )
++        if wants_full and not supports_full:
++            logger.warning(
++                "%s draft attention (%s) does not support full CUDA graphs; "
++                "running the draft eagerly.",
++                self._speculator_name,
++                self.attn_cg_support.min_cg_attn_backend,
++            )
++        # PIECEWISE cudagraphs are not supported for dflash.
++        if wants_full and supports_full:
++            cudagraph_mode = CUDAGraphMode.FULL_DECODE_ONLY
++        else:
++            cudagraph_mode = CUDAGraphMode.NONE
++
++        self.query_cudagraph_manager = DFlashCudaGraphManager(
++            self.vllm_config,
++            self.device,
++            cudagraph_mode,
++            decode_query_len=self.num_query_per_req,
++        )
++
++    def capture(self) -> None:
++        logger.info("Capturing model for %s speculator...", self._speculator_name)
++        # Padded sample rows must not scatter into a live request during capture.
++        self.sample_indices.zero_()
++        self.sample_pos.zero_()
++        self.sample_idx_mapping.fill_(-1)
++        assert self.query_cudagraph_manager is not None
++        self.query_cudagraph_manager.capture(
++            self._generate_draft,
++            self.input_buffers,
++            self.block_tables,
++            self.attn_groups,
++            self.kv_cache_config,
++            self.max_model_len,
++            causal=self._group_causal,
++            progress_bar_desc=f"Capturing {self._speculator_name.lower()} CUDA graphs",
++        )
++
++    def load_draft_model(
++        self,
++        target_model: nn.Module,
++        target_attn_layer_names: set[str],
++    ) -> nn.Module:
++        return load_dflash_model(target_model, self.vllm_config)
++
++    def set_attn(
++        self,
++        model_state: ModelState,
++        kv_cache_config: KVCacheConfig,
++        block_tables: BlockTables,
++        target_input_buffers: InputBuffers,
++        target_attn_groups: list[list[AttentionGroup]],
++    ) -> None:
++        super().set_attn(
++            model_state,
++            kv_cache_config,
++            block_tables,
++            target_input_buffers,
++            target_attn_groups,
++        )
++
++        self.draft_kv_cache_group_ids = [
++            gid for gid, g in enumerate(self.attn_groups) if g
++        ]
++        assert self.draft_kv_cache_group_ids, "No draft attention groups found."
++        self.draft_kv_cache_group_id = self.draft_kv_cache_group_ids[0]
++
++        # Per-group context slot buffers for the precompute (one row per group).
++        self._context_slot_mappings = torch.zeros(
++            len(self.draft_kv_cache_group_ids),
++            self.max_num_tokens,
++            dtype=torch.int64,
++            device=self.device,
++        )
++
++        # Map each draft decoder layer to the index (within draft_kv_cache_group_ids)
++        # of the kv-cache group its cache belongs to. Models that share a single group
++        # leave this as None and share one context slot mapping.
++        self._layer_group_idx: list[int] | None = None
++        # Per-KV-group causal, falling back to whether the drafter is all-causal.
++        self._group_causal: dict[int, bool] | bool = not self.requires_non_causal
++        if hasattr(self.model, "get_draft_kv_cache_layer_names"):
++            layer_names = self.model.get_draft_kv_cache_layer_names()
++            name_to_gid = {
++                ln: gid
++                for gid, group in enumerate(kv_cache_config.kv_cache_groups)
++                for ln in group.layer_names
++            }
++            gid_to_idx = {gid: i for i, gid in enumerate(self.draft_kv_cache_group_ids)}
++            self._layer_group_idx = [
++                gid_to_idx[name_to_gid[name]] for name in layer_names
++            ]
++            if hasattr(self.model, "get_draft_attn_causal"):
++                self._group_causal = {
++                    name_to_gid[name]: layer_causal
++                    for name, layer_causal in zip(
++                        layer_names, self.model.get_draft_attn_causal()
++                    )
++                }
++
++    @torch.inference_mode()
++    def _run_model(
++        self,
++        num_tokens: int,
++        attn_metadata: dict[str, Any] | None,
++        slot_mappings: dict[str, torch.Tensor] | None,
++        num_tokens_across_dp: torch.Tensor | None,
++        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
++    ) -> torch.Tensor:
++        batch_descriptor = BatchDescriptor(num_tokens=num_tokens)
++        with set_forward_context(
++            attn_metadata,
++            self.vllm_config,
++            num_tokens=num_tokens,
++            cudagraph_runtime_mode=cudagraph_runtime_mode,
++            num_tokens_across_dp=num_tokens_across_dp,
++            slot_mapping=slot_mappings,
++            batch_descriptor=batch_descriptor,
++        ):
++            last_hidden_states = self.model(
++                input_ids=self.input_buffers.input_ids[:num_tokens],
++                positions=self.input_buffers.positions[:num_tokens],
++                inputs_embeds=None,
++            )
++        return last_hidden_states
++
++    def _generate_draft(
++        self,
++        num_reqs: int,
++        num_tokens_padded: int,
++        attn_metadata: dict[str, Any] | None,
++        slot_mappings: dict[str, torch.Tensor] | None,
++        num_tokens_across_dp: torch.Tensor | None,
++        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
++    ) -> None:
++        last_hidden_states = self._run_model(
++            num_tokens_padded,
++            attn_metadata,
++            slot_mappings,
++            num_tokens_across_dp,
++            cudagraph_runtime_mode,
++        )
++        num_sample = num_reqs * self.draft_block
++        sample_hidden_states = last_hidden_states[self.sample_indices[:num_sample]]
++        # sample_pos is the predicted token's position Q; verification keys
++        # Gumbel by the predecessor (Q-1). sample_draft adds +1, so pass Q-2.
++        draft_tokens = self.sample_draft(
++            sample_hidden_states,
++            self.sample_pos[:num_sample] - 2,
++            self.sample_idx_mapping[:num_sample],
++            self.temperature,
++            self.seeds,
++            self.sample_col[:num_sample],
++            self.draft_logits,
++        )
++        self.draft_tokens[:num_reqs, : self.draft_block] = draft_tokens.view(
++            num_reqs, self.draft_block
++        )
++
++    def _build_draft_attn_metadata(
++        self,
++        num_reqs: int,
++        num_reqs_padded: int,
++        num_tokens_padded: int,
++        seq_lens_cpu_upper_bound: torch.Tensor,
++        step: int,
++        num_query_per_req: int | None = None,
++        causal: bool | Mapping[int, bool] = False,
++        query_start_loc_np: np.ndarray | None = None,
++    ) -> dict[str, Any] | None:
++        if not self.draft_attn_layer_names:
++            return None
++        assert num_query_per_req is None  # Omitted for DFlash, read from self instead
++        return super()._build_draft_attn_metadata(
++            num_reqs,
++            num_reqs_padded,
++            num_tokens_padded,
++            seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
++            step=step,
++            num_query_per_req=self.num_query_per_req,
++            causal=causal,
++            query_start_loc_np=query_start_loc_np,
++        )
++
++    @torch.inference_mode()
++    def propose(
++        self,
++        input_batch: InputBatch,
++        attn_metadata: dict[str, Any],
++        slot_mappings: dict[str, torch.Tensor],
++        # [num_tokens, hidden_size]
++        last_hidden_states: torch.Tensor,
++        # num_layers x [num_tokens, hidden_size]
++        aux_hidden_states: list[torch.Tensor] | None,
++        # [num_reqs]
++        num_sampled: torch.Tensor,
++        # [num_reqs]
++        num_rejected: torch.Tensor,
++        # [max_num_reqs]
++        last_sampled: torch.Tensor,
++        # [max_num_reqs]
++        next_prefill_tokens: torch.Tensor,
++        # [max_num_reqs]
++        temperature: torch.Tensor,
++        # [max_num_reqs]
++        seeds: torch.Tensor,
++        num_tokens_across_dp: torch.Tensor | None = None,
++        dummy_run: bool = False,
++        skip_attn_for_dummy_run: bool = False,
++        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
++        is_profile: bool = False,
++    ) -> torch.Tensor:
++        num_reqs = input_batch.num_reqs
++        # What the step that just ran actually produced per request: num_sampled counts the
++        # sampling slots it was given (bonus + drafts), num_rejected how many of those were
++        # thrown away, so the difference is the tokens it emitted. dflash2/lookup.py decides
++        # the next block length from it.
++        self.last_num_emitted = (num_sampled - num_rejected) if num_sampled is not None else None
++        num_target_tokens = input_batch.num_tokens
++        num_query_tokens = num_reqs * self.num_query_per_req
++        max_seq_len = input_batch.seq_lens_cpu_upper_bound[:num_reqs].max().item()
++        self.draft_max_seq_len = min(
++            max_seq_len + self.num_query_per_req, self.max_model_len
++        )
++
++        # NOTE: To avoid CPU-GPU synchronization without CPU knowing the
++        # number of rejected tokens, we maintain the size of input_ids and
++        # hidden_states the same as the target model's. This means, we pad each
++        # request's query length to include any rejected positions.
++        if aux_hidden_states:
++            hidden_states = self.model.combine_hidden_states(
++                torch.cat(aux_hidden_states, dim=-1)
++            )
++        else:
++            hidden_states = last_hidden_states
++        self.hidden_states[:num_target_tokens].copy_(hidden_states[:num_target_tokens])
++
++        if dummy_run and skip_attn_for_dummy_run:
++            # Memory profiling path: block_tables / kv_cache_config are not initialized.
++            # Since DFlash needs to build its own attention metadata, we must skip the
++            # preparation in this path and run a minimal forward pass.
++            self.model.precompute_and_store_context_kv(
++                self.hidden_states[:num_target_tokens],
++                self.context_positions[:num_target_tokens],
++            )
++            # DFlash processes all speculative tokens in one forward pass,
++            # so the real token count is num_query_tokens.
++            self._prepare_eplb_forward(num_query_tokens)
++            self._generate_draft(
++                num_reqs,
++                num_query_tokens,
++                attn_metadata=None,
++                slot_mappings=None,
++                num_tokens_across_dp=num_tokens_across_dp,
++                cudagraph_runtime_mode=CUDAGraphMode.NONE,
++            )
++            return self.draft_tokens[:num_reqs]
++
++        # The query slot mapping is written into the shared BlockTables slot_mappings.
++        # That buffer's address is what the captured CUDA graph reads from at replay.
++        assert self.draft_kv_cache_group_id >= 0
++        # Support multiple draft KV cache groups by preparing inputs once for each
++        for i, gid in enumerate(self.draft_kv_cache_group_ids):
++            prepare_dflash_inputs(
++                self.input_buffers,
++                self.block_tables.slot_mappings[gid],
++                self.context_positions,
++                self._context_slot_mappings[i],
++                self.sample_indices,
++                self.sample_pos,
++                self.sample_idx_mapping,
++                self.temperature,
++                self.seeds,
++                input_batch,
++                num_sampled,
++                num_rejected,
++                last_sampled,
++                next_prefill_tokens,
++                temperature,
++                seeds,
++                self.block_tables.input_block_tables[gid],
++                self.block_tables.kernel_block_sizes[gid],
++                self.parallel_drafting_token_id,
++                self.num_query_per_req,
++                self.draft_block,
++                self.max_num_reqs,
++                self.max_num_tokens,
++                self.max_model_len,
++                self.sample_from_anchor,
++            )
++
++        # Pre-insert context K/V into the cache. Runs eagerly outside the captured graph
++        # because the context shape varies per step. During dummy runs the block tables
++        # are placeholders, so we skip the cache write to avoid clobbering real entries.
++        # Each layer uses the context slots of its own kv-cache group.
++        if dummy_run:
++            context_slots: torch.Tensor | list[torch.Tensor | None] | None = None
++        elif self._layer_group_idx is not None:
++            context_slots = [
++                self._context_slot_mappings[gidx][:num_target_tokens]
++                for gidx in self._layer_group_idx
++            ]
++        else:
++            context_slots = self._context_slot_mappings[0][:num_target_tokens]
++        self.model.precompute_and_store_context_kv(
++            self.hidden_states[:num_target_tokens],
++            self.context_positions[:num_target_tokens],
++            context_slots,
++        )
++
++        # Every DFlash step has exactly num_query_per_req tokens, so we can use FULL CGs
++        batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
++            self.query_cudagraph_manager,
++            num_reqs,
++            num_query_tokens,
++            uniform_token_count=self.num_query_per_req,
++            dp_size=self.dp_size,
++            dp_rank=self.dp_rank,
++            need_eager=is_profile,
++        )
++
++        num_reqs_padded = batch_desc.num_reqs or num_reqs
++        num_tokens_padded = batch_desc.num_tokens
++
++        # Rebuild the draft attention metadata even when replaying the FULL
++        # graph so that any attention metadata builder state is updated.
++        draft_attn_metadata = self._build_draft_attn_metadata(
++            num_reqs=num_reqs,
++            num_reqs_padded=num_reqs_padded,
++            num_tokens_padded=num_tokens_padded,
++            seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
++            step=self.num_query_per_req,
++            causal=self._group_causal,
++        )
++        draft_slot_mappings_by_layer = build_slot_mappings_by_layer(
++            self.block_tables.slot_mappings[:, :num_tokens_padded],
++            self.kv_cache_config,
++        )
++
++        # DFlash processes all speculative tokens in one forward pass,
++        # so the real token count is num_query_tokens.
++        self._prepare_eplb_forward(num_query_tokens)
++
++        if batch_desc.cg_mode == CUDAGraphMode.FULL:
++            assert self.query_cudagraph_manager is not None
++            self.query_cudagraph_manager.run_fullgraph(batch_desc)
++        else:
++            self._generate_draft(
++                num_reqs,
++                num_tokens_padded,
++                draft_attn_metadata,
++                draft_slot_mappings_by_layer,
++                num_tokens_across_dp=num_tokens_across_dp,
++                cudagraph_runtime_mode=batch_desc.cg_mode,
++            )
++
++        return self.draft_tokens[:num_reqs]
++
++
++@triton.jit
++def _prepare_dflash_inputs_kernel(
++    # Outputs
++    out_input_ids_ptr,
++    out_query_positions_ptr,
++    out_query_start_loc_ptr,
++    out_seq_lens_ptr,
++    out_query_slot_mapping_ptr,
++    out_context_positions_ptr,
++    out_context_slot_mapping_ptr,
++    out_sample_indices_ptr,
++    out_sample_pos_ptr,
++    out_sample_idx_mapping_ptr,
++    out_temperature_ptr,
++    out_seeds_ptr,
++    # Inputs from target batch
++    target_positions_ptr,
++    target_query_start_loc_ptr,
++    idx_mapping_ptr,
++    last_sampled_ptr,
++    next_prefill_tokens_ptr,
++    num_sampled_ptr,
++    num_rejected_ptr,
++    # Sampling params
++    temperature_ptr,
++    seeds_ptr,
++    # Block table for slot mapping lookup.
++    block_table_ptr,
++    block_table_stride,
++    # Scalars
++    parallel_drafting_token_id,
++    block_size,
++    num_query_per_req,
++    num_speculative_steps,
++    max_num_reqs,
++    max_num_tokens,
++    max_model_len,
++    SAMPLE_FROM_ANCHOR: tl.constexpr,
++    PAD_SLOT_ID: tl.constexpr,
++    BLOCK_SIZE: tl.constexpr,
++):
++    req_idx = tl.program_id(0)
++    block_idx = tl.program_id(1)
++    num_reqs = tl.num_programs(0)
++    req_state_idx = tl.load(idx_mapping_ptr + req_idx)
++
++    ctx_start = tl.load(target_query_start_loc_ptr + req_idx)
++    ctx_end = tl.load(target_query_start_loc_ptr + req_idx + 1)
++    num_ctx = ctx_end - ctx_start
++
++    num_rejected = tl.load(num_rejected_ptr + req_idx)
++    valid_ctx_end = ctx_end - num_rejected
++    num_valid_ctx = valid_ctx_end - ctx_start
++
++    num_sampled = tl.load(num_sampled_ptr + req_idx)
++    if num_sampled > 0:
++        bonus_token = tl.load(last_sampled_ptr + req_state_idx).to(tl.int32)
++    else:
++        # Chunked prefilling: splice in the next prefill token.
++        bonus_token = tl.load(next_prefill_tokens_ptr + req_state_idx).to(tl.int32)
++
++    last_valid_pos = tl.load(target_positions_ptr + valid_ctx_end - 1)
++    query_base = req_idx * num_query_per_req
++
++    j = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
++    is_ctx = j < num_ctx
++    is_valid_ctx = j < num_valid_ctx
++    is_query = (j >= num_valid_ctx) & (j < num_valid_ctx + num_query_per_req)
++    query_off = j - num_valid_ctx
++
++    # --- Context positions / slots ---
++    ctx_pos_idx = ctx_start + tl.where(is_ctx, j, 0)
++    ctx_pos = tl.load(target_positions_ptr + ctx_pos_idx, mask=is_valid_ctx, other=0)
++    ctx_block_num = ctx_pos // block_size
++    ctx_block_num = tl.minimum(ctx_block_num, block_table_stride - 1)
++    ctx_block_id = tl.load(
++        block_table_ptr + req_idx * block_table_stride + ctx_block_num,
++        mask=is_valid_ctx,
++        other=0,
++    ).to(tl.int64)
++    # Block 0 is the null block. Old sliding-window context positions can map
++    # to it after eviction; rejected suffix rows are invalid context as well.
++    # Neither kind of row may write draft KV into physical block 0.
++    ctx_resident = is_valid_ctx & (ctx_block_id != 0)
++    ctx_slot = tl.where(
++        ctx_resident,
++        ctx_block_id * block_size + (ctx_pos % block_size),
++        PAD_SLOT_ID,
++    )
++    # Stored over the full [0, num_ctx) span while the loads above are masked to
++    # [0, num_valid_ctx): the rejected suffix rows in between get position 0 and
++    # PAD_SLOT_ID. That is intentional — those rows write no KV and their
++    # positions are never consumed, but the span must stay fully initialized so
++    # a replayed graph cannot observe a stale value from an earlier batch.
++    tl.store(out_context_positions_ptr + ctx_start + j, ctx_pos, mask=is_ctx)
++    tl.store(out_context_slot_mapping_ptr + ctx_start + j, ctx_slot, mask=is_ctx)
++
++    # --- Query positions / input_ids / slots ---
++    query_pos = last_valid_pos + 1 + query_off
++    query_idx = query_base + query_off
++    is_bonus = is_query & (query_off == 0)
++    input_id = tl.where(is_bonus, bonus_token, parallel_drafting_token_id)
++
++    q_block_num = query_pos // block_size
++    q_block_num = tl.minimum(q_block_num, block_table_stride - 1)
++    q_block_id = tl.load(
++        block_table_ptr + req_idx * block_table_stride + q_block_num,
++        mask=is_query,
++        other=0,
++    ).to(tl.int64)
++    # A null block is never a writable cache slot. This can occur when a
++    # sliding-window block table contains evicted/global padding entries.
++    q_resident = is_query & (q_block_id != 0)
++    q_slot = tl.where(
++        q_resident,
++        q_block_id * block_size + (query_pos % block_size),
++        PAD_SLOT_ID,
++    )
++
++    tl.store(out_input_ids_ptr + query_idx, input_id, mask=is_query)
++    clamped_query_pos = tl.minimum(query_pos, max_model_len - 1)
++    tl.store(out_query_positions_ptr + query_idx, clamped_query_pos, mask=is_query)
++    tl.store(out_query_slot_mapping_ptr + query_idx, q_slot, mask=is_query)
++
++    # --- Sample indices / positions / idx_mapping ---
++    # When SAMPLE_FROM_ANCHOR (DSpark), so we sample at EVERY query position
++    # and each position k predicts the NEXT token (sampled position = query_pos + 1).
++    # Otherwise (DFlash default) the anchor is the bonus token and only the mask tokens
++    # at offsets > 0 are sampled from, each AT its own position.
++    sample_off = 0 if SAMPLE_FROM_ANCHOR else 1
++    is_sample = is_query & (query_off >= sample_off)
++    sample_idx = req_idx * num_speculative_steps + (query_off - sample_off)
++    sample_pos = query_pos + 1 if SAMPLE_FROM_ANCHOR else query_pos
++    tl.store(out_sample_indices_ptr + sample_idx, query_idx, mask=is_sample)
++    tl.store(out_sample_pos_ptr + sample_idx, sample_pos, mask=is_sample)
++    tl.store(out_sample_idx_mapping_ptr + sample_idx, req_state_idx, mask=is_sample)
++
++    if block_idx == 0:
++        tl.store(out_query_start_loc_ptr + req_idx, query_base)
++        # seq_lens is the absolute sequence length the draft attention
++        # reads up to (context + query), not just the count of accepted
++        # tokens this step.
++        tl.store(
++            out_seq_lens_ptr + req_idx,
++            tl.minimum(last_valid_pos + 1 + num_query_per_req, max_model_len),
++        )
++        # Copy sampling state.
++        tl.store(
++            out_temperature_ptr + req_state_idx,
++            tl.load(temperature_ptr + req_state_idx),
++        )
++        tl.store(out_seeds_ptr + req_state_idx, tl.load(seeds_ptr + req_state_idx))
++        if req_idx == num_reqs - 1:
++            # Pad per-request buffers to max_num_reqs for CUDA graph safety.
++            last_query_end = num_reqs * num_query_per_req
++            for i in range(num_reqs, max_num_reqs + 1, BLOCK_SIZE):
++                block = i + tl.arange(0, BLOCK_SIZE)
++                mask = block < max_num_reqs + 1
++                tl.store(out_query_start_loc_ptr + block, last_query_end, mask=mask)
++            for i in range(num_reqs, max_num_reqs, BLOCK_SIZE):
++                block = i + tl.arange(0, BLOCK_SIZE)
++                mask = block < max_num_reqs
++                tl.store(out_seq_lens_ptr + block, 0, mask=mask)
++            # Padded sample slots point at query index 0 (a valid row in
++            # last_hidden_states) so CG replay never reads OOB. Padded
++            # sample idx mappings point to -1, which is ignored during
++            # sampling to prevent writing stale values to draft logits.
++            pad_start = num_reqs * num_speculative_steps
++            pad_end = max_num_reqs * num_speculative_steps
++            for i in range(pad_start, pad_end, BLOCK_SIZE):
++                block = i + tl.arange(0, BLOCK_SIZE)
++                mask = block < pad_end
++                tl.store(out_sample_indices_ptr + block, 0, mask=mask)
++                tl.store(out_sample_pos_ptr + block, 0, mask=mask)
++                tl.store(out_sample_idx_mapping_ptr + block, -1, mask=mask)
++            # Pad query slot mappings past num_query_tokens with PAD so the
++            # captured CG sees PAD slots (no K/V write) for replay sizes
++            # larger than the current request count.
++            q_pad_start = num_reqs * num_query_per_req
++            for i in range(q_pad_start, max_num_tokens, BLOCK_SIZE):
++                block = i + tl.arange(0, BLOCK_SIZE)
++                mask = block < max_num_tokens
++                tl.store(out_query_slot_mapping_ptr + block, PAD_SLOT_ID, mask=mask)
++
++
++def prepare_dflash_inputs(
++    input_buffers: InputBuffers,
++    query_slot_mapping: torch.Tensor,
++    context_positions: torch.Tensor,
++    context_slot_mapping: torch.Tensor,
++    sample_indices: torch.Tensor,
++    sample_pos: torch.Tensor,
++    sample_idx_mapping: torch.Tensor,
++    temperature: torch.Tensor,
++    seeds: torch.Tensor,
++    input_batch: InputBatch,
++    # [num_reqs]
++    num_sampled: torch.Tensor,
++    # [num_reqs]
++    num_rejected: torch.Tensor,
++    # [max_num_reqs]
++    last_sampled: torch.Tensor,
++    # [max_num_reqs]
++    next_prefill_tokens: torch.Tensor,
++    # [max_num_reqs]
++    input_temperature: torch.Tensor,
++    # [max_num_reqs]
++    input_seeds: torch.Tensor,
++    # [max_num_reqs, max_num_blocks]
++    block_table: torch.Tensor,
++    block_size: int,
++    parallel_drafting_token_id: int,
++    num_query_per_req: int,
++    num_speculative_steps: int,
++    max_num_reqs: int,
++    max_num_tokens: int,
++    max_model_len: int,
++    sample_from_anchor: bool = False,
++) -> None:
++    num_reqs = input_batch.num_reqs
++    assert num_reqs > 0
++    # Cover the longest possible per-request span (ctx + query). Use the max
++    # per-request query length, not the total token count across the batch.
++    max_target_query_len = int(input_batch.num_scheduled_tokens.max())
++    max_tokens_per_req = max_target_query_len + num_query_per_req
++    BLOCK_SIZE = min(256, triton.next_power_of_2(max(1, max_tokens_per_req)))
++    num_blocks = triton.cdiv(max_tokens_per_req, BLOCK_SIZE)
++    _prepare_dflash_inputs_kernel[(num_reqs, num_blocks)](
++        input_buffers.input_ids,
++        input_buffers.positions,
++        input_buffers.query_start_loc,
++        input_buffers.seq_lens,
++        query_slot_mapping,
++        context_positions,
++        context_slot_mapping,
++        sample_indices,
++        sample_pos,
++        sample_idx_mapping,
++        temperature,
++        seeds,
++        input_batch.positions,
++        input_batch.query_start_loc,
++        input_batch.idx_mapping,
++        last_sampled,
++        next_prefill_tokens,
++        num_sampled,
++        num_rejected,
++        input_temperature,
++        input_seeds,
++        block_table,
++        block_table.stride(0),
++        parallel_drafting_token_id,
++        block_size,
++        num_query_per_req,
++        num_speculative_steps,
++        max_num_reqs,
++        max_num_tokens,
++        max_model_len,
++        SAMPLE_FROM_ANCHOR=sample_from_anchor,
++        PAD_SLOT_ID=PAD_SLOT_ID,
++        BLOCK_SIZE=BLOCK_SIZE,
++    )

--- a/patches/dflash2-z-adaptive-emitted.patch
+++ b/patches/dflash2-z-adaptive-emitted.patch
@@ -1,0 +1,28 @@
+diff --git a/v1/worker/gpu/spec_decode/dflash/speculator.py b/v1/worker/gpu/spec_decode/dflash/speculator.py
+index 4ad1b10ba..c28a42115 100644
+--- a/v1/worker/gpu/spec_decode/dflash/speculator.py
++++ b/v1/worker/gpu/spec_decode/dflash/speculator.py
+@@ -362,7 +362,7 @@ class DFlashSpeculator(DraftModelSpeculator):
+         # sampling slots it was given (bonus + drafts), num_rejected how many of those were
+         # thrown away, so the difference is the tokens it emitted. dflash2/lookup.py decides
+         # the next block length from it.
+-        self.last_num_emitted = (num_sampled - num_rejected) if num_sampled is not None else None
++        self.last_num_emitted = num_sampled if num_sampled is not None else None
+         num_target_tokens = input_batch.num_tokens
+         num_query_tokens = num_reqs * self.num_query_per_req
+         max_seq_len = input_batch.seq_lens_cpu_upper_bound[:num_reqs].max().item()
+diff --git a/v1/worker/gpu/spec_decode/dflash2/speculator.py b/v1/worker/gpu/spec_decode/dflash2/speculator.py
+index 1371aab30..ac0d41df0 100644
+--- a/v1/worker/gpu/spec_decode/dflash2/speculator.py
++++ b/v1/worker/gpu/spec_decode/dflash2/speculator.py
+@@ -516,9 +516,7 @@ class DFlash2Speculator(DFlashSpeculator):
+         self.draft_max_seq_len = min(
+             max_seq_len + self.num_query_per_req, self.max_model_len
+         )
+-        self.last_num_emitted = (
+-            (num_sampled - num_rejected) if num_sampled is not None else None
+-        )
++        self.last_num_emitted = num_sampled if num_sampled is not None else None
+ 
+         if aux_hidden_states:
+             hidden_states = self.model.combine_hidden_states(

--- a/patches/dflash2-z-adaptive-emitted.patch
+++ b/patches/dflash2-z-adaptive-emitted.patch
@@ -1,5 +1,5 @@
 diff --git a/v1/worker/gpu/spec_decode/dflash/speculator.py b/v1/worker/gpu/spec_decode/dflash/speculator.py
-index 4ad1b10ba..c28a42115 100644
+index 1bd78be21..0556bcbb4 100644
 --- a/v1/worker/gpu/spec_decode/dflash/speculator.py
 +++ b/v1/worker/gpu/spec_decode/dflash/speculator.py
 @@ -362,7 +362,7 @@ class DFlashSpeculator(DraftModelSpeculator):

--- a/patches/hybrid-kv-groups-v2-cudagraph.patch
+++ b/patches/hybrid-kv-groups-v2-cudagraph.patch
@@ -30,7 +30,7 @@ inert for every other config in this repo (verified: MTP mode's pool is bit-iden
 Apply from the installed vllm package directory:
   patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/hybrid-kv-groups-v2-cudagraph.patch
 
-Written against vLLM 0.27.1. Reapply after upgrades.
+Validated against vLLM 0.28.0. Reapply after upgrades.
 
 --- a/v1/core/kv_cache_utils.py
 +++ b/v1/core/kv_cache_utils.py

--- a/patches/hybrid-sw-block-promote.patch
+++ b/patches/hybrid-sw-block-promote.patch
@@ -62,7 +62,7 @@ DFLASH_TOKENS=15 is untouched: 228,296 tokens, same as before.
 Apply from the repo root, after hybrid-kv-groups-v2-cudagraph.patch:
   patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/hybrid-sw-block-promote.patch
 
-Written against vLLM 0.27.1. Reapply after upgrades.
+Validated against vLLM 0.28.0. Reapply after upgrades.
 
 --- a/v1/core/kv_cache_utils.py
 +++ b/v1/core/kv_cache_utils.py

--- a/patches/mamba-chunked-prefill-align.patch
+++ b/patches/mamba-chunked-prefill-align.patch
@@ -1,16 +1,16 @@
 Fix state loss and NaN generation during chunked prefill in Mamba/GDN models:
 
 1. v1/worker/mamba_utils.py: In `preprocess_mamba_align_fused_kernel`, `src_col` was
-   unconditionally disabled with `tl.where(qlen > 1, -1, state_idx)` under the assumption
-   that `qlen > 1` is only fresh prefill without prior state. During chunked prefill
-   continuation (`qlen > 1` and `num_computed > 0`), crossing a Mamba block boundary
-   failed to copy the state from `state_idx` to `new_state_idx`, causing subsequent chunks
-   to read uninitialized memory (and eventually NaNs).
+   always stored as the previous state column. During fresh prefill and when the
+   state column is unchanged, that asks the pre-copy kernel to copy an invalid or
+   already-current state; during chunked prefill continuation, crossing a Mamba
+   block boundary must instead copy the state from `state_idx` to `new_state_idx`.
    Fixed to: `src_col = tl.where((num_computed == 0) | (state_idx < 0) | (state_idx == new_state_idx), -1, state_idx)`
 
-2. third_party/flash_linear_attention/ops/chunk_o.py: Mask `b_g` and `b_o` with `m_t` before
-   evaluating `tl.exp(b_g)` and `tl.exp(b_g[:, None] - b_g[None, :])` to prevent uninitialized
-   memory in partial boundary chunks from evaluating to NaNs in Triton.
+2. third_party/flash_linear_attention/ops/chunk_o.py: Compute `m_t` before the `USE_G` path
+   and mask `b_g` with it before evaluating `tl.exp(b_g)` and
+   `tl.exp(b_g[:, None] - b_g[None, :])`, preventing uninitialized memory in partial boundary
+   chunks from evaluating to NaNs in Triton.
 
 Apply from the installed vllm package directory:
   patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/mamba-chunked-prefill-align.patch
@@ -18,33 +18,40 @@ Apply from the installed vllm package directory:
 diff --git a/third_party/flash_linear_attention/ops/chunk_o.py b/third_party/flash_linear_attention/ops/chunk_o.py
 --- a/third_party/flash_linear_attention/ops/chunk_o.py
 +++ b/third_party/flash_linear_attention/ops/chunk_o.py
-@@ -107,6 +107,7 @@
-         b_h = tl.load(p_h, mask=mask_h, other=0.0).to(tl.float32)
-         if USE_G:
-             b_g = tl.load(p_g, mask=m_t, other=0.0).to(tl.float32)
-+            b_g = tl.where(m_t, b_g, 0.0)
-             b_h = b_h * tl.exp(b_g)[:, None]
-         b_o += tl.dot(b_q, b_h)
+@@ -112,15 +112,16 @@
+         # [BT, BK] @ [BK, BT] -> [BT, BT]
+         b_A += tl.dot(b_q, b_k)
  
-@@ -118,6 +119,7 @@
-         b_A = tl.load(p_A, mask=m_A, other=0.0).to(tl.float32)
-         if USE_G:
-             b_g = tl.load(p_g, mask=m_t, other=0.0).to(tl.float32)
-+            b_g = tl.where(m_t, b_g, 0.0)
-             b_g_diff = b_g[:, None] - b_g[None, :]
-             b_A = b_A * tl.exp(tl.where(m_A, b_g_diff, 0.0))
-         b_o += tl.dot(b_A.to(b_v.dtype), b_v)
++    o_t = i_t * BT + tl.arange(0, BT)
++    m_t = o_t < T
+     if USE_G:
+         g += bos * H + i_h
+         p_g = tl.make_block_ptr(g, (T,), (H,), (i_t * BT,), (BT,), (0,))
+         b_g = tl.load(p_g, boundary_check=(0,))
++        b_g = tl.where(m_t, b_g, 0.0)
+         b_o = b_o * exp(b_g)[:, None]
+         b_A = b_A * exp(b_g[:, None] - b_g[None, :])
+ 
+-    o_t = i_t * BT + tl.arange(0, BT)
+-    m_t = o_t < T
+     m_A = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
+     b_A = tl.where(m_A, b_A, 0)
+ 
 diff --git a/v1/worker/mamba_utils.py b/v1/worker/mamba_utils.py
 --- a/v1/worker/mamba_utils.py
 +++ b/v1/worker/mamba_utils.py
-@@ -424,8 +424,8 @@
-     computed_after = num_computed + qlen
- 
-     src_off = tl.maximum(num_accepted - 1, 0)
--    src_col = tl.where(qlen > 1, -1, state_idx)
-+    new_state_idx = (computed_after + MAMBA_BLOCK_SIZE - 1) // MAMBA_BLOCK_SIZE - 1
+@@ -419,10 +419,10 @@
+-    src_off = tl.maximum(num_accepted - 1, 0)
+-    tl.store(src_col_ptr + req_indices, state_idx, mask=mask)
+-    tl.store(src_off_ptr + req_indices, src_off, mask=mask)
+-
+     num_computed = tl.load(num_computed_tokens_ptr + req_indices, mask=mask, other=0)
+     query_start = tl.load(query_start_loc_ptr + offsets, mask=mask, other=0)
+     query_end = tl.load(query_start_loc_ptr + offsets + 1, mask=mask, other=0)
+     computed_after = num_computed + query_end - query_start
+     new_state_idx = (computed_after + MAMBA_BLOCK_SIZE - 1) // MAMBA_BLOCK_SIZE - 1
++    src_off = tl.maximum(num_accepted - 1, 0)
 +    src_col = tl.where((num_computed == 0) | (state_idx < 0) | (state_idx == new_state_idx), -1, state_idx)
-     tl.store(src_col_ptr + req_indices, src_col, mask=mask)
-     tl.store(src_off_ptr + req_indices, src_off, mask=mask)
--    new_state_idx = (computed_after + MAMBA_BLOCK_SIZE - 1) // MAMBA_BLOCK_SIZE - 1
++    tl.store(src_col_ptr + req_indices, src_col, mask=mask)
++    tl.store(src_off_ptr + req_indices, src_off, mask=mask)
      tl.store(state_idx_ptr + req_indices, new_state_idx, mask=mask)

--- a/patches/mamba-chunked-prefill-align.patch
+++ b/patches/mamba-chunked-prefill-align.patch
@@ -1,0 +1,50 @@
+Fix state loss and NaN generation during chunked prefill in Mamba/GDN models:
+
+1. v1/worker/mamba_utils.py: In `preprocess_mamba_align_fused_kernel`, `src_col` was
+   unconditionally disabled with `tl.where(qlen > 1, -1, state_idx)` under the assumption
+   that `qlen > 1` is only fresh prefill without prior state. During chunked prefill
+   continuation (`qlen > 1` and `num_computed > 0`), crossing a Mamba block boundary
+   failed to copy the state from `state_idx` to `new_state_idx`, causing subsequent chunks
+   to read uninitialized memory (and eventually NaNs).
+   Fixed to: `src_col = tl.where((num_computed == 0) | (state_idx < 0) | (state_idx == new_state_idx), -1, state_idx)`
+
+2. third_party/flash_linear_attention/ops/chunk_o.py: Mask `b_g` and `b_o` with `m_t` before
+   evaluating `tl.exp(b_g)` and `tl.exp(b_g[:, None] - b_g[None, :])` to prevent uninitialized
+   memory in partial boundary chunks from evaluating to NaNs in Triton.
+
+Apply from the installed vllm package directory:
+  patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/mamba-chunked-prefill-align.patch
+
+diff --git a/third_party/flash_linear_attention/ops/chunk_o.py b/third_party/flash_linear_attention/ops/chunk_o.py
+--- a/third_party/flash_linear_attention/ops/chunk_o.py
++++ b/third_party/flash_linear_attention/ops/chunk_o.py
+@@ -107,6 +107,7 @@
+         b_h = tl.load(p_h, mask=mask_h, other=0.0).to(tl.float32)
+         if USE_G:
+             b_g = tl.load(p_g, mask=m_t, other=0.0).to(tl.float32)
++            b_g = tl.where(m_t, b_g, 0.0)
+             b_h = b_h * tl.exp(b_g)[:, None]
+         b_o += tl.dot(b_q, b_h)
+ 
+@@ -118,6 +119,7 @@
+         b_A = tl.load(p_A, mask=m_A, other=0.0).to(tl.float32)
+         if USE_G:
+             b_g = tl.load(p_g, mask=m_t, other=0.0).to(tl.float32)
++            b_g = tl.where(m_t, b_g, 0.0)
+             b_g_diff = b_g[:, None] - b_g[None, :]
+             b_A = b_A * tl.exp(tl.where(m_A, b_g_diff, 0.0))
+         b_o += tl.dot(b_A.to(b_v.dtype), b_v)
+diff --git a/v1/worker/mamba_utils.py b/v1/worker/mamba_utils.py
+--- a/v1/worker/mamba_utils.py
++++ b/v1/worker/mamba_utils.py
+@@ -424,8 +424,8 @@
+     computed_after = num_computed + qlen
+ 
+     src_off = tl.maximum(num_accepted - 1, 0)
+-    src_col = tl.where(qlen > 1, -1, state_idx)
++    new_state_idx = (computed_after + MAMBA_BLOCK_SIZE - 1) // MAMBA_BLOCK_SIZE - 1
++    src_col = tl.where((num_computed == 0) | (state_idx < 0) | (state_idx == new_state_idx), -1, state_idx)
+     tl.store(src_col_ptr + req_indices, src_col, mask=mask)
+     tl.store(src_off_ptr + req_indices, src_off, mask=mask)
+-    new_state_idx = (computed_after + MAMBA_BLOCK_SIZE - 1) // MAMBA_BLOCK_SIZE - 1
+     tl.store(state_idx_ptr + req_indices, new_state_idx, mask=mask)

--- a/patches/marlin-int8-layer-select.patch
+++ b/patches/marlin-int8-layer-select.patch
@@ -12,7 +12,7 @@ KeyError: 'input_global_scale').
 Apply from the installed vllm package directory:
   patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/marlin-int8-layer-select.patch
 
-Written against vLLM 0.27.1.
+Validated against vLLM 0.28.0.
 
 --- a/envs.py
 +++ b/envs.py

--- a/patches/marlin-int8-negative-scales.patch
+++ b/patches/marlin-int8-negative-scales.patch
@@ -12,7 +12,7 @@ rare code -8 becomes -7 (one LSB) in flipped groups.
 Apply from the installed vllm package directory:
   patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/marlin-int8-negative-scales.patch
 
-Written against vLLM 0.27.1.
+Validated against vLLM 0.28.0.
 
 --- a/model_executor/kernels/linear/mixed_precision/marlin.py
 +++ b/model_executor/kernels/linear/mixed_precision/marlin.py

--- a/patches/offload-wsl2-devptr.patch
+++ b/patches/offload-wsl2-devptr.patch
@@ -83,10 +83,10 @@ index 40b57ac..0a3471b 100644
  
  
  def _new_descriptor_buffers(
-@@ -492,6 +557,9 @@ class CPUOffloadingWorker(OffloadingWorker):
+@@ -711,7 +776,10 @@ class CPUOffloadingWorker(OffloadingWorker):
  
              if mmap_region is not None:
-                 cpu_tensor = mmap_region.create_next_view(cpu_page_size_bytes)
+                 cpu_tensor = mmap_region.create_next_worker_view(cpu_page_size_bytes)
 +                # (fix 2026-08-28) ride the device-VA delta with the view
 +                cpu_tensor._offload_ptr_delta = (
 +                    getattr(mmap_region, "device_delta", 0) or 0)

--- a/patches/offload-wsl2-devptr.patch
+++ b/patches/offload-wsl2-devptr.patch
@@ -83,9 +83,8 @@ index 40b57ac..0a3471b 100644
  
  
  def _new_descriptor_buffers(
-@@ -711,7 +776,10 @@ class CPUOffloadingWorker(OffloadingWorker):
- 
-             if mmap_region is not None:
+@@ -786,5 +786,8 @@ class CPUOffloadingWorker(OffloadingWorker):
+            elif mmap_region is not None:
                  cpu_tensor = mmap_region.create_next_worker_view(cpu_page_size_bytes)
 +                # (fix 2026-08-28) ride the device-VA delta with the view
 +                cpu_tensor._offload_ptr_delta = (

--- a/patches/qwen3_5-embed-quant.patch
+++ b/patches/qwen3_5-embed-quant.patch
@@ -8,7 +8,7 @@ single-user mode crashes on load with "no parameter named
 Apply from the installed vllm package directory:
   patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/qwen3_5-embed-quant.patch
 
-Written against vLLM 0.27.1. Reapply after upgrades.
+Validated against vLLM 0.28.0. Reapply after upgrades.
 
 --- a/model_executor/models/qwen3_5.py
 +++ b/model_executor/models/qwen3_5.py

--- a/patches/qwen3_5-mtp-draft-vocab.patch
+++ b/patches/qwen3_5-mtp-draft-vocab.patch
@@ -10,7 +10,7 @@ MTP_DRAFT_VOCAB=0 to fall back to the shared full lm_head.
 Apply from the installed vllm package directory:
   patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/qwen3_5-mtp-draft-vocab.patch
 
-Written against vLLM 0.27.1.
+Validated against vLLM 0.28.0.
 
 --- a/model_executor/models/qwen3_5_mtp.py
 +++ b/model_executor/models/qwen3_5_mtp.py

--- a/patches/sampler-small-topk-fast-softmax.patch
+++ b/patches/sampler-small-topk-fast-softmax.patch
@@ -1,5 +1,5 @@
 Sort-free top-k/top-p for small k, multi-block row softmax, and top-k/top-p
-truncated drafts (vLLM 0.27.1).
+truncated drafts (vLLM 0.28.0).
 
 Three sampler costs that dominate a single-user speculative-decode step at the
 model's default sampling (temperature 1.0, top-p 0.95, top-k 20):

--- a/patches/spec-decode-attn.patch
+++ b/patches/spec-decode-attn.patch
@@ -1,5 +1,5 @@
 Split-KV attention for speculative-decode batches on the FLASH_ATTN backend
-(vLLM 0.27.1, Ampere), with query-row tiling so the verify block can be longer
+(vLLM 0.28.0, Ampere), with query-row tiling so the verify block can be longer
 than the drafter's.
 
 FlashAttention-2 only splits the KV sequence across thread blocks when a request

--- a/patches/spec-decode-int8-kv.patch
+++ b/patches/spec-decode-int8-kv.patch
@@ -37,7 +37,7 @@ aligned, which 260 does satisfy) and unpacking would recover most of the 61%; no
 Apply from the repo root, after spec-decode-attn.patch:
   patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/spec-decode-int8-kv.patch
 
-Written against vLLM 0.27.1. Reapply after upgrades.
+Validated against vLLM 0.28.0. Reapply after upgrades.
 
 --- a/v1/attention/backends/flash_attn.py
 +++ b/v1/attention/backends/flash_attn.py

--- a/patches/speed-knobs-envs.patch
+++ b/patches/speed-knobs-envs.patch
@@ -1,4 +1,4 @@
-Register the single-user speed knobs as vLLM env vars (vLLM 0.27.1).
+Register the single-user speed knobs as vLLM env vars (vLLM 0.28.0).
 
 VLLM_MARLIN_TUNE / VLLM_MARLIN_TUNE_DIR (tuned Marlin build, see marlin-tune/),
 VLLM_SPEC_DECODE_ATTN (patches/spec-decode-attn.patch) and VLLM_DRAFT_TOPK_TOPP

--- a/patches/vision-tower-cpu-offload.patch
+++ b/patches/vision-tower-cpu-offload.patch
@@ -1,60 +1,21 @@
-Keep the vision tower's weights in host RAM (vLLM 0.27.1).
+Keep the Qwen3 Vision tower's bulk weights in host RAM on vLLM 0.28.0.
 
-VISION=1 loads model.visual.* -- 878.8 MiB of BF16 on this checkpoint, of which
-blocks are 784.8 and merger 85.5 -- and on a 24 GB card shared with a desktop
-compositor that is most of the headroom the single-user configs run on. vLLM can
-already offload weights to pinned host memory, but the offloader is installed only
-in make_layers() (model_executor/models/utils.py), which the language decoder
-layers use and the ViT does not: Qwen3_VisionTransformer builds self.blocks as a
-plain nn.ModuleList. So --cpu-offload-gb cannot reach the tower, and setting it
-spends the budget on language layers instead, which puts PCIe in the decode loop.
+VLLM_VISION_CPU_OFFLOAD_GB is a dedicated tower-only budget. It uses UVAOffloader's bulk-copy path so the language-model offload budget remains independent.
 
-This routes the tower's blocks and merger through their own UVAOffloader --
-dedicated, so it never competes with --cpu-offload-gb -- with the zero-copy mode
-turned off, leaving the bulk-copy path: each module is copied H2D once per forward
-and freed. patch_embed and pos_embed (8.5 MiB) stay resident, so visual.device and
-visual.dtype still report cuda.
-
-VLLM_VISION_CPU_OFFLOAD_GB is the budget in GiB; 0 (default) changes nothing.
-1 covers the whole tower. Registered in envs.py so validate_environ() does not
-warn about it. VISION_OFFLOAD in either start script sets it, defaulting to on.
-
-On 24 GB this is what makes SPEC=dflash2 + VISION=1 possible at all. Without it
-that config dies in graph capture -- torch.OutOfMemoryError: Tried to allocate
-960.00 MiB ... 787.50 MiB is free, at spec_decode_attn.py:184 (the split-KV
-verify part_o buffer) -- because the dflash2 pool is pinned by bytes, so the
-tower comes out of the ~1.1 GiB transient margin and is 0.85 of it. With the
-offload the same config comes up at its full 69,758-token pool and reads images.
-SPEC=mtp boots either way.
-
-Measured on an RTX 3090 at PCIe 4.0 x16, one 8192-patch image (the 2048-image-token
-cap both start scripts ship), median of 10 forwards, isolated tower:
-
-  VLLM_VISION_CPU_OFFLOAD_GB   weights on GPU   peak alloc   forward
-  0 (stock)                       891.3 MiB     1160.5 MiB    296 ms
-  1                                 9.0 MiB      308.2 MiB    333 ms
-
-Bit-exact against the resident tower (same state_dict, torch.equal on the output).
-Do NOT leave the UVA zero-copy path on for this: same memory, but 3327 ms per
-image, because the GEMMs then re-read operand tiles over PCIe in the inner loop.
-
-Applies after speed-knobs-envs.patch and marlin-int8-layer-select.patch, which
-also touch envs.py (disjoint hunks, and glob order puts this one last):
-  patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/vision-tower-cpu-offload.patch
+--- generated against the v0.28.0 tree after the repo's active patches ---
 
 --- a/envs.py
 +++ b/envs.py
-@@ -188,6 +188,9 @@
+@@ -195,6 +195,8 @@
      VLLM_MARLIN_TUNE_DIR: str = ""
      VLLM_SPEC_DECODE_ATTN: bool = False
      VLLM_DRAFT_TOPK_TOPP: bool = True
-+    # syv patch: GiB of vision-tower weights to keep in pinned host memory
-+    # (patches/vision-tower-cpu-offload.patch). 0 disables.
++    # GiB of vision-tower weights to keep in pinned host memory; 0 disables.
 +    VLLM_VISION_CPU_OFFLOAD_GB: float = 0.0
      VLLM_HUMMING_MOE_GEMM_TYPE: Literal["indexed", "grouped", "auto"] | None = None
      VLLM_DEEPEPLL_NVFP4_DISPATCH: bool = False
      VLLM_V1_USE_OUTLINES_CACHE: bool = False
-@@ -1480,6 +1483,9 @@
+@@ -1539,6 +1541,9 @@
      "VLLM_MARLIN_TUNE_DIR": lambda: os.environ.get("VLLM_MARLIN_TUNE_DIR", ""),
      "VLLM_SPEC_DECODE_ATTN": lambda: os.environ.get("VLLM_SPEC_DECODE_ATTN", "0") == "1",
      "VLLM_DRAFT_TOPK_TOPP": lambda: os.environ.get("VLLM_DRAFT_TOPK_TOPP", "1") == "1",
@@ -71,25 +32,14 @@ also touch envs.py (disjoint hunks, and glob order puts this one last):
  from transformers.video_utils import VideoMetadata
  
 +import vllm.envs as envs
- from vllm.compilation.decorators import support_torch_compile
- from vllm.config import VllmConfig
- from vllm.config.multimodal import (
-@@ -596,6 +597,40 @@
+ from vllm.compilation.decorators import (
+     should_torch_compile_mm_encoder,
+     support_torch_compile,
+@@ -619,6 +620,17 @@
+             is_neox_style=True,
              rope_parameters={"partial_rotary_factor": 0.5},
          )
- 
-+        # syv patch: with VLLM_VISION_CPU_OFFLOAD_GB>0 the tower's weights live in
-+        # pinned host memory and each module is copied to the GPU for the duration of
-+        # its own forward, so the ViT costs ~0 resident VRAM while its GEMMs still run
-+        # on the GPU (see the path note below). blocks (784.8 MiB on the
-+        # Qwen3.8-27B AutoRound checkpoint) and merger (85.5 MiB) are 99% of the
-+        # tower's 878.8 MiB; patch_embed and pos_embed stay resident, because 8.5 MiB
-+        # is not worth putting an embedding gather on the PCIe bus.
-+        #
-+        # A dedicated offloader, NOT get_offloader(): the global one shares its byte
-+        # budget with the language decoder layers (make_layers), so --cpu-offload-gb
-+        # would spend it on whichever modules are built first and put PCIe in the
-+        # decode hot loop. This one only ever sees the tower.
++
 +        vision_offloader = None
 +        if envs.VLLM_VISION_CPU_OFFLOAD_GB > 0:
 +            from vllm.model_executor.offloader.uva import UVAOffloader
@@ -97,25 +47,13 @@ also touch envs.py (disjoint hunks, and glob order puts this one last):
 +            vision_offloader = UVAOffloader(
 +                int(envs.VLLM_VISION_CPU_OFFLOAD_GB * 1024**3)
 +            )
-+            # Force the bulk-copy path (functional_call + .to(device) per module)
-+            # instead of UVA zero-copy. Measured on a 3090 at PCIe 4.0 x16, one
-+            # 8192-patch image (the 2048-image-token cap the start scripts ship),
-+            # median of 10 forwards:
-+            #   resident weights   296 ms   891 MiB weights, 1160 MiB peak
-+            #   bulk copy          333 ms     9 MiB weights,  308 MiB peak
-+            #   UVA zero-copy     3327 ms     9 MiB weights,  278 MiB peak
-+            # Zero-copy leaves the GEMMs reading operand tiles over PCIe in the
-+            # inner loop, which re-reads each tile and lands at ~290 MB/s effective
-+            # -- 11x slower than just keeping the weights resident. The copy path
-+            # moves each module once, contiguously, at bulk PCIe rate: +36 ms.
-+            # Set on the instance rather than via VLLM_WEIGHT_OFFLOADING_DISABLE_UVA
-+            # so this does not change what --cpu-offload-gb does elsewhere.
++            # Bulk-copy each module for its forward. UVA zero-copy makes every
++            # GEMM reread operand tiles over PCIe and is much slower here.
 +            vision_offloader.uva_offloading = False
-+
+ 
          self.merger = Qwen3_VisionPatchMerger(
              d_model=vision_config.out_hidden_size,
-             context_dim=self.hidden_size,
-@@ -604,6 +639,8 @@
+@@ -628,6 +640,8 @@
              quant_config=quant_config,
              prefix=f"{prefix}.merger",
          )
@@ -124,12 +62,10 @@ also touch envs.py (disjoint hunks, and glob order puts this one last):
  
          self.deepstack_merger_list = nn.ModuleList(
              [
-@@ -625,19 +662,24 @@
+@@ -649,19 +663,22 @@
              dtype=torch.get_default_dtype(),
          )
  
-+        # syv patch: a generator, so UVAOffloader.wrap_modules can offload each block as
-+        # it is built and stop exactly at the byte budget (see the merger above).
 +        blocks_iter = (
 +            Qwen3_VisionBlock(
 +                dim=self.hidden_size,
@@ -159,5 +95,4 @@ also touch envs.py (disjoint hunks, and glob order puts this one last):
 +            if vision_offloader is not None
 +            else list(blocks_iter)
          )
- 
      @property

--- a/patches/vllm-pr50021-gdn-spec-bounds.patch
+++ b/patches/vllm-pr50021-gdn-spec-bounds.patch
@@ -15,7 +15,7 @@ Apply from the installed vllm package directory:
 Source: https://github.com/vllm-project/vllm/pull/50021 (Apache-2.0).
 
 diff --git a/model_executor/layers/mamba/ops/causal_conv1d.py b/model_executor/layers/mamba/ops/causal_conv1d.py
-index 8335c849666d..e7387484cca6 100644
+index 8335c8496..e7387484c 100644
 --- a/model_executor/layers/mamba/ops/causal_conv1d.py
 +++ b/model_executor/layers/mamba/ops/causal_conv1d.py
 @@ -871,9 +871,21 @@ def _causal_conv1d_update_kernel(
@@ -44,7 +44,7 @@ index 8335c849666d..e7387484cca6 100644
          conv_state_token_offset = 0
  
 diff --git a/model_executor/layers/mamba/ops/mamba_ssm.py b/model_executor/layers/mamba/ops/mamba_ssm.py
-index af45467886ea..73c892d67b5d 100644
+index af4546788..73c892d67 100644
 --- a/model_executor/layers/mamba/ops/mamba_ssm.py
 +++ b/model_executor/layers/mamba/ops/mamba_ssm.py
 @@ -333,7 +333,15 @@ def _selective_scan_update_kernel(
@@ -85,10 +85,10 @@ index af45467886ea..73c892d67b5d 100644
          state_ptr += state_batch_idx * stride_state_batch + pid_h * stride_state_head
      else:
 diff --git a/third_party/flash_linear_attention/ops/fused_recurrent.py b/third_party/flash_linear_attention/ops/fused_recurrent.py
-index c8004cb57173..02907c44588e 100644
+index e1d0d965f..4888d0389 100644
 --- a/third_party/flash_linear_attention/ops/fused_recurrent.py
 +++ b/third_party/flash_linear_attention/ops/fused_recurrent.py
-@@ -107,11 +107,24 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
+@@ -107,11 +107,29 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
              else:
                  i_t = 0
              # Load state index and check for invalid entries
@@ -113,21 +113,24 @@ index c8004cb57173..02907c44588e 100644
 +                mask=idx_in_row,
 +                other=0,
 +            ).to(tl.int64)
--            if state_idx <= 0:
--                return
--            p_h0 = h0 + state_idx * stride_init_state_token
-+            if state_idx > 0:
-+                p_h0 = h0 + state_idx * stride_init_state_token
++            # Skip invalid state indices without exposing uninitialized output.
+             if state_idx <= 0:
++                zero = tl.zeros([BV], dtype=tl.float32).to(p_o.dtype.element_ty)
++                for _ in range(0, T):
++                    tl.store(p_o, zero, mask=mask_v)
++                    p_o += HV * V
+                 return
+             p_h0 = h0 + state_idx * stride_init_state_token
          else:
 diff --git a/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py b/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
-index 7e0c7e05cab1..261befff8f9a 100644
+index 7e0c7e05c..261befff8 100644
 --- a/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
 +++ b/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
-@@ -106,12 +106,24 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
+@@ -106,12 +106,29 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
                  i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
              else:
                  i_t = 0
-             # Load state index and check for invalid entries
+-            # Load state index and check for invalid entries
 -            state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
 -                tl.int64
 -            )
@@ -141,16 +144,21 @@ index 7e0c7e05cab1..261befff8f9a 100644
 +            # non-positive values, so an out-of-range read returning a garbage
 +            # positive int flows into ``h0 + state_idx * stride_init_state_token``
 +            # and faults the SM. Mask the load to the row; ``other=0`` falls into
-+            # the invalid-state path below.
++            # the invalid-state path below, which also returns before the
++            # ``final_state_idx`` load later.
 +            idx_in_row = (i_t >= 0) & (i_t < stride_indices_seq)
 +            state_idx = tl.load(
 +                ssm_state_indices + i_n * stride_indices_seq + i_t,
 +                mask=idx_in_row,
 +                other=0,
 +            ).to(tl.int64)
--            if state_idx <= 0:
--                return
--            p_h0 = h0 + state_idx * stride_init_state_token
-+            if state_idx > 0:
-+                p_h0 = h0 + state_idx * stride_init_state_token
++            # Skip invalid state indices without exposing uninitialized output.
+             if state_idx <= 0:
++                zero = tl.zeros([BV], dtype=tl.float32).to(p_o.dtype.element_ty)
++                for _ in range(0, T):
++                    tl.store(p_o, zero, mask=mask_v)
++                    p_o += HV * V
+                 return
+             p_h0 = h0 + state_idx * stride_init_state_token
          else:
+

--- a/patches/vllm-pr50021-gdn-spec-bounds.patch
+++ b/patches/vllm-pr50021-gdn-spec-bounds.patch
@@ -88,7 +88,7 @@ diff --git a/third_party/flash_linear_attention/ops/fused_recurrent.py b/third_p
 index c8004cb57173..02907c44588e 100644
 --- a/third_party/flash_linear_attention/ops/fused_recurrent.py
 +++ b/third_party/flash_linear_attention/ops/fused_recurrent.py
-@@ -107,11 +107,29 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
+@@ -107,11 +107,24 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
              else:
                  i_t = 0
              # Load state index and check for invalid entries
@@ -113,24 +113,21 @@ index c8004cb57173..02907c44588e 100644
 +                mask=idx_in_row,
 +                other=0,
 +            ).to(tl.int64)
-+            # Skip invalid state indices without exposing uninitialized output.
-             if state_idx <= 0:
-+                zero = tl.zeros([BV], dtype=tl.float32).to(p_o.dtype.element_ty)
-+                for _ in range(0, T):
-+                    tl.store(p_o, zero, mask=mask_v)
-+                    p_o += HV * V
-                 return
-             p_h0 = h0 + state_idx * stride_init_state_token
+-            if state_idx <= 0:
+-                return
+-            p_h0 = h0 + state_idx * stride_init_state_token
++            if state_idx > 0:
++                p_h0 = h0 + state_idx * stride_init_state_token
          else:
 diff --git a/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py b/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
 index 7e0c7e05cab1..261befff8f9a 100644
 --- a/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
 +++ b/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
-@@ -106,12 +106,29 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
+@@ -106,12 +106,24 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
                  i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
              else:
                  i_t = 0
--            # Load state index and check for invalid entries
+             # Load state index and check for invalid entries
 -            state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
 -                tl.int64
 -            )
@@ -144,20 +141,16 @@ index 7e0c7e05cab1..261befff8f9a 100644
 +            # non-positive values, so an out-of-range read returning a garbage
 +            # positive int flows into ``h0 + state_idx * stride_init_state_token``
 +            # and faults the SM. Mask the load to the row; ``other=0`` falls into
-+            # the invalid-state path below, which also returns before the
-+            # ``final_state_idx`` load later.
++            # the invalid-state path below.
 +            idx_in_row = (i_t >= 0) & (i_t < stride_indices_seq)
 +            state_idx = tl.load(
 +                ssm_state_indices + i_n * stride_indices_seq + i_t,
 +                mask=idx_in_row,
 +                other=0,
 +            ).to(tl.int64)
-+            # Skip invalid state indices without exposing uninitialized output.
-             if state_idx <= 0:
-+                zero = tl.zeros([BV], dtype=tl.float32).to(p_o.dtype.element_ty)
-+                for _ in range(0, T):
-+                    tl.store(p_o, zero, mask=mask_v)
-+                    p_o += HV * V
-                 return
-             p_h0 = h0 + state_idx * stride_init_state_token
+-            if state_idx <= 0:
+-                return
+-            p_h0 = h0 + state_idx * stride_init_state_token
++            if state_idx > 0:
++                p_h0 = h0 + state_idx * stride_init_state_token
          else:

--- a/patches/vllm-pr50021-gdn-spec-bounds.patch
+++ b/patches/vllm-pr50021-gdn-spec-bounds.patch
@@ -1,19 +1,3 @@
-vLLM PR #50021 (open at the time of writing): bound accepted-token state
-lookups in the Gated DeltaNet / Mamba speculative-decode kernels.
-
-The fused_recurrent / fused_sigmoid_gating / causal_conv1d / selective-scan
-kernels index the recurrent-state slot with (num_accepted_tokens - 1) without
-checking it against the row width; stale or oversized counts produce wild GPU
-addresses. Vendored here (kernel hunks only; the mamba_utils.py prefix-caching
-hunks of the PR are not needed with this repo's v0.28.0 prefix-caching
-off) because we hit illegal-memory-access crashes with several concurrent MTP
-requests. Note: it does NOT fix the k=4 crash described in single-user/README.md.
-
-Apply from the installed vllm package directory:
-  patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/vllm-pr50021-gdn-spec-bounds.patch
-
-Source: https://github.com/vllm-project/vllm/pull/50021 (Apache-2.0).
-
 diff --git a/model_executor/layers/mamba/ops/causal_conv1d.py b/model_executor/layers/mamba/ops/causal_conv1d.py
 index 8335c8496..e7387484c 100644
 --- a/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -161,4 +145,3 @@ index 7e0c7e05c..261befff8 100644
                  return
              p_h0 = h0 + state_idx * stride_init_state_token
          else:
-

--- a/patches/vllm-pr50021-gdn-spec-bounds.patch
+++ b/patches/vllm-pr50021-gdn-spec-bounds.patch
@@ -5,7 +5,7 @@ The fused_recurrent / fused_sigmoid_gating / causal_conv1d / selective-scan
 kernels index the recurrent-state slot with (num_accepted_tokens - 1) without
 checking it against the row width; stale or oversized counts produce wild GPU
 addresses. Vendored here (kernel hunks only; the mamba_utils.py prefix-caching
-hunks of the PR do not apply to 0.27.1 and are not needed with prefix caching
+hunks of the PR are not needed with this repo's v0.28.0 prefix-caching
 off) because we hit illegal-memory-access crashes with several concurrent MTP
 requests. Note: it does NOT fix the k=4 crash described in single-user/README.md.
 

--- a/patches/xgrammar-spec-terminated.patch
+++ b/patches/xgrammar-spec-terminated.patch
@@ -6,7 +6,7 @@ xgrammar matcher terminates: the matcher completes at the grammar's own end (a
 tool call's closing tag, a JSON schema's final brace, or the stop token), and
 the same step's remaining accepted tokens -- a newline after </tool_call>, the
 stop token itself, anything after it under ignore_eos -- arrive at
-accept_tokens() anyway. 0.27.1 treats both arrivals as failure:
+accept_tokens() anyway. The v0.28.0 base treats both arrivals as failure:
 
   - a post-termination token inside one call fails matcher.accept_token()
     ("Failed to advance FSM ... Please file an issue", plus xgrammar's

--- a/single-user/README.md
+++ b/single-user/README.md
@@ -15,6 +15,9 @@ Realistic chat prompts (8 mixed English/Danish/code tasks in
 [bench/prompts_real.jsonl](../bench/prompts_real.jsonl), 1,024-token answers),
 `vllm bench serve --dataset-name custom`, RTX 3090 at 250 W:
 
+> These are vLLM 0.27.1 baseline measurements. Re-benchmark on a GPU after the
+> v0.28.0 upgrade before using the figures for capacity planning.
+
 **`CTX=fast` + fast variant (the default; 64k context)**, as reproduced by
 `bash bench/run_benchmarks.sh single`:
 
@@ -77,7 +80,8 @@ per step, which is the stable signal.
 is a 5-layer block drafter that predicts 7 tokens in one non-autoregressive
 pass from the target's layer 5/19/33/47/61 hidden states, plus a path selector
 over 16 candidates per slot. It runs on vLLM's V2 model runner through
-`patches/dflash2-backport.patch` (vLLM PR #52816 backported to 0.27.1) with the
+vLLM 0.28.0's native DFlash2 support plus
+`patches/dflash2-lookup-drafting.patch` and `patches/dflash2-ngram-chains.patch` with the
 drafter requantized to W4A16 by this repo (1.19 GB instead of 3.85 GB —
 `drafter/README.md`): per step it reads ~1 GB of drafter plus an 8-token verify,
 26.5 ms vs MTP's 24.8, and accepts 3.2-3.4 tokens per step at default sampling
@@ -296,7 +300,7 @@ attempt that did not help).
 
 k=4 is the fastest but not the default: on the FlashInfer attention backend
 (the only one that supports fp8 KV on Ampere, and fp8 KV is what makes 150k
-context fit) vLLM 0.27.1 dies with an illegal memory access as soon as one
+context fit) the vLLM 0.28.0 FlashInfer path dies with an illegal memory access as soon as one
 request finishes while another is mid-generation with 4 drafts (with or
 without our patches; the vendored PR #50021 bounds fix does not cure it;
 club-3090 sees the same "n=4 eventually dies, n=3 stable" on their rigs, and

--- a/single-user/README.md
+++ b/single-user/README.md
@@ -156,7 +156,7 @@ and draft acceptance is unaffected (2.23 / 2.03 / 2.28 tokens per step with the 
 2.27 / 1.80 / 1.96 without). Worth it for anything conversational; leave it off if you serve
 unrelated one-shot prompts and want the pool.
 
-**Lookup-augmented drafting** (`LOOKUP=1`, on by default for `SPEC=dflash2`) fixes the other
+**Lookup-augmented drafting** (`VLLM_DFLASH2_LOOKUP=1`, on by default for `SPEC=dflash2`) fixes the other
 half. With prefill nearly free, long-context chat is decode-bound, and that is exactly where
 the block drafter is weakest: it sees a 2,048-token window, so when the model quotes or
 reproduces part of a 25k document, the drafter is guessing at text that is sitting verbatim
@@ -246,7 +246,7 @@ without it, and 96.0% with the hold — one question, which is what a 200-questi
 resolves. `bench/labd_soak.py` is the check that matters for the parts of this that are
 decided for the whole batch: it runs a verbatim copy inside a mixed four-way batch and
 insists it comes out the same in every round. Greedy *text* matches on 7 of 9 long prompts against the same server with
-`LOOKUP=0`; the two that differ are near-tie flips of the kind any drafter change produces
+`VLLM_DFLASH2_LOOKUP=0`; the two that differ are near-tie flips of the kind any drafter change produces
 here (the block is one chunk through the recurrent layers, so changing what is in it changes
 the last bits of the logits — gotcha 14), not a change of distribution: the lookup's
 positions carry a point mass, which is a legal proposal for the rejection sampler, and
@@ -384,13 +384,14 @@ included (`tools` + `tool_choice: "auto"` come back as `tool_calls`).
 | `MODEL` | `models/Qwen3.8-27B-W4A16-AutoRound-fast` if present, else the base dir | the fast variant (`prepare/fetch_fast_variant.py`) is +15% |
 | `CTX` | `fast` | `fast`: bf16 KV / FlashAttention / 64k / 4 drafts / split-KV attention. `long`: fp8 KV / FlashInfer / 150k / 3 drafts, ~15% slower at C1, faster from C4 up. `huge`: KVarN 4/2-bit KV / 200k / 3 drafts (needs `bash kvarn/install.sh`; docs/long-context.md) — buys 1.7x the pool for **half the decode rate past ~100k** (32.0 vs 68.1 tok/s at 112k), so take it when the request would not otherwise fit, not for speed |
 | `PREFIX_CACHE` | 0 | 1 = reuse a shared prompt prefix across requests (`--enable-prefix-caching --mamba-cache-mode align`): 20x faster follow-up turns, ~16% smaller KV pool |
-| `LOOKUP` | 1 (`SPEC=dflash2`) | draft from the request's own context when it repeats itself (`patches/dflash2-lookup-drafting.patch`), and fill the verify positions the drafter's block does not reach. `VLLM_DFLASH2_LOOKUP_NMIN` (6) is the shortest suffix that may match, `_NMAX` (12) the longest — the kernel prefers the longest match and breaks ties by recency, so a higher cap makes it choose an older long match over a newer short one, which is the worse predictor — `_NSTRONG` (6) the match length trusted on its own, `_AGREE` (0) how many tokens the drafter must independently agree on for a shorter match to be taken, `_NMIN_TAIL` (4) the same for positions the drafter never proposed, `_ADAPTIVE` (1 = ask the scheduler for the long block only while a copy is running, 0 = always long), `_LONGMIN` (6) the match length that counts as a fillable tail, `_STICKY` (3) steps to hold the long block after the flag drops, with one request in flight only — copies do not end when the flag says so, and re-entry costs two steps, but the counter is batch-wide and holding it across a mixed batch makes the block length depend on when the other requests arrived — `_CHEAP_CTX` (0 = off) a context length below which the long block is taken unconditionally |
+| `VLLM_DFLASH2_LOOKUP` | 1 (`SPEC=dflash2`) | draft from the request's own context when it repeats itself (`patches/dflash2-lookup-drafting.patch`), and fill the verify positions the drafter's block does not reach. `VLLM_DFLASH2_LOOKUP_NMIN` (6) is the shortest suffix that may match, `_NMAX` (12) the longest — the kernel prefers the longest match and breaks ties by recency, so a higher cap makes it choose an older long match over a newer short one, which is the worse predictor — `_NSTRONG` (6) the match length trusted on its own, `_AGREE` (0) how many tokens the drafter must independently agree on for a shorter match to be taken, `_NMIN_TAIL` (4) the same for positions the drafter never proposed, `VLLM_DFLASH2_LOOKUP_ADAPTIVE` (1 = ask the scheduler for the long block only while a copy is running, 0 = always long), `_LONGMIN` (6) the match length that counts as a fillable tail, `_STICKY` (3) steps to hold the long block after the flag drops, with one request in flight only — copies do not end when the flag says so, and re-entry costs two steps, but the counter is batch-wide and holding it across a mixed batch makes the block length depend on when the other requests arrived — `_CHEAP_CTX` (0 = off) a context length below which the long block is taken unconditionally |
 | `SPEC` | `mtp` | `dflash2`: the DFlash2 block drafter (`prepare/fetch_dflash2.py`; `CTX=fast` or `CTX=long`, V2 model runner). `DRAFT` overrides the drafter dir, `DFLASH_TOKENS` (7) the *verify* block — the drafter always proposes the 7 it was trained for, and 15 here is reproduction mode (4 request slots, 56k context) — `DFLASH_MAX_LEN` (65536, or 57344 at `DFLASH_TOKENS=15`) the context, `KV_MEM` (5583457484 = 5.2 GiB) pins the KV pool — set `KV_MEM=` to size it from `GPU_UTIL` instead; `VLLM_DFLASH2_DRAFT_TOPK_TOPP=0` disables the proposal truncation, `VLLM_DFLASH2_TORCH_TOPK=1` avoids the FlashInfer top-k JIT |
 | `DRAFT_TOKENS` | 4 (3 for `CTX=long`/`huge`) | speculative depth; 5 and 6 are slower |
 | `SPEC_ATTN` | 1 (`CTX=fast` only) | split-KV Triton attention for the verify step (`patches/spec-decode-attn.patch`); 0 = FlashAttention-2 |
 | `DRAFT_SAMPLE` | `probabilistic` | `greedy` drafts: same speed at T=0, ~15% slower at T>0 |
 | `MAX_SEQS` | 8 | how many requests are *admitted*, not how many the pool can hold: each resident request needs k+1 recurrent-state slots (0.88 GiB at DFlash2 k=7 — seven residents with short prompts, five at 4k, two at 16k), and the launcher prints the number at boot |
 | `MAX_LEN` | 65536 (`fast`) / 150000 (`long`) | 150k needs `GPU_UTIL` 0.93 |
+| `CHAT_TEMPLATE` | `chat_template-froggeric-v22.4.jinja` | Jinja chat template passed to vLLM; set an absolute path to A/B-test or roll back |
 | `GPU_UTIL` | 0.93 | soak-tested with a 100k prompt and 4×6k-token generations; batch mode's 0.972 OOMs in the MTP path (docs/gotchas.md, gotcha 4) |
 | `MTP_DRAFT_VOCAB` | 1 | set 0 to draft with the full lm_head (more acceptance, slower per draft) |
 | `TOOLS` | 1 | tool/function calling (`--enable-auto-tool-choice --tool-call-parser`). `TOOL_PARSER` (`qwen3_coder`) must match the XML call format this model's chat template emits — `hermes` parses the JSON a Qwen model does *not* produce here, and fails silently. 0 = off, and `tool_choice: "auto"` then 400s |
@@ -398,6 +399,10 @@ included (`tools` + `tool_choice: "auto"` come back as `tool_calls`).
 | `VISION_OFFLOAD` | 1 | with `VISION=1`, keeps the tower's weights in pinned host RAM and copies each module to the GPU for its own forward (`patches/vision-tower-cpu-offload.patch`). **On 24 GB, `SPEC=dflash2` + `VISION=1` does not boot with this off** — the tower is 0.85 GiB of the ~1.1 GiB transient margin, and graph capture OOMs allocating the 960 MiB split-KV verify buffer with 787 MiB free. With it on, the same config comes up at the full 69,758-token pool and reads images. Costs 296 → 333 ms of encode per 8192-patch image, output bit-exact. 0 only on a card with headroom to spare. `VLLM_VISION_CPU_OFFLOAD_GB` (default 1) is the budget in GiB |
 | `REQ_METRICS` | 0 | 1 = `--enable-per-request-metrics --enable-force-include-usage`: per-request timing fields in every response and `usage` on every request, the fields llama-swap's dashboard reads ([#51](https://github.com/syv-ai/qwen38-27b-rtx3090/issues/51)). `prompt_tokens_details.cached_tokens` is always on. Not compatible with `--disable-log-stats` in `EXTRA_ARGS`; vLLM's per-request spec-decode summary flag is nightly-only, not in 0.27.1 |
 | `PORT` | 18020 | |
+
+`LOOKUP` and `LOOKUP_ADAPTIVE` are deprecated compatibility aliases. Use
+`VLLM_DFLASH2_LOOKUP` and `VLLM_DFLASH2_LOOKUP_ADAPTIVE` instead. If both forms are
+set with different values, the launcher exits rather than choosing one silently.
 
 ## Switching modes
 

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -799,13 +799,6 @@ fi
 BATCHED_TOKENS=${MAX_NUM_BATCHED_TOKENS:-2048}
 CUSTOM_OPS=${CUSTOM_OPS:-[\"+rms_norm\",\"+silu_and_mul\"]}
 
-# Keep the default enabled, but do not pass the same argparse key twice when a
-# user's EXTRA_ARGS already carries it (as the Jarvis .env currently does).
-PROMPT_TOKENS_DETAILS_ARGS=(--enable-prompt-tokens-details)
-case " ${EXTRA_ARGS:-} " in
-  *" --enable-prompt-tokens-details "*) PROMPT_TOKENS_DETAILS_ARGS=() ;;
-esac
-
 exec venv/bin/vllm serve "$MODEL" \
   --chat-template "$CHAT_TEMPLATE" \
   --served-model-name qwen3.8-27b \
@@ -822,7 +815,7 @@ exec venv/bin/vllm serve "$MODEL" \
   "${SPEC_ARGS[@]}" \
   --compilation-config "{\"max_cudagraph_capture_size\":$CG,\"custom_ops\":$CUSTOM_OPS${CG_MODE}}" \
   --reasoning-parser qwen3 \
-  "${PROMPT_TOKENS_DETAILS_ARGS[@]}" \
+  --enable-prompt-tokens-details \
   "${METRICS_ARGS[@]}" \
   "${TOOL_ARGS[@]}" \
   "${KV_TRANSFER_ARGS[@]}" \

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -799,6 +799,13 @@ fi
 BATCHED_TOKENS=${MAX_NUM_BATCHED_TOKENS:-2048}
 CUSTOM_OPS=${CUSTOM_OPS:-[\"+rms_norm\",\"+silu_and_mul\"]}
 
+# Keep the default enabled, but do not pass the same argparse key twice when a
+# user's EXTRA_ARGS already carries it (as the Jarvis .env currently does).
+PROMPT_TOKENS_DETAILS_ARGS=(--enable-prompt-tokens-details)
+case " ${EXTRA_ARGS:-} " in
+  *" --enable-prompt-tokens-details "*) PROMPT_TOKENS_DETAILS_ARGS=() ;;
+esac
+
 exec venv/bin/vllm serve "$MODEL" \
   --chat-template "$CHAT_TEMPLATE" \
   --served-model-name qwen3.8-27b \
@@ -815,7 +822,7 @@ exec venv/bin/vllm serve "$MODEL" \
   "${SPEC_ARGS[@]}" \
   --compilation-config "{\"max_cudagraph_capture_size\":$CG,\"custom_ops\":$CUSTOM_OPS${CG_MODE}}" \
   --reasoning-parser qwen3 \
-  --enable-prompt-tokens-details \
+  "${PROMPT_TOKENS_DETAILS_ARGS[@]}" \
   "${METRICS_ARGS[@]}" \
   "${TOOL_ARGS[@]}" \
   "${KV_TRANSFER_ARGS[@]}" \

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -24,7 +24,7 @@
 # CTX=fast (default here): FlashAttention + bf16 KV, 4 drafts, 64k context.
 # CTX=long: fp8 KV via FlashInfer, 150k context, 3 drafts (k=4 crashes on
 #   FlashInfer as soon as one request finishes while another is mid-generation,
-#   vLLM 0.27.1); the split-KV attention patch is bf16-KV only, so ~90/98 tok/s.
+#   vLLM 0.28.0); the split-KV attention patch is bf16-KV only, so ~90/98 tok/s.
 #   KNOW THE EXPOSURE: fp8 KV has exactly ONE backend on sm86 -- FLASH_ATTN
 #   refuses it (needs FA3/SM90+) and TRITON_ATTN refuses it (needs SM89+),
 #   both measured -- so this tier runs FlashInfer with no A/B possible, and
@@ -136,7 +136,7 @@ CTX=${CTX:-fast}
 # SPEC=dflash2: the DFlash2 block drafter (incoai/Qwen3.8-27B-DFlash2, requantized
 #   to W4A16 by this repo: prepare/fetch_dflash2.py), 7 drafts in ONE non-autoregressive
 #   pass + a path selector; runs on vLLM's V2 model runner
-#   (patches/dflash2-backport.patch). CTX=fast (bf16, 64k), CTX=long (int8,
+#   (vLLM 0.28.0 native DFlash2, plus the repo's lookup/chain patches). CTX=fast (bf16, 64k), CTX=long (int8,
 #   128k) or, with kvarn/install.sh, CTX=huge (KVarN 4/2-bit, 240k + prefix
 #   caching); see README "DFlash2".
 # SPEC=off (or none): no speculative decoding at all. This used to fall through
@@ -174,7 +174,7 @@ if [ "$SPEC" = "dflash2" ] && [ "$CTX" = "long" ]; then
   ATTN_ARGS="--attention-backend TRITON_ATTN --kv-cache-dtype int8_per_token_head"
   export VLLM_SPEC_DECODE_ATTN=${SPEC_ATTN:-1}
 elif [ "$SPEC" = "dflash2" ] && [ "$CTX" = "huge" ]; then
-  # KVarN 4/2-bit KV on the V2 runner (kvarn/, with kvarn-v2-runner.patch as its
+  # KVarN 4/2-bit KV on the V2 runner (kvarn/, with kvarn-v2-runner-0.28.0.patch as its
   # second stage): the pinned pool holds 268k tokens at 245760 max-model-len.
   # The split-KV verify attention is bf16-KV only -- the KVarN backend brings
   # its own dequant path, so the env stays off here.
@@ -533,7 +533,7 @@ fi
 # ASYNC_SCHED=0 (set above for a long DFlash2 verify block) runs the scheduler
 # synchronously, which is the only path on which vLLM lets the worker choose how many draft
 # tokens to put up for verification. Note --async-scheduling is already the default in
-# 0.27.1: --no-async-scheduling is what turns it off.
+# 0.28.0: --no-async-scheduling is what turns it off.
 # Array, not $( ... || echo ... ): errexit-safe via the fallback, but the
 # unquoted expansion word-splits; match METRICS_ARGS below.
 ASYNC_ARGS=(--no-async-scheduling)
@@ -552,7 +552,7 @@ ASYNC_ARGS=(--no-async-scheduling)
 # which reads as the model being bad at tools rather than as a misconfigured server.
 # The name is the call format, not the checkpoint -- nothing here is Qwen3-Coder.
 # qwen3_coder, qwen3_xml and mimo are three names for one Qwen3EngineToolParser in
-# 0.27.1, which is the tool-side adapter of the same parser engine that
+# 0.28.0, which is the tool-side adapter of the same parser engine that
 # --reasoning-parser qwen3 already uses (vllm/parser/qwen3.py).
 TOOL_PARSER=${TOOL_PARSER:-qwen3_coder}
 # Array, not $( [ ] && echo ): exits 1 when TOOLS is off (the shape #59 fixed)

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -34,6 +34,9 @@
 #   ships, or for mtp: VLLM_SPEC_DECODE_ATTN=1 EXTRA_ARGS="--attention-backend
 #   =TRITON_ATTN --kv-cache-dtype=int8_per_token_head" at ~25% wall cost at
 #   depth (23.7 vs 18.9 s for 17.9k in + 256 out, measured).
+# CTX=longfp8: DFlash2 + fp8 KV via FlashInfer, 150k context, 3 drafts. This
+#   is the long-context DFlash2 variant; unlike CTX=long it does not use the
+#   custom Triton int8 KV path.
 # CTX=huge: KVarN 4/2-bit KV cache (kvarn/), 200k context with MTP, at roughly
 #   half the decode rate past 100k — see below and docs/long-context.md.
 #
@@ -73,6 +76,7 @@ if [ -z "$MODEL" ] && [ -d "$REPO/models/Qwen3.8-27B-W4A16-AutoRound-fast" ]; th
   MODEL=$REPO/models/Qwen3.8-27B-W4A16-AutoRound-fast
 fi
 MODEL=${MODEL:-$REPO/models/Qwen3.8-27B-W4A16-AutoRound}
+CHAT_TEMPLATE=${CHAT_TEMPLATE:-$REPO/chat_template-froggeric-v22.4.jinja}
 PORT=${PORT:-18020}
 MAX_SEQS=${MAX_SEQS:-}
 # INT8_ACT=int8 turns on the W4A8 Marlin path (weights stay int4, activations
@@ -125,6 +129,12 @@ GPU_UTIL=${GPU_UTIL:-0.93}
 API_SERVERS=${API_SERVERS:-1}
 # CTX=fast (default): bf16 KV via FlashAttention, ~64k context, 4 drafts (~+7%).
 # CTX=long: fp8 KV via FlashInfer, 150k context, 3 drafts.
+
+if [ ! -f "$CHAT_TEMPLATE" ]; then
+  echo "chat template not found: $CHAT_TEMPLATE" >&2
+  exit 1
+fi
+# CTX=longfp8: same FP8/FlashInfer target path, reserved for SPEC=dflash2.
 # CTX=huge: KVarN 4/2-bit KV cache (kvarn/ in this repo, run kvarn/install.sh
 #           once), 200k context with MTP. The decode tax is a function of context,
 #           not a constant: ~6% on short prompts, but 2.13x at 112k (32.0 vs fp8's
@@ -156,6 +166,10 @@ elif [ "$CTX" = "huge" ]; then
   DRAFT_TOKENS=${DRAFT_TOKENS:-3}
   ATTN_ARGS="--kv-cache-dtype kvarn_k4v2_g128 --block-size 128"
   export KVARN_POOL_MEM_FRAC=${KVARN_POOL_MEM_FRAC:-0.15}
+elif [ "$CTX" = "longfp8" ]; then
+  MAX_LEN=${MAX_LEN:-150000}
+  DRAFT_TOKENS=${DRAFT_TOKENS:-3}
+  ATTN_ARGS="--attention-backend FLASHINFER --kv-cache-dtype fp8"
 else
   MAX_LEN=${MAX_LEN:-150000}
   DRAFT_TOKENS=${DRAFT_TOKENS:-3}
@@ -179,8 +193,8 @@ elif [ "$SPEC" = "dflash2" ] && [ "$CTX" = "huge" ]; then
   # The split-KV verify attention is bf16-KV only -- the KVarN backend brings
   # its own dequant path, so the env stays off here.
   export VLLM_SPEC_DECODE_ATTN=0
-elif [ "$SPEC" = "dflash2" ] && [ "$CTX" != "fast" ]; then
-  echo "SPEC=dflash2 supports CTX=fast (bf16, 64k), CTX=long (int8, 128k) and CTX=huge (KVarN, 240k; kvarn/install.sh); CTX=$CTX keeps SPEC=mtp" >&2
+elif [ "$SPEC" = "dflash2" ] && [ "$CTX" != "fast" ] && [ "$CTX" != "longfp8" ]; then
+  echo "SPEC=dflash2 supports CTX=fast (bf16, 64k), CTX=long (int8, 128k), CTX=longfp8 (fp8, 150k) and CTX=huge (KVarN, 240k; kvarn/install.sh); CTX=$CTX keeps SPEC=mtp" >&2
   SPEC=mtp
 fi
 # gotcha 51 / #64: KVarN + MTP + prefix caching, all three, corrupts prompt_logprobs --
@@ -202,8 +216,23 @@ if [ "$SPEC" = "dflash2" ]; then
   [ -n "$DRAFT" ] || { echo "SPEC=dflash2 needs the drafter: venv/bin/python prepare/fetch_dflash2.py" >&2; exit 1; }
   # Lookup-augmented drafting: when the model is reproducing something from its context,
   # draft from the context instead of from the drafter
-  # (patches/dflash2-lookup-drafting.patch).
-  export VLLM_DFLASH2_LOOKUP=${LOOKUP:-1}
+  # (patches/dflash2-lookup-drafting.patch). VLLM_DFLASH2_LOOKUP is the canonical
+  # runtime variable. LOOKUP remains a compatibility alias for older .env files.
+  if [ "${LOOKUP+x}" = x ]; then
+    echo "[start_qwen] LOOKUP is deprecated; use VLLM_DFLASH2_LOOKUP" >&2
+  fi
+  if [ "${VLLM_DFLASH2_LOOKUP+x}" = x ] && [ "${LOOKUP+x}" = x ] \
+     && [ "$VLLM_DFLASH2_LOOKUP" != "$LOOKUP" ]; then
+    echo "LOOKUP and VLLM_DFLASH2_LOOKUP disagree; set only VLLM_DFLASH2_LOOKUP" >&2
+    exit 1
+  fi
+  if [ "${VLLM_DFLASH2_LOOKUP+x}" != x ]; then
+    export VLLM_DFLASH2_LOOKUP="${LOOKUP:-1}"
+  fi
+  case "$VLLM_DFLASH2_LOOKUP" in
+    0|1) ;;
+    *) echo "VLLM_DFLASH2_LOOKUP must be 0 or 1" >&2; exit 1 ;;
+  esac
   # DFLASH_TOKENS is the *verify* block, which no longer has to equal the drafter's: the
   # DFlash2 checkpoint always proposes the 7 tokens it was trained for, and any position
   # past that is filled from the request's own context, costing the drafter nothing. The
@@ -235,7 +264,8 @@ if [ "$SPEC" = "dflash2" ]; then
   # and the constant-length setting is clean at every residue that broke (16/64/96/124),
   # cold and warm, byte-identical.
   #
-  # Note what the earlier controls actually varied: DFLASH_TOKENS=7, LOOKUP=0 and SPEC=mtp
+  # Note what the earlier controls actually varied: DFLASH_TOKENS=7,
+  # VLLM_DFLASH2_LOOKUP=0 and SPEC=mtp
   # all make the block a CONSTANT length, so "clean" there was never evidence about the
   # block being short or the lookup being off. And a wrong draft cannot corrupt greedy
   # output at all -- rejection_sampler.py emits target_argmax whether it accepts or not --
@@ -244,14 +274,36 @@ if [ "$SPEC" = "dflash2" ]; then
   # Pinning the length is not a sacrifice here: 14.71 tok/step is the FASTEST number in the
   # series, above the adaptive path's own 14.29 cold. Root cause still open; this is a
   # correct and fast setting, not a workaround with a cost.
-  if [ -z "${LOOKUP_ADAPTIVE:-}" ] && [ "$VLLM_DFLASH2_LOOKUP" = "1" ] && [ "$DRAFT_TOKENS" -gt 7 ] \
-     && [ "$CTX" = "huge" ] && [ "${PREFIX_CACHE:-0}" = "1" ]; then
-    echo "DFLASH_TOKENS>7 + CTX=huge + PREFIX_CACHE=1: pinning the verify block to" >&2
-    echo "$((DRAFT_TOKENS + 1)) tokens (VLLM_DFLASH2_LOOKUP_ADAPTIVE=0). The adaptive length" >&2
-    echo "corrupts the second turn over a shared prefix on the KVarN cache; pinned is both" >&2
-    echo "correct and faster. LOOKUP_ADAPTIVE=1 asks for the adaptive path anyway." >&2
-    export VLLM_DFLASH2_LOOKUP_ADAPTIVE=0
+  # VLLM_DFLASH2_LOOKUP_ADAPTIVE is canonical. LOOKUP_ADAPTIVE is retained only as a
+  # compatibility alias; unlike the old path, an explicit alias is translated into the
+  # runtime variable instead of merely affecting the huge-mode auto-pin condition.
+  if [ "${LOOKUP_ADAPTIVE+x}" = x ]; then
+    echo "[start_qwen] LOOKUP_ADAPTIVE is deprecated; use VLLM_DFLASH2_LOOKUP_ADAPTIVE" >&2
   fi
+  if [ "${VLLM_DFLASH2_LOOKUP_ADAPTIVE+x}" = x ] \
+     && [ "${LOOKUP_ADAPTIVE+x}" = x ] \
+     && [ "$VLLM_DFLASH2_LOOKUP_ADAPTIVE" != "$LOOKUP_ADAPTIVE" ]; then
+    echo "LOOKUP_ADAPTIVE and VLLM_DFLASH2_LOOKUP_ADAPTIVE disagree; set only the VLLM variable" >&2
+    exit 1
+  fi
+  if [ "${VLLM_DFLASH2_LOOKUP_ADAPTIVE+x}" != x ]; then
+    if [ "${LOOKUP_ADAPTIVE+x}" = x ]; then
+      export VLLM_DFLASH2_LOOKUP_ADAPTIVE="$LOOKUP_ADAPTIVE"
+    elif [ "$VLLM_DFLASH2_LOOKUP" = "1" ] && [ "$DRAFT_TOKENS" -gt 7 ] \
+       && [ "$CTX" = "huge" ] && [ "${PREFIX_CACHE:-0}" = "1" ]; then
+      echo "DFLASH_TOKENS>7 + CTX=huge + PREFIX_CACHE=1: pinning the verify block to" >&2
+      echo "$((DRAFT_TOKENS + 1)) tokens (VLLM_DFLASH2_LOOKUP_ADAPTIVE=0). The adaptive length" >&2
+      echo "corrupts the second turn over a shared prefix on the KVarN cache; pinned is both" >&2
+      echo "correct and faster. Set VLLM_DFLASH2_LOOKUP_ADAPTIVE=1 to force the adaptive path." >&2
+      export VLLM_DFLASH2_LOOKUP_ADAPTIVE=0
+    else
+      export VLLM_DFLASH2_LOOKUP_ADAPTIVE=1
+    fi
+  fi
+  case "$VLLM_DFLASH2_LOOKUP_ADAPTIVE" in
+    0|1) ;;
+    *) echo "VLLM_DFLASH2_LOOKUP_ADAPTIVE must be 0 or 1" >&2; exit 1 ;;
+  esac
   if [ "$VLLM_DFLASH2_LOOKUP" = "1" ] && [ "$DRAFT_TOKENS" -gt 7 ]; then
     # Adaptive block length means the worker tells the scheduler how many draft tokens to
     # put up for verification next step, and vLLM only feeds that back on the synchronous
@@ -345,6 +397,20 @@ if [ "$SPEC" = "dflash2" ]; then
     else
       export VLLM_V2_CUDAGRAPH_MEM_MIB=${VLLM_V2_CUDAGRAPH_MEM_MIB:-1400}
     fi
+  elif [ "$CTX" = "longfp8" ]; then
+    # FP8/FlashInfer keeps the long-context pool at the same 5.2 GiB pin used
+    # by the int8 mode, but avoids the Triton prefill/decode tax. Four slots
+    # leave room for the V2 graphs and the DFlash2 drafter.
+    MAX_SEQS=${MAX_SEQS:-4}
+    MAX_LEN=${DFLASH_MAX_LEN:-150000}
+    KV_MEM=${KV_MEM-5583457484}
+    if [ "$DRAFT_TOKENS" -gt 15 ]; then
+      export VLLM_V2_CUDAGRAPH_MEM_MIB=${VLLM_V2_CUDAGRAPH_MEM_MIB:-2300}
+    elif [ "$DRAFT_TOKENS" -gt 7 ]; then
+      export VLLM_V2_CUDAGRAPH_MEM_MIB=${VLLM_V2_CUDAGRAPH_MEM_MIB:-1900}
+    else
+      export VLLM_V2_CUDAGRAPH_MEM_MIB=${VLLM_V2_CUDAGRAPH_MEM_MIB:-1400}
+    fi
   elif [ "$DRAFT_TOKENS" -gt 7 ]; then
     # 4 slots and 56k instead of 8 and 64k: the aligned state pages and the bigger decode
     # graphs are what the long block costs, and this is where they still fit next to the
@@ -355,7 +421,11 @@ if [ "$SPEC" = "dflash2" ]; then
     # Decode graphs are captured for both block lengths (the drafter's and the full verify
     # block), or the short step -- the common one -- runs piecewise and costs 8%. That is
     # 1.8 GiB of graphs instead of 1.45.
-    export VLLM_V2_CUDAGRAPH_MEM_MIB=${VLLM_V2_CUDAGRAPH_MEM_MIB:-1900}
+    if [ "$DRAFT_TOKENS" -gt 15 ]; then
+      export VLLM_V2_CUDAGRAPH_MEM_MIB=${VLLM_V2_CUDAGRAPH_MEM_MIB:-2300}
+    else
+      export VLLM_V2_CUDAGRAPH_MEM_MIB=${VLLM_V2_CUDAGRAPH_MEM_MIB:-1900}
+    fi
   else
     MAX_LEN=${DFLASH_MAX_LEN:-65536}
     KV_MEM=${KV_MEM-5583457484}
@@ -530,6 +600,73 @@ if [ -n "${CUDAGRAPH_MODE:-}" ] && [ -z "${CG_MODE:-}" ]; then
   CG_MODE=",\"cudagraph_mode\":\"$CUDAGRAPH_MODE\""
 fi
 
+# KV_DISK_CACHE_DIR enables vLLM's native hybrid KV/GDN offload connector.  The
+# filesystem tier is keyed by prefix hashes, so PYTHONHASHSEED must be fixed for
+# a cache to be usable after a process restart.  Keep this opt-in: the normal
+# service still uses the GPU prefix cache only unless this variable is set.
+#
+# DFlash2's hybrid groups contain null/padded blocks.  vLLM 0.28.0's generic
+# transfer path under-counts those blocks when blocks_per_chunk > 1, which can
+# crash a restart during a store flush.  One-block chunks are slower/more
+# numerous on disk, but pass the exact restart test and preserve correctness.
+KV_TRANSFER_ARGS=()
+if [ -n "${KV_DISK_CACHE_DIR:-}" ]; then
+  case "$KV_DISK_CACHE_DIR" in
+    /*) ;;
+    *) echo "KV_DISK_CACHE_DIR must be an absolute in-container path" >&2; exit 1 ;;
+  esac
+  case "${KV_OFFLOAD_CPU_BYTES:-8589934592}" in
+    ''|*[!0-9]*) echo "KV_OFFLOAD_CPU_BYTES must be an integer" >&2; exit 1 ;;
+  esac
+  case "${KV_OFFLOAD_BLOCKS_PER_CHUNK:-1}" in
+    ''|*[!0-9]*|0) echo "KV_OFFLOAD_BLOCKS_PER_CHUNK must be a positive integer" >&2; exit 1 ;;
+  esac
+  case "${KV_OFFLOAD_READ_THREADS:-16}" in
+    ''|*[!0-9]*|0) echo "KV_OFFLOAD_READ_THREADS must be a positive integer" >&2; exit 1 ;;
+  esac
+  case "${KV_OFFLOAD_WRITE_THREADS:-16}" in
+    ''|*[!0-9]*|0) echo "KV_OFFLOAD_WRITE_THREADS must be a positive integer" >&2; exit 1 ;;
+  esac
+  if [ -n "${PYTHONHASHSEED:-}" ] && [ "$PYTHONHASHSEED" != "0" ]; then
+    echo "KV_DISK_CACHE_DIR requires PYTHONHASHSEED=0 for restart-stable prefix hashes" >&2
+    exit 1
+  fi
+  export PYTHONHASHSEED=0
+  export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:False}
+  mkdir -p "$KV_DISK_CACHE_DIR"
+  KV_TRANSFER_CONFIG=$("$REPO/venv/bin/python" - \
+    "$KV_DISK_CACHE_DIR" \
+    "${KV_OFFLOAD_CPU_BYTES:-8589934592}" \
+    "${KV_OFFLOAD_BLOCKS_PER_CHUNK:-1}" \
+    "${KV_OFFLOAD_READ_THREADS:-16}" \
+    "${KV_OFFLOAD_WRITE_THREADS:-16}" <<'PY'
+import json
+import sys
+
+root, cpu_bytes, blocks_per_chunk, read_threads, write_threads = sys.argv[1:]
+config = {
+    "kv_connector": "OffloadingConnector",
+    "kv_role": "kv_both",
+    "kv_load_failure_policy": "recompute",
+    "kv_connector_extra_config": {
+        "cpu_bytes_to_use": int(cpu_bytes),
+        "spec_name": "TieringOffloadingSpec",
+        "blocks_per_chunk": int(blocks_per_chunk),
+        "secondary_tiers": [{
+            "type": "fs",
+            "root_dir": root,
+            "n_read_threads": int(read_threads),
+            "n_write_threads": int(write_threads),
+        }],
+    },
+}
+print(json.dumps(config, separators=(",", ":")))
+PY
+  )
+  KV_TRANSFER_ARGS=(--kv-transfer-config "$KV_TRANSFER_CONFIG")
+  echo "Persistent KV/GDN offload enabled: $KV_DISK_CACHE_DIR (blocks_per_chunk=${KV_OFFLOAD_BLOCKS_PER_CHUNK:-1}, cpu_bytes=${KV_OFFLOAD_CPU_BYTES:-8589934592})" >&2
+fi
+
 # ASYNC_SCHED=0 (set above for a long DFlash2 verify block) runs the scheduler
 # synchronously, which is the only path on which vLLM lets the worker choose how many draft
 # tokens to put up for verification. Note --async-scheduling is already the default in
@@ -659,7 +796,11 @@ if [ -z "$VLLM_API_KEY" ] && [ -f "$REPO/api_key.txt" ]; then
   export VLLM_API_KEY="$(cat "$REPO/api_key.txt")"
 fi
 
+BATCHED_TOKENS=${MAX_NUM_BATCHED_TOKENS:-2048}
+CUSTOM_OPS=${CUSTOM_OPS:-[\"+rms_norm\",\"+silu_and_mul\"]}
+
 exec venv/bin/vllm serve "$MODEL" \
+  --chat-template "$CHAT_TEMPLATE" \
   --served-model-name qwen3.8-27b \
   --host ${HOST:-0.0.0.0} --port $PORT \
   --gpu-memory-utilization $GPU_UTIL \
@@ -670,11 +811,12 @@ exec venv/bin/vllm serve "$MODEL" \
   $ATTN_ARGS \
   --mamba-ssm-cache-dtype float16 \
   "${ASYNC_ARGS[@]}" \
-  --max-num-batched-tokens 2048 \
+  --max-num-batched-tokens "$BATCHED_TOKENS" \
   "${SPEC_ARGS[@]}" \
-  --compilation-config "{\"max_cudagraph_capture_size\":$CG,\"custom_ops\":[\"+rms_norm\",\"+silu_and_mul\"]${CG_MODE}}" \
+  --compilation-config "{\"max_cudagraph_capture_size\":$CG,\"custom_ops\":$CUSTOM_OPS${CG_MODE}}" \
   --reasoning-parser qwen3 \
   --enable-prompt-tokens-details \
   "${METRICS_ARGS[@]}" \
   "${TOOL_ARGS[@]}" \
+  "${KV_TRANSFER_ARGS[@]}" \
   ${EXTRA_ARGS}

--- a/single-user/start_with_warmup.sh
+++ b/single-user/start_with_warmup.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Optional warm-start wrapper for a known long prefix.
+#
+# WARMUP_REQUEST_FILE points to a JSON request consumed by warmup_prefix.py.
+# The normal single-user service does not use this wrapper; docker/entrypoint.sh
+# selects it only when WARMUP_REQUEST_FILE is set.
+set -euo pipefail
+cd /app
+
+warmup_file=$(printenv WARMUP_REQUEST_FILE 2>/dev/null || true)
+if [ -z "$warmup_file" ]; then
+  echo "warm-start: WARMUP_REQUEST_FILE must be set" >&2
+  exit 2
+fi
+
+bash single-user/start_qwen.sh "$@" &
+server_pid=$!
+
+cleanup() {
+  kill "$server_pid" 2>/dev/null || true
+  wait "$server_pid" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+port=$(printenv PORT 2>/dev/null || true)
+[ -n "$port" ] || port=18020
+health_url=$(printenv WARMUP_HEALTH_URL 2>/dev/null || true)
+if [ -z "$health_url" ]; then
+  health_url="http://127.0.0.1:"$port"/health"
+fi
+timeout_s=$(printenv WARMUP_START_TIMEOUT 2>/dev/null || true)
+[ -n "$timeout_s" ] || timeout_s=3600
+started=$(date +%s)
+
+while :; do
+  if curl -fsS "$health_url" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "$server_pid" 2>/dev/null; then
+    echo "warm-start: vLLM exited before becoming healthy" >&2
+    exit 1
+  fi
+  now=$(date +%s)
+  if [ $((now - started)) -ge "$timeout_s" ]; then
+    echo "warm-start: timed out waiting for $health_url" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+/app/venv/bin/python /app/single-user/warmup_prefix.py "$warmup_file"
+touch /tmp/warmup-prefix.done
+echo "warm-start: prefix is resident in the in-memory KV/GDN cache" >&2
+
+trap - EXIT INT TERM
+wait "$server_pid"

--- a/single-user/warmup_prefix.py
+++ b/single-user/warmup_prefix.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Send one exact request to populate vLLM's in-memory hybrid prefix cache.
+
+This is deliberately a warm-start helper, not a disk KV serializer. It is
+safe for the hybrid GDN model because vLLM itself computes and stores the KV
+and recurrent state; after a restart the helper simply pays the prefill once
+before the service is considered ready by the wrapper.
+
+The request file is JSON with this shape:
+
+  {"endpoint": "/v1/chat/completions", "payload": { ... }}
+
+The payload should contain the same long prefix that future requests will
+reuse. The final question/output can be a one-token warm-up request.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.request
+
+
+def api_key() -> str:
+    key = os.environ.get("VLLM_API_KEY", "")
+    if key:
+        return key
+    try:
+        with open("/app/api_key.txt", encoding="utf-8") as f:
+            return f.read().strip()
+    except OSError:
+        return ""
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: warmup_prefix.py REQUEST_JSON", file=sys.stderr)
+        return 2
+
+    request_path = sys.argv[1]
+    with open(request_path, encoding="utf-8") as f:
+        spec = json.load(f)
+
+    endpoint = spec.get("endpoint", "/v1/chat/completions")
+    payload = dict(spec["payload"])
+    payload.setdefault("max_tokens", 1)
+    payload.setdefault("temperature", 0)
+    payload["stream"] = False
+
+    base = os.environ.get(
+        "WARMUP_API", f"http://127.0.0.1:{os.environ.get('PORT', '18020')}"
+    )
+    url = base.rstrip("/") + "/" + endpoint.lstrip("/")
+    headers = {"Content-Type": "application/json"}
+    if key := api_key():
+        headers["Authorization"] = f"Bearer {key}"
+
+    started = time.perf_counter()
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(
+        request, timeout=float(os.environ.get("WARMUP_REQUEST_TIMEOUT", "3600"))
+    ) as response:
+        body = json.load(response)
+
+    usage = body.get("usage", {}) if isinstance(body, dict) else {}
+    elapsed = time.perf_counter() - started
+    print(
+        "warmup prefix complete: "
+        f"prompt_tokens={usage.get('prompt_tokens', '?')} "
+        f"elapsed={elapsed:.2f}s",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verify.sh
+++ b/verify.sh
@@ -20,8 +20,18 @@ warn() { printf "  WARN  %s\n" "$1"; }
 fail() { printf "  FAIL  %s\n" "$1"; FAILS=$((FAILS+1)); }
 MODEL=${MODEL:-$HERE/models/Qwen3.8-27B-W4A16-AutoRound}
 PY=${PY:-$HERE/venv/bin/python}
+CHAT_TEMPLATE=${CHAT_TEMPLATE:-$HERE/chat_template-froggeric-v22.4.jinja}
 
 echo "== environment"
+if [ -f "$CHAT_TEMPLATE" ]; then
+  if grep -q 'template_version = "qwen3.8-froggeric-v22.4"' "$CHAT_TEMPLATE"; then
+    ok "chat template: $CHAT_TEMPLATE (Froggeric v22.4)"
+  else
+    ok "chat template: $CHAT_TEMPLATE (custom)"
+  fi
+else
+  fail "missing chat template: $CHAT_TEMPLATE"
+fi
 [ -x "$PY" ] && ok "python: $PY" || { fail "no $PY (see README Setup)"; exit 1; }
 VER=$($PY -c "import vllm; print(vllm.__version__)" 2>/dev/null | tail -n1)
 [ "$VER" = "0.28.0" ] && ok "vllm $VER" || warn "vllm ${VER:-missing} (patches were written against 0.28.0)"

--- a/verify.sh
+++ b/verify.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Check that this repo is installed the way the README numbers assume:
-# venv + vLLM version, every patch applied, the model requantized (lm_head,
+# venv + vLLM version, every compatible patch applied, the model requantized (lm_head,
 # embed_tokens, MTP module, draft head), keys/files present, and — if a
 # server is running — that it answers and which backend/pool it came up with.
 #
@@ -24,7 +24,7 @@ PY=${PY:-$HERE/venv/bin/python}
 echo "== environment"
 [ -x "$PY" ] && ok "python: $PY" || { fail "no $PY (see README Setup)"; exit 1; }
 VER=$($PY -c "import vllm; print(vllm.__version__)" 2>/dev/null | tail -n1)
-[ "$VER" = "0.27.1" ] && ok "vllm $VER" || warn "vllm ${VER:-missing} (patches were written against 0.27.1)"
+[ "$VER" = "0.28.0" ] && ok "vllm $VER" || warn "vllm ${VER:-missing} (patches were written against 0.28.0)"
 SP=$($PY -c "import vllm, os; print(os.path.dirname(vllm.__file__))" 2>/dev/null | tail -n1)
 [ -n "$SP" ] && [ -d "$SP" ] && ok "vllm package at $SP" || { fail "cannot import vllm with $PY"; exit 1; }
 if [ $INSTALL = 0 ]; then
@@ -61,6 +61,10 @@ superseded_by() {
 # The reverse dry-run is exact, but two patches touching the same file (the DFlash2 pair)
 # can no longer be reversed individually once both are applied; then look for their content.
 for p in patches/*.patch; do
+  if [ "$(basename "$p")" = "dflash2-backport.patch" ]; then
+    ok "dflash2-backport.patch retired (DFlash2 is native in vLLM 0.28.0)"
+    continue
+  fi
   if patch -p1 -R --dry-run -s -d "$SP" < "$p" >/dev/null 2>&1; then ok "$(basename $p) applied"
   elif $PY patches/_check_applied.py "$p" "$SP" 2>/dev/null; then ok "$(basename $p) applied (content check; hunks overlap another patch)"
   elif s=$(superseded_by "$(basename $p)"); then ok "$(basename $p) applied (superseded by $s, which is applied)"
@@ -71,12 +75,12 @@ grep -q "VLLM_MARLIN_INT8_INCLUDE_RE" "$SP/envs.py" 2>/dev/null && ok "int8 laye
 
 echo "== KVarN (optional, kvarn/)"
 if [ -f "$SP/v1/attention/backends/kvarn_attn.py" ]; then
-  if patch -p1 -R --dry-run -s -d "$SP" < kvarn/kvarn-0.27.1.patch >/dev/null 2>&1; then
+  if patch -p1 -R --dry-run -s -d "$SP" < kvarn/kvarn-0.28.0.patch >/dev/null 2>&1; then
     $PY -c "from vllm.v1.attention.backends.registry import AttentionBackendEnum; AttentionBackendEnum.KVARN.get_class()" 2>/dev/null && ok "KVarN backend importable, patch applied (KV=kvarn / CTX=huge available)" || fail "KVarN files present but backend does not import"
-  else fail "KVarN modules present but kvarn-0.27.1.patch not applied (bash kvarn/install.sh)"; fi
-  if $PY patches/_check_applied.py kvarn/kvarn-v2-runner.patch "$SP" >/dev/null 2>&1; then
-    ok "kvarn-v2-runner.patch applied (SPEC=dflash2 + CTX=huge available)"
-  else warn "kvarn-v2-runner.patch not applied (re-run bash kvarn/install.sh for DFlash2 at 240k)"; fi
+  else fail "KVarN modules present but kvarn-0.28.0.patch not applied (bash kvarn/install.sh)"; fi
+  if $PY patches/_check_applied.py kvarn/kvarn-v2-runner-0.28.0.patch "$SP" >/dev/null 2>&1; then
+    ok "kvarn-v2-runner-0.28.0.patch applied (SPEC=dflash2 + CTX=huge available)"
+  else warn "kvarn-v2-runner-0.28.0.patch not applied (re-run bash kvarn/install.sh for DFlash2 at 240k)"; fi
 else warn "KVarN not installed (optional; bash kvarn/install.sh for 262k context)"; fi
 
 if [ $INSTALL = 0 ]; then
@@ -148,7 +152,7 @@ fi
 echo "== single-user DFlash2 drafter (optional, SPEC=dflash2)"
 if [ -f "$HERE/models/Qwen3.8-27B-DFlash2-W4A16/config.json" ]; then
   $PY -c "import json,sys; c=json.load(open('$HERE/models/Qwen3.8-27B-DFlash2-W4A16/config.json')); assert c['architectures']==['DFlash2DraftModel'] and c['quantization_config']['quant_method']=='compressed-tensors'" 2>/dev/null && ok "DFlash2 drafter present, W4A16 (models/Qwen3.8-27B-DFlash2-W4A16)" || fail "models/Qwen3.8-27B-DFlash2-W4A16 is not a quantized DFlash2DraftModel checkpoint"
-  [ -f "$SP/model_executor/models/qwen3_dflash2.py" ] || fail "DFlash2 drafter present but patches/dflash2-backport.patch not applied"
+  [ -f "$SP/model_executor/models/qwen3_dflash2.py" ] || fail "DFlash2 drafter present but vLLM 0.28.0 native DFlash2 support is missing"
 elif [ -f "$HERE/models/Qwen3.8-27B-DFlash2/config.json" ]; then warn "only the bf16 DFlash2 drafter is present (3.85 GB; venv/bin/python prepare/fetch_dflash2.py for the 1 GB W4A16 one)"
 else warn "no DFlash2 drafter (venv/bin/python prepare/fetch_dflash2.py; SPEC=dflash2 single-user mode needs it)"; fi
 


### PR DESCRIPTION
Stacked on #43: this branch is #43's current head (e34afaf) plus one commit.

1. **What it carries.** The second `attention.py` hunk of the 0.27.1 `kvarn/kvarn-v2-runner.patch`, restored inside `kvarn/kvarn-v2-runner-0.28.0.patch`. For KVarN cache dtypes on a hybrid model without skip layers it pads the DFlash drafter's sliding-window pages to the mamba page (`shared_page = cache_config.mamba_page_size_padded`). The attribute exists in 0.28.0 core. The condition is gated on the kvarn dtype, so it is a no-op for int4, int8 and bf16.

2. **What it fixes.** On #43 as filed, KVarN + DFlash2 collapses into repetition ("duct Register Register ...") from the second turn of a conversation, on two machines (an RTX 4090 under WSL2 and a native RTX 3090), at every draft width tried (1, 3, 7, 15), with prefix caching on or off. KVarN + MTP and KVarN with speculation off are unaffected, and the 0.27.1 fork passes the same cell 18/18 on both machines. The installed `kvarn_attn.py` is byte-identical between the two builds, so the regression is in what the runner feeds KVarN. A hunk-by-hunk census of the two runner patches found exactly one hunk missing, this one; it has been absent since the first 0.28 commit regenerated the patch.

3. **Why it breaks.** Without the hunk the drafter's sliding-window spec starts at a 16-token block with a 65,536-byte page. The block-promotion step then grows it to a 544-token block with a 2,228,224-byte page, which becomes the new maximum page for every group, and unification pads the KVarN target spec up to it (400,384 bytes more per manager block). Core allocation walks by that padded page while KVarN's packed view and flush lifecycle walk by seventeen 128-token tiles, so block ownership and byte ownership diverge and a later flush overwrites bytes the target still addresses as another block. With the hunk the drafter's page equals the mamba page from the start, it is excluded from promotion, and the two views stay identical. The boot-time line "Disabling fine-grained prefix-cache hits ... SlidingWindowManager" is a symptom of the same geometry and disappears with the fix.

4. **How it was verified.** Twelve-turn tool-using conversation (flightbench mission v6.1, thinking off, 900-token reply cap), KVarN k4v2 + DFlash2 k=7:
   - RTX 4090, WSL2: as filed 6-9/18 over three runs with 9-11 of 12 replies cut at the cap; hunk applied at boot 16/18 and 11/18 with no reply cut; this branch built on e34afaf 14/18 with no reply cut, and 14/18 with `PREFIX_CACHE=0`; int4 + DFlash2 on this branch 15/18, unchanged.
   - RTX 3090, native: as filed 3/18 with 10 of 12 replies cut; hunk restored 15/18 with no reply cut and none capped, and 15/18 with `PREFIX_CACHE=0`; KVarN + MTP 15/18 on the same box.
   - `bench/residue_sweep.py`, all 128 residues, KVarN + DFlash2 k=7 (RTX 4090): as filed, 46 of 46 residues broken before the run was stopped (coverage 0.00, mostly 2,695 characters of repetition, 2.7 minutes per residue); with the hunk, 0 of 128 broken, coverage 1.00, one identical 834-character answer on all 128.
   The full cell-by-cell record, including every knob that did not heal it: https://github.com/cpuchip/qwen38-27b-rtx3090/blob/v0.28-validation/docs/v0.28-validation.md

5. **Not in scope.** On the port, about half the turns of a tool-using conversation hit the tool-call cap on every tier, drafter or not (bf16 with speculation off: 9 of 12 turns), and prefix caching off removes it; not present on 0.27.1. Documented in the write-up as a separate regression.
