### PR TITLE
dflash2-z-adaptive-emitted: keep the code, fix the comment that contradicts it

### DIFF
--- a/patches/dflash2-z-adaptive-emitted.patch
+++ b/patches/dflash2-z-adaptive-emitted.patch
@@ -1,21 +1,26 @@
-diff --git a/v1/worker/gpu/spec_decode/dflash/speculator.py b/v1/worker/gpu/spec_decode/dflash/speculator.py
-index 1bd78be21..0556bcbb4 100644
---- a/v1/worker/gpu/spec_decode/dflash/speculator.py
-+++ b/v1/worker/gpu/spec_decode/dflash/speculator.py
-@@ -362,7 +362,7 @@ class DFlashSpeculator(DraftModelSpeculator):
-         # sampling slots it was given (bonus + drafts), num_rejected how many of those were
-         # thrown away, so the difference is the tokens it emitted. dflash2/lookup.py decides
-         # the next block length from it.
+--- a/v1/worker/gpu/spec_decode/dflash/speculator.py	2026-09-05 00:21:38.703248441 +0000
++++ b/v1/worker/gpu/spec_decode/dflash/speculator.py	2026-09-05 00:21:38.735250379 +0000
+@@ -358,11 +358,12 @@
+         is_profile: bool = False,
+     ) -> torch.Tensor:
+         num_reqs = input_batch.num_reqs
+-        # What the step that just ran actually produced per request: num_sampled counts the
+-        # sampling slots it was given (bonus + drafts), num_rejected how many of those were
+-        # thrown away, so the difference is the tokens it emitted. dflash2/lookup.py decides
+-        # the next block length from it.
 -        self.last_num_emitted = (num_sampled - num_rejected) if num_sampled is not None else None
++        # What the step that just ran actually produced per request. num_sampled is the
++        # count the sampler EMITTED (bonus + accepted drafts): input_batch.py defines
++        # num_rejected = num_logits - num_sampled, so subtracting num_rejected here would
++        # double-count the rejections. dflash2/lookup.py decides the next block length
++        # from this number.
 +        self.last_num_emitted = num_sampled if num_sampled is not None else None
          num_target_tokens = input_batch.num_tokens
          num_query_tokens = num_reqs * self.num_query_per_req
          max_seq_len = input_batch.seq_lens_cpu_upper_bound[:num_reqs].max().item()
-diff --git a/v1/worker/gpu/spec_decode/dflash2/speculator.py b/v1/worker/gpu/spec_decode/dflash2/speculator.py
-index 1371aab30..ac0d41df0 100644
---- a/v1/worker/gpu/spec_decode/dflash2/speculator.py
-+++ b/v1/worker/gpu/spec_decode/dflash2/speculator.py
-@@ -516,9 +516,7 @@ class DFlash2Speculator(DFlashSpeculator):
+--- a/v1/worker/gpu/spec_decode/dflash2/speculator.py	2026-09-05 00:21:38.707248685 +0000
++++ b/v1/worker/gpu/spec_decode/dflash2/speculator.py	2026-09-05 00:21:38.735250379 +0000
+@@ -519,9 +519,7 @@
          self.draft_max_seq_len = min(
              max_seq_len + self.num_query_per_req, self.max_model_len
          )


### PR DESCRIPTION
Keeps the code in `dflash2-z-adaptive-emitted.patch` and fixes the comment that contradicts it. Follows from #73, where you said the patch should be re-justified or dropped on its own merits and that you would take a PR either way.

**The code is right and the comment is wrong, on both engines.** `v1/worker/gpu/input_batch.py` defines the counters the same way on 0.27.1 and 0.28:

```python
num_rejected = num_logits - num_sampled
```

So `num_sampled` is the count the sampler emitted, bonus plus accepted drafts, and `num_rejected` is the slots it did not fill. The comment says the opposite, that `num_sampled` counts the slots given and the difference is what was emitted. Under the true definitions the 0.27.1 formula `num_sampled - num_rejected` works out to twice the emitted count minus the slot count, which double-subtracts every rejection. The patch replaced that with `num_sampled`, which is the emitted count, so the commit title "Fix DFlash2 adaptive accepted-token accounting" was accurate and the comment above it was stale from the day the formula was first written.

This PR changes the comment to state the definitions and why the subtraction is wrong, and leaves both code hunks as they are. The regenerated patch applies cleanly to a pristine 0.28.0 tree with the rest of the series and reproduces the same source, plus five comment lines.

**On the 2.66 to 2.79 you measured from reversing it.** Reversing reintroduces the double subtraction, which feeds the block-length policy an emitted count that is too low, so the long block is entered less often. On your cohort that scored higher. That is a real effect and it is worth having, but it is a tuning result reached by feeding the policy a wrong number, and it will move the moment acceptance changes for any other reason. The band analysis from #73 says the same thing from the other side: the two formulas disagree only on steps that sample at least eight tokens and reject enough to fall back under eight, so the gain is confined to workloads that live in the long block. If shorter blocks are better for your cohort, the honest way to get them is the policy's own threshold, which is `1 + draft_block` in `next_num_draft_tokens`, exposed as a knob or raised by one. I have not measured that and would not merge a threshold change on this evidence; I am naming it so the 0.13 does not get chased through the accounting again.

Runtime-verified on the 3090 side of the earlier work: the predicate reads the corrected value on 98 of 99 steps identically under either formula on a short prompt, which is why single-prompt cells could not see this patch at all.
