### PR TITLE
docs: improve Windows/WSL2 onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,67 @@
+# Copy this file to .env before starting Docker Compose.
+# .env is ignored by git so local keys and tuning changes stay out of commits.
+
+# Speed-first single-user config for a local RTX 3090.
+# This is the repo's recommended default for best speed when the card is yours alone.
+SPEC=dflash2
+PREFIX_CACHE=1
+
+# Optional toggles kept commented out for easy activation later.
+# Uncomment ONLY when you need the behaviour below.
+
+# DFLASH_TOKENS=15
+# Use when the model is reproducing or quoting a long prompt/document/code block.
+# This is the "copy/edit/quote" mode: much faster when the answer is reusing context,
+# but it reduces request slots and context headroom compared with the default 7-token verify block.
+# Typical use: long docs, code edits, RAG with quoting, prompt-copy workloads.
+
+# CTX=long
+# Use when you need about 150k context and are willing to trade speed for more tokens.
+# Slower than the default speed mode; good for longer chats or long prompts, not the fastest profile.
+
+# CTX=huge
+# Use only after running: bash kvarn/install.sh in a Linux shell with bash available.
+# This is the maximum-context KVarN profile for 200k+ context; it is slower and not the speed winner.
+# Best for genuinely long prompts where the context window matters more than decode rate.
+
+# SPEC=dflash2 is the default, so this is enabled in the template for Docker Desktop/WSL2.
+# Native Linux can leave it enabled; WSL2 needs it or the V2 runner aborts with UVA errors.
+VLLM_WSL2_ENABLE_PIN_MEMORY=1
+
+# GPU_UTIL=0.93
+# WSL2 fallback for startup memory headroom; default for this repo's single-user path is 0.93.
+# Uncomment only if WSL/Docker is tight and the server refuses to boot on Windows/WSL2.
+
+# MAX_SEQS=8
+# Leave alone unless you understand the state-pool/capacity tradeoff.
+# In this repo, the real limit is the resident-state pool, not MAX_SEQS; for local speed mode, keep the default.
+
+# INT8_ACT=int8
+# Only for extra prefill speed in some workloads; not the main speed knob for single-user decode.
+# Best used if you care about prompt-side throughput and are okay with the tradeoff.
+
+# PREFILL_ATTN=int8
+# Companion to INT8_ACT for prefill optimization on a few long prompts.
+# Useful for heavy prompt workloads; not generally needed for normal chat/coding sessions.
+
+# SPEC_ATTN=1
+# Split-KV attention for the MTP verify step on CTX=fast.
+# Leave default unless you specifically want to tune the MTP attention path.
+
+# LOOKUP=1
+# DFlash2 lookup-augmented drafting.
+# Leave enabled unless you are debugging DFlash2 drafting behavior.
+
+# VLLM_API_KEY=replace-with-random-key
+# Optional for local-only use. Set a real random key before exposing the server beyond this machine.
+
+# FAST_VARIANT=0
+# Uncomment only if you want to skip the extra fast-variant download during the first boot.
+# This is a lighter first-time setup and can help on constrained hosts, but it gives up the faster variant.
+
+# PORT=18020
+# Change only if you need to avoid a local port conflict.
+
+# MAX_LEN=65536
+# Override only if you intentionally want a different context ceiling for the active profile.
+# The defaults are chosen for the profile in [single-user/start_qwen.sh](single-user/start_qwen.sh).

--- a/README.md
+++ b/README.md
@@ -18,9 +18,18 @@ on port 18020. Pick a mode — one GPU serves one at a time:
 ```bash
 git clone https://github.com/syv-ai/qwen38-27b-rtx3090 && cd qwen38-27b-rtx3090
 
+cp .env.example .env                 # Linux / WSL
+# PowerShell: Copy-Item .env.example .env
+
 docker compose --profile single up -d    # one or a few people chatting
 docker compose --profile batch  up -d    # API backend, many concurrent requests
 ```
+
+The example uses the recommended single-user `SPEC=dflash2` profile. If Docker
+Desktop is using WSL2, keep `VLLM_WSL2_ENABLE_PIN_MEMORY=1` enabled in `.env` or
+the V2 runner will abort with `RuntimeError: UVA is not available`. The example
+leaves API-key authentication disabled for local-only use; set `VLLM_API_KEY`
+before exposing the server beyond this machine.
 
 | | `--profile batch` → [batch/](batch/) | `--profile single` → [single-user/](single-user/) |
 |---|---|---|

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -15,10 +15,17 @@ configured as a runtime. The 250 W power limit is a host setting
 
 ```bash
 git clone https://github.com/syv-ai/qwen38-27b-rtx3090 && cd qwen38-27b-rtx3090
-echo "VLLM_API_KEY=$(openssl rand -hex 24)" > .env   # all knobs live in .env (gitignored)
+cp .env.example .env                              # all knobs live in .env (gitignored)
+# PowerShell: Copy-Item .env.example .env
+# Set VLLM_API_KEY in .env before exposing the server beyond this machine.
 docker compose --profile single up -d               # or --profile batch
 docker compose logs -f single
 ```
+
+The example enables the repo's recommended single-user DFlash2 profile. On
+Docker Desktop with WSL2, leave `VLLM_WSL2_ENABLE_PIN_MEMORY=1` enabled; it is
+required by the V2 runner before model loading begins. The detailed failure
+signature and other WSL2 workarounds are below.
 
 **The image is prebuilt**: every push to `main` builds and pushes
 `ghcr.io/syv-ai/qwen38-27b-rtx3090:latest` (plus an immutable `sha-<7>` tag

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -177,3 +177,34 @@ hard abort rather than a tuning question:
      kernel**, and that ninja build can fail here. `EXTRA_ARGS="--kv-cache-dtype
      auto"` sidesteps it — `EXTRA_ARGS` is last on the command line, so it wins
      over `KV_ARGS`.
+
+6. **Windows host memory can kill the CPU-only prepare step.** An exit 137 while
+   `prepare/quant_lm_head.py` is running, with little VRAM in use, is WSL/Docker
+   host-memory pressure rather than a GPU OOM. Give WSL enough memory and swap in
+   `%USERPROFILE%\\.wslconfig`, for example:
+
+   ```ini
+   [wsl2]
+   memory=20GB
+   swap=8GB
+   processors=8
+   ```
+
+   Run `wsl --shutdown` after changing the file, then restart Docker Desktop.
+   If the first preparation still exceeds the available host memory, set
+   `FAST_VARIANT=0` in `.env` to skip the optional ~1 GB fast-variant download;
+   this reduces the first-boot footprint but does not change the base model.
+
+   Keep Linux venv files on WSL's native filesystem when the checkout is under
+   `/mnt/c`. Some Ubuntu/DrvFs combinations fail during `python3 -m venv venv`
+   with an `ensurepip` or `Operation not permitted` error. Create the venv under
+   `$HOME` and link it into the checkout instead:
+
+   ```bash
+   python3 -m venv "$HOME/qwen38-venv"
+   ln -s "$HOME/qwen38-venv" venv
+   ```
+
+   The model directory may remain on the Windows-mounted checkout; only the
+   Linux venv needs native WSL storage. This workaround is for the manual WSL
+   venv path. The prebuilt Docker image already contains its own venv.


### PR DESCRIPTION
## Summary

- add a sanitized `.env.example` with the recommended single-user settings and WSL2 pin-memory requirement
- show Linux/WSL and PowerShell first-run setup in the quick-start docs
- surface the `VLLM_WSL2_ENABLE_PIN_MEMORY=1` requirement before Docker startup
- document Windows WSL/Docker host-memory and `/mnt/c` venv workarounds

## Motivation

New Windows users can otherwise hit `RuntimeError: UVA is not available` during DFlash2 startup or host-memory/DrvFs failures during preparation. The template contains no secrets; `.env` remains gitignored.

The WSL2 guidance was tested against the Docker Desktop setup used by this repository.