### PR TITLE
Backport vLLM #54282: decouple the draft's Gumbel noise from the target's

### DIFF
--- a/patches/vllm-pr54282-draft-gumbel-salt.patch
+++ b/patches/vllm-pr54282-draft-gumbel-salt.patch
@@ -1,0 +1,405 @@
+Backport of vLLM PR #54282 (commit fe755c889, "Decouple the draft's gumbel noise stream
+from the target's", Aug 29 2026) onto 0.28.0 plus this repo's patch set.
+
+With draft_sample_method=probabilistic, the Gumbel noise that re-samples a rejected draft
+token was drawn from the same Philox offset (seed, position) as the noise that produced
+that draft token, so the verifier's draw was correlated with the draft's and the accepted
+stream was biased toward the drafter. The fix salts the draft's offset (1 << 30) so the
+two streams are independent, and moves the "position before the sampled token"
+convention out of sample_draft into each speculator call site. Greedy draft sampling
+never calls gumbel_sample for drafts and is unaffected.
+
+Upstream's test tests/v1/spec_decode/test_rejection_sampler_utils.py::
+test_gumbel_drafted_rejection_sample_is_unbiased fails on this tree before the patch and
+passes after it (shipped image, RTX 4090). The DFlash2 candidate-selector hunk did not
+apply against this tree (dflash2-lookup-drafting.patch changed its context) and is
+ported by hand: IS_DRAFTING=True and the P-1 position, as at the other call sites.
+Upstream's other test file exercises PR #53017 (draft logits cache column stride) as
+well, which this tree does not carry; that one test is the only failure left and is
+unrelated to this patch.
+
+--- a/v1/worker/gpu/sample/gumbel.py
++++ b/v1/worker/gpu/sample/gumbel.py
+@@ -13,6 +13,12 @@
+ # attribute is `None`, and `tl.constexpr(...)` would crash at import time.
+ _TL_RAND_MIN = tl.constexpr(4.6566127342e-10) if HAS_TRITON else 4.6566127342e-10
+ 
++# Offset salt keeping the draft's Gumbel noise disjoint from the target's.
++# Verification is a probability-ratio test, not a Gumbel coupling, so a proposal
++# and the residual it is resampled from must not share a noise vector.
++# Positions are int64 and never approach 2**30, so the streams cannot collide.
++_DRAFT_NOISE_SALT = tl.constexpr(1 << 30) if HAS_TRITON else (1 << 30)
++
+ 
+ @triton.jit
+ def _temperature_kernel(
+@@ -89,6 +95,7 @@
+     seed,
+     pos,
+     temp,
++    IS_DRAFTING: tl.constexpr,
+     USE_FP64: tl.constexpr,
+     APPLY_TEMPERATURE: tl.constexpr = True,
+ ):
+@@ -108,6 +115,8 @@
+     if USE_FP64:
+         logits = logits.to(tl.float64)
+     if temp != 0.0:
++        if IS_DRAFTING:
++            pos = pos + _DRAFT_NOISE_SALT
+         gumbel_seed = tl.randint(seed, pos)
+         if USE_FP64:
+             u = tl_rand64(gumbel_seed, keys, includes_zero=False)
+@@ -135,6 +144,7 @@
+     logits_cache_stride,
+     logits_cache_col_ptr,
+     vocab_size,
++    IS_DRAFTING: tl.constexpr,
+     APPLY_TEMPERATURE: tl.constexpr,
+     USE_FP64: tl.constexpr,
+     PER_TOKEN_COL: tl.constexpr = False,
+@@ -171,6 +181,7 @@
+         seed,
+         pos,
+         temp,
++        IS_DRAFTING=IS_DRAFTING,
+         USE_FP64=USE_FP64,
+         APPLY_TEMPERATURE=APPLY_TEMPERATURE,
+     )
+@@ -193,6 +204,7 @@
+     temp_ptr,
+     vocab_size,
+     BLOCK_SIZE: tl.constexpr,
++    IS_DRAFTING: tl.constexpr,
+     APPLY_TEMPERATURE: tl.constexpr,
+     USE_FP64: tl.constexpr,
+     PER_TOKEN_COL: tl.constexpr,
+@@ -221,6 +233,7 @@
+         logits_cache_stride,
+         logits_cache_col_ptr,
+         vocab_size,
++        IS_DRAFTING=IS_DRAFTING,
+         APPLY_TEMPERATURE=APPLY_TEMPERATURE,
+         USE_FP64=USE_FP64,
+         PER_TOKEN_COL=PER_TOKEN_COL,
+@@ -237,6 +250,7 @@
+     seed: torch.Tensor,  # [max_num_reqs]
+     pos: torch.Tensor,  # [num_tokens]
+     apply_temperature: bool,
++    is_drafting: bool,
+     logits_cache: torch.Tensor | None = None,  # [max_num_reqs, num_cols, vocab_size]
+     logits_cache_col: torch.Tensor | None = None,  # scalar or [num_tokens]
+     use_fp64: bool = False,
+@@ -269,6 +283,7 @@
+         temperature,
+         vocab_size,
+         BLOCK_SIZE=BLOCK_SIZE,
++        IS_DRAFTING=is_drafting,
+         APPLY_TEMPERATURE=apply_temperature,
+         USE_FP64=use_fp64,
+         PER_TOKEN_COL=per_token_col,
+--- a/v1/worker/gpu/sample/sampler.py
++++ b/v1/worker/gpu/sample/sampler.py
+@@ -291,6 +291,7 @@
+                 self.sampling_states.seeds.gpu,
+                 pos,
+                 apply_temperature=False,
++                is_drafting=False,
+                 use_fp64=self.use_fp64_gumbel,
+             )
+         return sampled, processed_logits
+--- a/v1/worker/gpu/spec_decode/autoregressive/speculator.py
++++ b/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+@@ -37,6 +37,9 @@
+         self.last_token_indices = torch.zeros(
+             self.max_num_reqs, dtype=torch.int64, device=device
+         )
++        self.sample_src_positions = torch.zeros(
++            self.max_num_reqs, dtype=torch.int64, device=device
++        )
+ 
+         self.inputs_embeds: torch.Tensor | None = None
+ 
+@@ -321,6 +324,7 @@
+             input_batch.seq_lens,
+             num_rejected,
+             self.input_buffers,
++            self.sample_src_positions,
+             self.max_model_len,
+             self.max_num_reqs,
+             advance_draft_positions=self.advance_draft_positions,
+@@ -428,6 +432,10 @@
+     ) -> None:
+         last_token_indices = self.last_token_indices[:num_reqs]
+         positions = self.input_buffers.positions[last_token_indices]
++        # The output hidden state at position P (= positions) and the token id
++        # at P+1 are used to draft the token at P+2. Sampling keys a draw by the
++        # position before the sampled token, so the net adjustment is +1.
++        sample_src_positions = positions + 1
+         idx_mapping = self.idx_mapping[:num_reqs]
+ 
+         last_hidden_states, hidden_states = self._run_model(
+@@ -438,11 +446,11 @@
+             cudagraph_runtime_mode=cudagraph_runtime_mode,
+             mm_inputs=mm_inputs,
+         )
+-        sample_hidden_states = last_hidden_states[last_token_indices]
+ 
++        sample_hidden_states = last_hidden_states[last_token_indices]
+         self.draft_tokens[:num_reqs, 0] = self.sample_draft(
+             sample_hidden_states,
+-            positions,
++            sample_src_positions,
+             idx_mapping,
+             self.temperature,
+             self.seeds,
+@@ -454,6 +462,7 @@
+         else:
+             self.hidden_states[:num_reqs] = hidden_states[last_token_indices]
+         self.input_buffers.positions[:num_reqs] = positions
++        self.sample_src_positions[:num_reqs] = sample_src_positions
+ 
+     def _multi_step_decode(
+         self,
+@@ -606,7 +615,6 @@
+         self._prepare_eplb_forward(num_reqs)
+ 
+         idx_mapping = self.idx_mapping[:num_reqs]
+-        positions = self.input_buffers.positions[:num_reqs]
+         # Run the draft model forward pass.
+         last_hidden_states, hidden_states = self._run_model(
+             num_tokens_padded,
+@@ -615,18 +623,13 @@
+             num_tokens_across_dp,
+             cudagraph_runtime_mode,
+         )
+-        last_hidden_states = last_hidden_states[:num_reqs]
+-
+-        sample_positions = positions
+-        if not self.advance_draft_positions:
+-            # The forward pass holds positions fixed (Q-only, shared target KV),
+-            # but Gumbel sampling still needs the absolute draft position.
+-            sample_positions = positions + self.current_draft_step
+ 
+         # Sample the draft tokens.
++        sample_hidden_states = last_hidden_states[:num_reqs]
++        sample_src_positions = self.sample_src_positions[:num_reqs]
+         draft_tokens = self.sample_draft(
+-            last_hidden_states,
+-            sample_positions,
++            sample_hidden_states,
++            sample_src_positions,
+             idx_mapping,
+             self.temperature,
+             self.seeds,
+@@ -642,6 +645,7 @@
+             self.draft_tokens,
+             self.hidden_states,
+             self.input_buffers,
++            self.sample_src_positions,
+             num_reqs,
+             self.max_model_len,
+             self.num_speculative_steps,
+@@ -779,6 +783,7 @@
+     num_rejected_ptr,
+     input_ids_ptr,
+     positions_ptr,
++    sample_src_positions_ptr,
+     query_start_loc_ptr,
+     seq_lens_ptr,
+     max_model_len,
+@@ -807,6 +812,10 @@
+     draft_token = tl.load(draft_tokens_ptr + req_idx * draft_tokens_stride)
+     tl.store(input_ids_ptr + req_idx, draft_token)
+ 
++    # Advance the draft sampling key.
++    sample_position = tl.load(sample_src_positions_ptr + req_idx)
++    tl.store(sample_src_positions_ptr + req_idx, sample_position + 1)
++
+     target_seq_len = tl.load(target_seq_lens_ptr + req_idx)
+     num_rejected = tl.load(num_rejected_ptr + req_idx)
+     seq_len = target_seq_len - num_rejected
+@@ -826,6 +835,7 @@
+     target_seq_lens: torch.Tensor,
+     num_rejected: torch.Tensor,
+     input_buffers: InputBuffers,
++    sample_src_positions: torch.Tensor,
+     max_model_len: int,
+     max_num_reqs: int,
+     advance_draft_positions: bool = True,
+@@ -838,6 +848,7 @@
+         num_rejected,
+         input_buffers.input_ids,
+         input_buffers.positions,
++        sample_src_positions,
+         input_buffers.query_start_loc,
+         input_buffers.seq_lens,
+         max_model_len,
+@@ -855,6 +866,7 @@
+     next_input_hidden_states_stride,
+     input_ids_ptr,
+     positions_ptr,
++    sample_src_positions_ptr,
+     seq_lens_ptr,
+     draft_tokens_ptr,
+     current_draft_step_ptr,
+@@ -880,6 +892,10 @@
+         # This is the final step. Skip updating draft forward inputs.
+         return
+ 
++    # Advance the draft sampling key.
++    sample_position = tl.load(sample_src_positions_ptr + req_idx)
++    tl.store(sample_src_positions_ptr + req_idx, sample_position + 1)
++
+     # Write the sampled draft token into the input ids tensor for the next
+     # forward pass.
+     tl.store(input_ids_ptr + req_idx, draft_token)
+@@ -921,6 +937,7 @@
+     output_draft_tokens: torch.Tensor,
+     next_input_hidden_states: torch.Tensor,
+     input_buffers: InputBuffers,
++    sample_src_positions: torch.Tensor,
+     num_reqs: int,
+     max_model_len: int,
+     num_speculative_steps: int,
+@@ -934,6 +951,7 @@
+         next_input_hidden_states.stride(0),
+         input_buffers.input_ids,
+         input_buffers.positions,
++        sample_src_positions,
+         input_buffers.seq_lens,
+         draft_tokens,
+         current_draft_step,
+--- a/v1/worker/gpu/spec_decode/dflash/speculator.py
++++ b/v1/worker/gpu/spec_decode/dflash/speculator.py
+@@ -289,11 +289,11 @@
+         )
+         num_sample = num_reqs * self.draft_block
+         sample_hidden_states = last_hidden_states[self.sample_indices[:num_sample]]
+-        # sample_pos is the predicted token's position Q; verification keys
+-        # Gumbel by the predecessor (Q-1). sample_draft adds +1, so pass Q-2.
++        # sample_pos is the predicted token's position P. Sampling keys a draw
++        # by the position before the sampled token, P-1.
+         draft_tokens = self.sample_draft(
+             sample_hidden_states,
+-            self.sample_pos[:num_sample] - 2,
++            self.sample_pos[:num_sample] - 1,
+             self.sample_idx_mapping[:num_sample],
+             self.temperature,
+             self.seeds,
+--- a/v1/worker/gpu/spec_decode/dflash2/speculator.py
++++ b/v1/worker/gpu/spec_decode/dflash2/speculator.py
+@@ -84,14 +84,17 @@
+             keep = mask & (rank < req_top_k) & (mass_before < req_top_p)
+             scores = tl.where(keep, scores, -float("inf"))
+ 
+-        position = tl.load(sample_pos_ptr + flat) - 1
++        # sample_pos is the predicted token's position P. Sampling keys a draw
++        # by the position before the sampled token, P-1.
++        sample_pos = tl.load(sample_pos_ptr + flat) - 1
+         _, index = gumbel_noised_argmax(
+             scores,
+             candidates,
+             mask & valid,
+             seed,
+-            position,
++            sample_pos,
+             temperature if SAMPLE_PROBABILISTIC else 0.0,
++            IS_DRAFTING=True,
+             USE_FP64=USE_FP64,
+         )
+         # A degenerate distribution can produce NaN scores. Keep the walk in
+--- a/v1/worker/gpu/spec_decode/dspark/speculator.py
++++ b/v1/worker/gpu/spec_decode/dspark/speculator.py
+@@ -135,8 +135,8 @@
+             buf.index_copy_(1, self._d2t_scatter_index, logits.to(buf.dtype))
+             logits = buf
+ 
+-        # sample_pos is the predicted token's position Q; the target verifies
+-        # it with the predecessor's Gumbel key (Q-1). Pass Q-1.
++        # sample_pos is the predicted token's position P. Sampling keys a draw
++        # by the position before the sampled token, P-1.
+         return gumbel_sample(
+             logits,
+             idx_map,
+@@ -144,6 +144,7 @@
+             self.seeds,
+             sample_pos - 1,
+             apply_temperature=True,
++            is_drafting=True,
+             logits_cache=self.draft_logits,
+             logits_cache_col=self._step_cols[step],
+             use_fp64=self.use_fp64_gumbel,
+--- a/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
++++ b/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
+@@ -375,7 +375,11 @@
+         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+     ) -> None:
+         last_token_indices = self.last_token_indices[:num_reqs]
+-        sample_positions = self.input_buffers.positions[last_token_indices]
++        positions = self.input_buffers.positions[last_token_indices]
++        # The output hidden state at position P (= positions) and the token id
++        # at P+1 are used to draft the token at P+2. Sampling keys a draw by the
++        # position before the sampled token, so the net adjustment is +1.
++        sample_src_positions = positions + 1
+         idx_mapping = self.idx_mapping[:num_reqs]
+ 
+         # Cache the trailing token's ids, hidden states (and embeddings for
+@@ -413,7 +417,7 @@
+             sample_hidden_states = last_hidden_states[last_token_indices]
+             draft_tokens = self.sample_draft(
+                 sample_hidden_states,
+-                sample_positions,
++                sample_src_positions,
+                 idx_mapping,
+                 self.temperature,
+                 self.seeds,
+@@ -444,7 +448,8 @@
+                     idx_mapping,
+                     num_reqs,
+                 )
+-                sample_positions += 1
++                # Advance the draft sampling key.
++                sample_src_positions += 1
+ 
+ 
+ @triton.jit
+--- a/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
++++ b/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
+@@ -836,6 +836,7 @@
+         0,  # logits_cache_stride
+         None,  # logits_cache_col_ptr
+         vocab_size,
++        IS_DRAFTING=False,
+         APPLY_TEMPERATURE=False,
+         USE_FP64=USE_FP64,
+     )
+--- a/v1/worker/gpu/spec_decode/speculator.py
++++ b/v1/worker/gpu/spec_decode/speculator.py
+@@ -326,7 +326,7 @@
+     def sample_draft(
+         self,
+         hidden_states: torch.Tensor,
+-        positions: torch.Tensor,
++        sample_src_positions: torch.Tensor,
+         idx_mapping: torch.Tensor,
+         temperature: torch.Tensor,
+         seeds: torch.Tensor,
+@@ -335,15 +335,14 @@
+     ) -> torch.Tensor:
+         if draft_logits is not None:
+             logits = self.model.compute_logits(hidden_states)
+-            # NOTE(woosuk): We must add 1 to the positions to match the Gumbel noise
+-            # used for draft and target sampling.
+             return gumbel_sample(
+                 logits,
+                 idx_mapping,
+                 temperature,
+                 seeds,
+-                positions + 1,
++                sample_src_positions,
+                 apply_temperature=True,
++                is_drafting=True,
+                 logits_cache=draft_logits,
+                 logits_cache_col=draft_step,
+                 use_fp64=self.use_fp64_gumbel,


### PR DESCRIPTION
Backport of vLLM #54282 (fe755c889): the draft's Gumbel noise stream is salted (offset 1 << 30) so it is independent of the target's, and each speculator states its own "position before the sampled token" convention instead of relying on the +1 inside `sample_draft`. One new file, `patches/vllm-pr54282-draft-gumbel-salt.patch`, sorted after the repo's patches; it touches `sample/gumbel.py`, `sample/sampler.py`, `spec_decode/rejection_sampler_utils.py`, `spec_decode/speculator.py` and the five speculators.

Why it matters here: it only acts under `draft_sample_method=probabilistic`, which is what this launcher ships. Before the patch the noise that re-samples a rejected draft token comes from the same Philox offset that produced the draft token, so the verifier's draw is correlated with the draft's and the accepted stream leans toward the drafter. Upstream's `test_gumbel_drafted_rejection_sample_is_unbiased` measures it: with the draft drawn on the shared stream, the way this tree draws it today, the accepted distribution fails the chi-square check at position 0 with chi2 1584.9 against a threshold of 69.8; with the patch it passes.

What I measured, RTX 4090 under WSL2, the shipped default (`SPEC=dflash2 CTX=fast DFLASH_TOKENS=7 PREFIX_CACHE=1`, int8 activations and prefill attention), fresh compile cache, the patch applied to the installed tree before the launcher ran:

1. `verify.sh --no-server` passes with it applied: `verify: OK (0 failures)`. The DFlash2 candidate-selector hunk did not apply against this tree because `dflash2-lookup-drafting.patch` moved its context, so that one hunk is ported by hand (IS_DRAFTING=True and the P-1 position, the same as the other sites); the other 35 apply as upstream wrote them.
2. Upstream's tests in the shipped image with pytest installed into a throwaway container: `test_rejection_sampler_utils.py` 44 passed with the patch. One honest note on the red: the shipped test's draft helper passes `is_drafting=True`, which the old `gumbel_sample` does not accept, so unpatched it dies with a TypeError before measuring anything. To see the bias itself I ran the same test with that one keyword removed from the helper (the test's own docstring describes this adaptation) against the unpatched tree: both cases fail the unbiasedness assertion (chi2 1584.9, df 15, threshold 69.8 at position 0). That is the red; the shipped test on the patched tree is the green. `test_gpu_gumbel_sample.py` 18 of 20 pass patched; the two failures, `test_logits_cache_columns_stay_separate_across_steps[1]` and `test_logits_cache_narrower_than_logits_is_rejected`, both test vLLM #53017 (a draft-logits-cache column stride fix from August 20 that neither 0.28.0 nor this tree carries). That bug needs a cache row wider than the logits, which this drafter does not have (the DFlash2 path caches through its own strided kernel and the draft vocabulary equals the target's), so I left it out of this PR.
3. Pool unchanged at 68,605 tokens; lookup-augmented drafting on at k=7 as before.
4. Paired cohort against the main baseline I measured yesterday (same client, the repo's eight `bench/prompts_real.jsonl` prompts, 1024 tokens, temperature 1.0, seeds 1-8, rows paired by seed and prompt):

| | main 7ca84fc | with patch | delta | paired t |
|---|---|---|---|---|
| tok/step, seeds 1-4 (n=32) | 3.730 | 3.788 | +0.057 | +0.57 |
| tok/step, seeds 5-8 (n=31) | 3.840 | 3.817 | -0.023 | -0.31 |
| tok/step, pooled (n=63) | 3.784 | 3.802 | +0.018 | +0.28 |
| accepted per drafted token, pooled | 0.3629 | 0.3646 | | |
| tok/s, pooled | 160.3 | 162.3 | +2.0 | +0.72 |

On this card acceptance does not move, which is what upstream expected (their independent trials put it at 0.1068 against 0.1071). On the native 3090 (threadchip, same client, same prompts and seeds, k=7, pool 68,605 both arms) it moved down: tok/step 3.878 to 3.757 (delta -0.121, sd 0.56, n=64, paired t -1.72), accepted per drafted token 0.3781 to 0.3612, tok/s 153.8 to 148.8, with the distinct-token and gzip ratios slightly up. Pooling the paired differences from both cards gives -0.052 tok/step (n=127, t -1.10): not resolved at this size, and the 3090's sign is the one you would expect from removing a bias toward the drafter, so treat a small acceptance cost as possible rather than excluded. One caveat on the 3090 row: that box runs a native tree (cb5679d) on which `verify.sh` reports `dflash2-lookup-drafting.patch` and `dflash2-prewarm.patch` as not applied, before and after this patch alike, so its two arms pair cleanly against each other but not like-for-like against the image tree. The row that is missing from the second seed set is seed 7 on prompt 5, where the patched run emitted a single token and stopped, so there was no speculation to count. That is a property of the prompt, not the patch: the unpatched record has the same prompt stopping after one or two tokens on seeds 2, 3 and 4 in twelve earlier arms.

What I did not measure: output quality. The bias this removes is in the distribution of accepted tokens, and a cohort's tok/step cannot see that; the unbiasedness test is the oracle for it. The distinct-token and gzip ratios the client reports did not change (0.543 to 0.545 and 0.451 to 0.443).

With all three backports applied together (this, #54373 and #54374) the same boot serves the same pool and the cohort is indistinguishable from this patch alone (tok/step 3.788 against 3.759 on seeds 1-4, paired t -0.33; 3.817 against 3.844 on seeds 5-8, t +0.24), which is the boot-level check that the other two are dormant here.
