### PR TITLE
dspark: loader patch for a bf16 DSpark drafter beside the quantized target; DRAFT_METHOD; README

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,20 @@ name: `VLLM_WSL_PIN_MEMORY` is **not** a vLLM variable and setting it does
 nothing — this README named it for 22 minutes on 2026-08-21 (`589daae`, fixed in
 `27f51fa`), so a tree cloned in that window will have it.
 
+**Running a DSpark drafter.** vLLM 0.28.0 can serve RadixArk/Qwen3.8-27B-DSpark
+(bf16, seven drafts per step like the shipped head) once two things are in
+place: `patches/dspark-draft-quant-config.patch` (the loader refuses a bf16
+drafter beside the quantized target without it), and a copy of the checkpoint
+whose `config.json` names the architecture `Qwen3DSparkModel` instead of
+`DSparkDraftModel` (the registry maps the published name to the DeepSeek V4
+class; the weights are unchanged, so hard-link the safetensors). Then
+`DRAFT=/path/to/that/copy DRAFT_METHOD=dspark KV_MEM=3000000000
+DFLASH_MAX_LEN=8192 SPEC=dflash2 CTX=fast bash single-user/start_qwen.sh`. It
+serves, and loses to the shipped head on the same requests: 3.19 against 3.77
+accepted tokens per step and 115 against 160 tok/s on a 4090, 3.37 against 3.83
+and 114 against 150 on a 3090 (issue #25, items 15 and 16). Documented so nobody
+re-derives the two errors, not as a recommendation.
+
 One knob this mode used to set for you, and now sets only for MTP:
 `cudagraph_mode=PIECEWISE`. Prefix caching and a *captured* (FULL) verify step
 did not mix on this path. On WSL2 that showed up as acceptance collapsing to

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ class; the weights are unchanged, so hard-link the safetensors). Then
 `DRAFT=/path/to/that/copy DRAFT_METHOD=dspark KV_MEM=3000000000
 DFLASH_MAX_LEN=8192 SPEC=dflash2 CTX=fast bash single-user/start_qwen.sh`. It
 serves, and loses to the shipped head on the same requests: 3.19 against 3.77
-accepted tokens per step and 115 against 160 tok/s on a 4090, 3.37 against 3.83
+tokens per step (accepted drafts plus the bonus token) and 115 against 160 tok/s on a 4090, 3.37 against 3.83
 and 114 against 150 on a 3090 (issue #25, items 15 and 16). Documented so nobody
 re-derives the two errors, not as a recommendation.
 

--- a/patches/dspark-draft-quant-config.patch
+++ b/patches/dspark-draft-quant-config.patch
@@ -1,0 +1,32 @@
+Let a bf16 DSpark drafter load beside a quantized target.
+
+get_draft_quant_config asks for the draft's quantization config through the
+target's hf_overrides. SpeculativeConfig composes those overrides as a callable
+for the DFlash family, and get_quant_config refuses a callable ("hf_overrides
+must be a dict"), so a bf16 DSpark head beside the W4A16 target dies at load
+before any weight is read. The draft carries no quantization_config of its own,
+so there is nothing to look up: return None in that case.
+
+The second thing a published Qwen3 DSpark checkpoint needs is not a patch: vLLM
+0.28.0's model registry maps the architecture name "DSparkDraftModel" (which
+RadixArk/Qwen3.8-27B-DSpark declares) to the DeepSeek V4 DSpark class and
+registers the Qwen3 class as "Qwen3DSparkModel", so the drafter is built against
+the wrong model and dies on a DeepSeek-only field. A copy of the checkpoint whose
+config.json names Qwen3DSparkModel loads; see the README's DSpark paragraph.
+
+Apply from the installed vllm package directory:
+  patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/dspark-draft-quant-config.patch
+
+Validated against vLLM 0.28.0 (issue #25, item 15). Reapply after upgrades.
+
+--- a/model_executor/models/utils.py	2026-09-05 17:22:45.731599800 -0500
++++ b/model_executor/models/utils.py	2026-09-05 17:22:46.075505600 -0500
+@@ -897,7 +897,7 @@
+ 
+     return (
+         VllmConfig.get_quantization_config(draft_model_config, draft_load_config)
+-        if draft_model_config
++        if draft_model_config and getattr(draft_model_config.hf_config, "quantization_config", None) is not None
+         else None
+     )
+ 

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -224,7 +224,10 @@ if [ "$SPEC" = "dflash2" ]; then
   # reference 3090, CTX=fast k=15: 2.66 tok/step and 101.4 tok/s unset against 3.23 and
   # 121.7 set, with 3.19/120.5 on 0.27.1. The boot log says which you got: draft_logits.
   # The mtp branch below has always set it.
-  SPEC_CFG="{\"method\":\"dflash\",\"model\":\"$DRAFT\",\"num_speculative_tokens\":$DRAFT_TOKENS,\"draft_sample_method\":\"${DRAFT_SAMPLE:-probabilistic}\"}"
+  # DRAFT_METHOD=dspark runs a DSpark drafter (RadixArk/Qwen3.8-27B-DSpark, seven drafts per
+  # step like the shipped head) through the same profile; it needs
+  # patches/dspark-draft-quant-config.patch and the architecture rename in the README.
+  SPEC_CFG="{\"method\":\"${DRAFT_METHOD:-dflash}\",\"model\":\"$DRAFT\",\"num_speculative_tokens\":$DRAFT_TOKENS,\"draft_sample_method\":\"${DRAFT_SAMPLE:-probabilistic}\"}"
   # The split-KV verify attention (patches/spec-decode-attn.patch) sizes its partial
   # buffers once for the longest query block it will see -- a captured CUDA graph holds
   # their addresses, so they must not be grown later.


### PR DESCRIPTION
1. `patches/dspark-draft-quant-config.patch`: one hunk in vLLM 0.28.0's `model_executor/models/utils.py`. The loader asks for the draft's quantization config through the target's `hf_overrides`, which `SpeculativeConfig` composes as a callable for the DFlash family, and `get_quant_config` refuses a callable, so a bf16 DSpark drafter beside the W4A16 target dies at load. The draft carries no `quantization_config`, so the patch returns None in that case. Header in the style of the other patches; `_check_applied.py` sees it.
2. `DRAFT_METHOD` in the launcher (default `dflash`, unchanged behaviour), so running a DSpark drafter is an environment variable rather than an edit of the `SPEC_CFG` line.
3. A README paragraph on what a published Qwen3 DSpark checkpoint needs: this patch, and a copy whose `config.json` names `Qwen3DSparkModel` (the registry maps the published architecture name `DSparkDraftModel` to the DeepSeek V4 class, which is upstream's to fix, not a patch here). It says the drafter loses to the shipped head on the same requests, so it is documentation, not a recommendation.

Checked in the container image on an RTX 4090: the patch dry-runs and applies to the installed tree, `patches/_check_applied.py` reports it present, and the launcher with `DRAFT=<renamed copy> DRAFT_METHOD=dspark KV_MEM=3000000000 DFLASH_MAX_LEN=8192` boots to health in 270 s with `method: dspark` in the engine's args, serves a coherent 120-token completion, and reports 36 drafts, 252 draft tokens, 89 accepted on it. The measurements behind the README's numbers are in issue #25 (items 15 and 16).

Wording: "tokens per step" in the README paragraph counts accepted drafts plus the bonus token, the usual speculative-decoding figure.
