### PR TITLE
kv sharing: let the full-attention layers share a KV cache (experiment, needs a GPU to judge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,7 +885,7 @@ bug, `python bench/residue_sweep.py <tag>` (all 128 residues) with
 | | |
 |---|---|
 | [docs/optimizations.md](docs/optimizations.md) | Every optimization in full: why it was needed, what it measured, which patch implements it. Includes the two speculative-decoding modes (MTP and DFlash2) and the lookup drafter. |
-| [docs/gotchas.md](docs/gotchas.md) | 53 things that each cost us hours — read before debugging something that looks like a vLLM bug. |
+| [docs/gotchas.md](docs/gotchas.md) | 54 things that each cost us hours — read before debugging something that looks like a vLLM bug. |
 | [docs/quality.md](docs/quality.md) | IFBench, perplexity and GSM8K per configuration. |
 | [docs/docker.md](docs/docker.md) | The container image, and an independent WSL2 reproduction. |
 | [docs/kv-sharing.md](docs/kv-sharing.md) | Cross-layer KV cache sharing for the 16 full-attention layers: an unmeasured experiment (`KV_SHARE=group:2`) that would cut the global KV cache 2-4x if the quality holds, plus why the DeepSeek-V4.1-Flash prefill trick does not port to this model. |

--- a/README.md
+++ b/README.md
@@ -885,9 +885,10 @@ bug, `python bench/residue_sweep.py <tag>` (all 128 residues) with
 | | |
 |---|---|
 | [docs/optimizations.md](docs/optimizations.md) | Every optimization in full: why it was needed, what it measured, which patch implements it. Includes the two speculative-decoding modes (MTP and DFlash2) and the lookup drafter. |
-| [docs/gotchas.md](docs/gotchas.md) | 18 things that each cost us hours — read before debugging something that looks like a vLLM bug. |
+| [docs/gotchas.md](docs/gotchas.md) | 53 things that each cost us hours — read before debugging something that looks like a vLLM bug. |
 | [docs/quality.md](docs/quality.md) | IFBench, perplexity and GSM8K per configuration. |
 | [docs/docker.md](docs/docker.md) | The container image, and an independent WSL2 reproduction. |
+| [docs/kv-sharing.md](docs/kv-sharing.md) | Cross-layer KV cache sharing for the 16 full-attention layers: an unmeasured experiment (`KV_SHARE=group:2`) that would cut the global KV cache 2-4x if the quality holds, plus why the DeepSeek-V4.1-Flash prefill trick does not port to this model. |
 | [docs/long-context.md](docs/long-context.md) | 262k context with the KVarN 4/2-bit KV cache, what vLLM's own per-token-head KV modes are worth here, and how to run the DFlash2 drafter past 64k (`CTX=long`, 114-139k — worth it only for context reproduction). |
 | [batch/](batch/) · [single-user/](single-user/) | The two serving modes: full benchmark tables, every env knob, systemd units. |
 | [prepare/](prepare/) | The one-time model-preparation scripts run by [Setup](#setup) (and by `docker compose run --rm prepare`). |

--- a/bench/kv_share_sweep.sh
+++ b/bench/kv_share_sweep.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Cross-layer KV cache sharing sweep (patches/qwen3_5-kv-cache-sharing.patch).
+#
+# Asks the only question that matters about the feature: these 16 full_attention
+# layers were never trained to share a KV cache, so how much quality does each
+# sharing layout cost? The memory saving is arithmetic and needs no experiment --
+# group:2 halves the global KV cache, group:4 quarters it. The damage does.
+#
+#   bash bench/kv_share_sweep.sh                      # off group:2 group:4
+#   ARMS="off group:2 group:4 suffix:8" bash bench/kv_share_sweep.sh
+#   GSM_N=100 NEEDLE=0 bash bench/kv_share_sweep.sh   # quicker first look
+#
+# Results under bench/results-kv-share/<arm>/, one ROW line per measurement.
+# Budget roughly 25 minutes per arm with the defaults.
+#
+# THREE THINGS THIS SCRIPT REFUSES TO GET WRONG, because each of them has
+# produced a confident wrong answer in this repo before:
+#
+#  1. It verifies the arm actually took effect, by reading the owner count out
+#     of the server log and comparing it to the arithmetic. An arm that silently
+#     ran stock would report "no quality loss" and be believed. That is exactly
+#     how the patch-integrity CI job stayed green for months while checking
+#     nothing (docs/gotchas.md, the `git apply` prefix entry).
+#  2. It boots each arm TWICE and measures the second boot. VLLM_QWEN_KV_SHARE
+#     is part of the torch.compile cache key -- it has to be, it changes which
+#     layers own a cache -- so every arm's first boot compiles cold, and a cold
+#     compile profiles ~0.9 GiB more peak activation than a warm one. Comparing
+#     a cold arm against a warm arm is comparing compile-cache states, not
+#     layouts. Never A/B a KV pool across boots without this.
+#  3. It runs perplexity with PREFIX_CACHE=0. prompt_logprobs is corrupted by
+#     prefix caching on this hybrid model and reads ~23% high (gotcha 51).
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(dirname "$HERE")"
+cd "$REPO"
+ARMS=${ARMS:-"off group:2 group:4"}
+PORT=${PORT:-18021}          # do not fight the production port
+GSM_N=${GSM_N:-200}
+NEEDLE=${NEEDLE:-1}
+NEEDLE_TOKENS=${NEEDLE_TOKENS:-32000}
+ROOT="$HERE/results-kv-share"; mkdir -p "$ROOT"
+export PATH="$REPO/venv/bin:$PATH"
+export VLLM_API="http://127.0.0.1:$PORT/v1"
+SUMMARY="$ROOT/summary.txt"; : > "$SUMMARY"
+
+# 16 full_attention layers on Qwen3.8-27B (64 layers, full_attention_interval 4).
+FULL=16
+owners_for() {   # arm -> how many layers should still own a KV cache
+  case "$1" in
+    off)      echo $FULL ;;
+    group:*)  python3 -c "import math;print(math.ceil($FULL/${1#group:}))" ;;
+    suffix:*) echo "${1#suffix:}" ;;
+    *)        echo "unknown arm $1" >&2; exit 2 ;;
+  esac
+}
+
+stop_server() {
+  pkill -f "[v]llm serve" 2>/dev/null
+  for i in $(seq 1 60); do pgrep -f "[v]llm serve" >/dev/null || break; sleep 2; done
+  pgrep -f "[v]llm serve" >/dev/null && pkill -9 -f "[v]llm serve"
+  sleep 5
+}
+
+boot() {   # boot(arm, logfile) -> waits for health, returns 1 if it never came up
+  local arm=$1 log=$2
+  local share=""; [ "$arm" != off ] && share=$arm
+  KV_SHARE="$share" SPEC=${SPEC:-dflash2} CTX=${CTX:-fast} \
+  DFLASH_TOKENS=${DFLASH_TOKENS:-15} PREFIX_CACHE=0 \
+  PORT=$PORT HOST=127.0.0.1 \
+  nohup bash single-user/start_qwen.sh > "$log" 2>&1 &
+  echo $! > "$log.pid"
+  for i in $(seq 1 150); do
+    sleep 5; curl -sf -o /dev/null "http://127.0.0.1:$PORT/health" && return 0
+    kill -0 "$(cat "$log.pid")" 2>/dev/null || { echo "server died; tail:"; tail -30 "$log"; return 1; }
+  done
+  echo "no health after 12 min"; tail -30 "$log"; return 1
+}
+
+for ARM in $ARMS; do
+  OUT="$ROOT/${ARM//:/-}"; mkdir -p "$OUT"
+  WANT=$(owners_for "$ARM")
+  echo "=== arm $ARM  (expect $WANT of $FULL full_attention layers to own a cache)"
+
+  # --- boot 1: warm the compile cache for THIS arm's cache key, then discard ---
+  stop_server
+  boot "$ARM" "$OUT/boot-warm.log" || { echo "ROW $ARM FAILED-TO-BOOT" | tee -a "$SUMMARY"; continue; }
+  stop_server
+
+  # --- boot 2: the one we measure ------------------------------------------
+  boot "$ARM" "$OUT/server.log" || { echo "ROW $ARM FAILED-TO-BOOT-WARM" | tee -a "$SUMMARY"; continue; }
+
+  # --- did the arm actually take effect? -----------------------------------
+  GOT=$(grep -o "KV sharing ([^)]*): [0-9]* of [0-9]*" "$OUT/server.log" | tail -1 | awk '{print $4}')
+  if [ "$ARM" = off ]; then
+    if [ -n "$GOT" ]; then
+      echo "ROW $ARM ABORT: baseline arm logged KV sharing ($GOT owners)" | tee -a "$SUMMARY"; stop_server; continue
+    fi
+  elif [ "$GOT" != "$WANT" ]; then
+    echo "ROW $ARM ABORT: expected $WANT owners, server logged '${GOT:-nothing}'." | tee -a "$SUMMARY"
+    echo "     The patch is not applied, or the launcher did not export VLLM_QWEN_KV_SHARE." | tee -a "$SUMMARY"
+    stop_server; continue
+  fi
+
+  POOL=$(grep -o "GPU KV cache size: [0-9,]* tokens" "$OUT/server.log" | tail -1 | tr -d ',' | awk '{print $5}')
+  nvidia-smi --query-gpu=memory.used,power.limit --format=csv,noheader > "$OUT/gpu.txt"
+  echo "ROW $ARM owners=${GOT:-$FULL}/$FULL pool=${POOL:-?} tokens vram=$(cat "$OUT/gpu.txt")" | tee -a "$SUMMARY"
+
+  # --- quality: perplexity + GSM8K, then needle at depth --------------------
+  python3 bench/quality_battery.py "kvshare-${ARM//:/-}" --gsm-n "$GSM_N" 2>&1 | tee "$OUT/quality.log"
+  grep -E "PPL|GSM8K" "$OUT/quality.log" | sed "s/^/ROW $ARM /" | tee -a "$SUMMARY"
+
+  if [ "$NEEDLE" = 1 ]; then
+    for D in 0.1 0.5 0.9; do
+      python3 bench/needle_test.py "$NEEDLE_TOKENS" "$D" > "$OUT/needle-$D.log" 2>&1
+      echo "ROW $ARM needle tokens=$NEEDLE_TOKENS depth=$D $(tail -1 "$OUT/needle-$D.log")" | tee -a "$SUMMARY"
+    done
+  fi
+
+  stop_server
+done
+
+echo
+echo "=== summary ==="
+cat "$SUMMARY"
+echo
+echo "Baseline is the 'off' arm measured on the same box in the same sweep."
+echo "Numbers from a different session are not a baseline; boot-to-boot drift on"
+echo "this stack is larger than several of the effects people have tried to claim."

--- a/docs/kv-sharing.md
+++ b/docs/kv-sharing.md
@@ -1,0 +1,134 @@
+# Cross-layer KV cache sharing
+
+**Status: experiment, off by default, unmeasured.** Nothing here has run on a
+GPU yet. The patch is written and the harness is written; what is missing is the
+only thing that decides whether the idea survives.
+
+## What this is
+
+Qwen3.8-27B is 64 layers with `full_attention_interval: 4`, so 16 layers own a
+KV cache and 48 are gated-delta-net layers that own a recurrent state instead.
+Each owner stores 2 x 4 heads x 256 head_dim per token:
+
+| storage | global KV cache | a 57,669-token pool |
+|---|---:|---:|
+| fp16 | 65,536 B/token | 3.52 GiB |
+| int8 | 32,768 B/token | 1.76 GiB |
+| int4 | 16,384 B/token | 0.88 GiB |
+
+DeepSeek-V4.1-Flash reports 890 bytes per token. A large part of how it gets
+there is that most of its attention layers do not own a cache at all: across 40
+layers only four compress their own, and the rest read those. The same trick is
+available to us, because vLLM already implements the mechanism.
+
+An `Attention` layer constructed with `kv_sharing_target_layer_name` is skipped
+when the runner builds KV cache specs, so **no memory is allocated for it**, and
+its cache tensor is aliased to the target's. vLLM validates that the target
+comes before it in the model and has the same attention type. The Qwen3.5 model
+code simply never passes the argument.
+`patches/qwen3_5-kv-cache-sharing.patch` passes it.
+
+## What this is not
+
+It is not the Late Layer KV Approximation doing the rounds after
+DeepSeek-V4.1-Flash shipped (`kishida/Q3-8B-KVA-Projector`). That technique
+trains a small projector to *guess* the back half's KV entries from a
+mid-network hidden state, so the back half's forward pass can be skipped during
+prefill. It saves prefill compute and leaves the cache exactly the same size.
+
+It also does not port to this model. Its 50% comes from Qwen3-8B being entirely
+full-attention, so the whole back half is skippable. Three quarters of our
+layers are gated-delta-net, whose recurrent state is a sequential function of
+every prompt token and cannot be written per-position, so the back half's
+forward pass has to run anyway and only the eight full-attention mixers in it
+come out:
+
+| prompt tokens | ceiling on prefill saving |
+|---|---:|
+| 4,096 | 4.1% |
+| 16,384 | 6.4% |
+| 51,200 | 11.7% |
+
+That is a ceiling with a perfect projector and no kernel overhead, against ~50%
+for the model it was built on. It was not worth a training run.
+
+## The layouts
+
+`KV_SHARE` (launcher) sets `VLLM_QWEN_KV_SHARE` (vLLM).
+
+- `group:N` groups consecutive full-attention layers N at a time; the first of
+  each group owns the cache. `group:2` leaves owners at layers 3, 11, 19, 27,
+  35, 43, 51, 59. The target is always within three attention layers, which
+  should be the gentler layout.
+- `suffix:K` keeps the first K owners and points every later layer at the K-th.
+  `suffix:4` leaves owners at 3, 7, 11, 15 and has layers 19 through 63 all read
+  layer 15. This is the You Only Cache Once layout, and it is the only one
+  `--kv-sharing-fast-prefill` can use, because that flag requires the sharing
+  layers to form a suffix. It should be the more damaging layout, and it is the
+  one that also buys prefill time.
+
+`group:4` and `suffix:4` both leave four owners, which is DeepSeek's count.
+
+## Running the sweep
+
+```bash
+bash bench/kv_share_sweep.sh                      # off, group:2, group:4
+ARMS="off group:2 group:4 suffix:4" bash bench/kv_share_sweep.sh
+GSM_N=100 NEEDLE=0 bash bench/kv_share_sweep.sh   # quicker first look
+```
+
+It boots on port 18021, so it does not fight a production server on 18020.
+Budget about 25 minutes per arm. Results land in `bench/results-kv-share/`.
+
+Three things the harness refuses to get wrong, each because the mistake has
+already produced a confident wrong answer in this repo:
+
+1. **It verifies the arm took effect**, by reading the owner count out of the
+   server log and comparing it against the arithmetic. An arm that silently ran
+   stock would report no quality loss and be believed. That is how the
+   patch-integrity CI job stayed green while checking five of thirty patches.
+2. **It boots each arm twice and measures the second boot.**
+   `VLLM_QWEN_KV_SHARE` is in the torch.compile cache key, so every arm's first
+   boot compiles cold, and a cold compile profiles about 0.9 GiB more peak
+   activation than a warm one. Comparing a cold arm against a warm arm compares
+   compile-cache states, not layouts.
+3. **It measures perplexity with `PREFIX_CACHE=0`**, because prompt_logprobs is
+   corrupted by prefix caching on this hybrid model and reads about 23% high.
+
+## What would make this shippable
+
+The baseline is the `off` arm from the same sweep on the same box. Numbers from
+another session are not a baseline.
+
+Untrained, the honest expectation is that `group:2` degrades and `group:4` falls
+apart. The useful output is the *shape* of the curve, because that is what says
+whether a light adapter fine-tune could close the gap or whether these layers
+are too dissimilar to share at all.
+
+Roughly:
+
+- `group:2` within noise of baseline on GSM8K and needle retrieval would be a
+  genuine surprise and would make a fine-tune obviously worth costing.
+- `group:2` down a few points, `group:4` broken, says the mechanism works and
+  the weights need adapting. That is the interesting middle, and it is what a
+  cheap QLoRA on the 16 attention layers would target.
+- `group:2` already broken says these layers carry genuinely different
+  information and sharing is not a retrofit. Write it up as a gotcha and close
+  the book.
+
+Needle retrieval at depth is the sharpest instrument of the three. Perplexity
+moves least and hides the failure mode people actually notice.
+
+## Known risks
+
+- **Cache group geometry.** Shared layers are appended to their target's KV
+  cache group. On this hybrid model, group composition has been the source of
+  several hard bugs already: block promotion needing to divide rather than cover,
+  and scratch allocation landing outside the memory profile. Expect the first
+  failure here rather than in model quality.
+- **Speculative decoding.** The sweep runs `SPEC=dflash2` because that is
+  production. If an arm fails to boot, re-run it with `SPEC=off` before
+  concluding anything about the sharing layout.
+- **The `off` arm must log nothing.** The harness aborts the baseline if it
+  sees a sharing line, because a baseline that is quietly sharing would flatten
+  every difference in the table.

--- a/patches/qwen3_5-kv-cache-sharing.patch
+++ b/patches/qwen3_5-kv-cache-sharing.patch
@@ -1,0 +1,166 @@
+Let the Qwen3.5 full_attention layers share one another's KV cache, so the
+global KV cache can be 2x or 4x smaller at the cost of model quality.
+
+vLLM already implements the mechanism: an Attention layer constructed with
+kv_sharing_target_layer_name gets no KVCacheSpec, the runner allocates nothing
+for it, and its cache tensor is aliased to the target's. The Qwen3.5 model code
+never passes the argument, so the capability is unreachable. This patch wires it
+to VLLM_QWEN_KV_SHARE:
+
+  group:N   consecutive full_attention layers grouped N at a time, the first of
+            each group owns the cache. Target is always nearby.
+  suffix:K  the first K full_attention layers own a cache, every later one reads
+            the K-th. You Only Cache Once layout; the only one that
+            --kv-sharing-fast-prefill can use, since that flag requires the
+            sharing layers to form a suffix.
+
+Unset (the default) is stock behaviour and touches nothing.
+
+On Qwen3.8-27B (64 layers, full_attention every 4th, 16 owners at 64 KiB/token
+fp16) group:2 gives 8 owners and group:4 gives 4 owners, which is DeepSeek
+V4.1-Flash's owner count.
+
+These layers were NOT trained to share. The knob exists so the quality cost can
+be measured before anyone spends a fine-tune on it -- see bench/kv_share_sweep.py
+and docs/kv-sharing.md. Do not ship a sharing layout on the strength of a boot
+log; it will boot happily and answer badly.
+
+VLLM_QWEN_KV_SHARE is registered in envs.py so it takes part in the
+torch.compile cache key. It changes which layers own a KV cache and therefore
+the compiled graph; without registration a sweep would silently replay the
+previous setting's graph.
+
+Depends on patches/marlin-int8-layer-select.patch for the envs.py context
+(same file, adjacent hunks). Apply the series in glob order, as the README and
+Dockerfile do:
+  patch -p1 -d venv/lib/python3.12/site-packages/vllm < patches/qwen3_5-kv-cache-sharing.patch
+
+Validated against vLLM 0.28.0. Reapply after upgrades.
+
+--- a/envs.py
++++ b/envs.py
+@@ -186,6 +186,11 @@ if TYPE_CHECKING:
+     VLLM_MARLIN_INPUT_DTYPE: Literal["int8", "fp8"] | None = None
+     VLLM_MARLIN_INT8_INCLUDE_RE: str = ""
+     VLLM_MARLIN_INT8_EXCLUDE_RE: str = "lm_head|mtp"
++    # syv patch: cross-layer KV cache sharing for the Qwen3.5 full_attention
++    # layers. Registered here so the layout takes part in the torch.compile
++    # cache key -- it changes which layers own a KV cache, and therefore the
++    # compiled graph. "" disables. See patches/qwen3_5-kv-cache-sharing.patch.
++    VLLM_QWEN_KV_SHARE: str = ""
+     VLLM_HUMMING_ONLINE_QUANT_CONFIG: dict[str, Any] | None = None
+     VLLM_HUMMING_INPUT_QUANT_CONFIG: dict[str, Any] | None = None
+     VLLM_HUMMING_USE_F16_ACCUM: bool = False
+@@ -1524,6 +1529,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
+     "VLLM_MARLIN_INT8_EXCLUDE_RE": lambda: os.environ.get(
+         "VLLM_MARLIN_INT8_EXCLUDE_RE", "lm_head|mtp"
+     ),
++    # syv patch: Qwen3.5 cross-layer KV cache sharing layout ("group:N" /
++    # "suffix:K"); part of the compile cache key, see the note above.
++    "VLLM_QWEN_KV_SHARE": lambda: os.environ.get("VLLM_QWEN_KV_SHARE", ""),
+     # The online quantization dtype for humming kernel
+     "VLLM_HUMMING_ONLINE_QUANT_CONFIG": lambda: maybe_convert_json_str_or_file(
+         os.environ.get("VLLM_HUMMING_ONLINE_QUANT_CONFIG", None)
+--- a/model_executor/models/qwen3_next.py
++++ b/model_executor/models/qwen3_next.py
+@@ -8,6 +8,7 @@ from itertools import islice
+ import torch
+ from torch import nn
+ 
++from vllm import envs
+ from vllm._aiter_ops import rocm_aiter_ops
+ from vllm.compilation.decorators import support_torch_compile
+ from vllm.config import CacheConfig, ModelConfig, VllmConfig
+@@ -224,6 +225,84 @@ class Qwen3NextSparseMoeBlock(nn.Module):
+         return final_hidden_states.view(orig_shape)
+ 
+ 
++# syv patch: cross-layer KV cache sharing for the full_attention layers.
++#
++# vLLM supports this natively -- an Attention layer built with
++# kv_sharing_target_layer_name gets no KVCacheSpec of its own, so the runner
++# allocates nothing for it and aliases its cache tensor to the target's
++# (gpu_model_runner.py, "The layer doesn't need its own KV cache"). The Qwen3.5
++# model code simply never passes the argument. VLLM_QWEN_KV_SHARE does:
++#
++#   group:N   consecutive full_attention layers are grouped N at a time and the
++#             FIRST layer of each group owns the cache. Uniform, and the target
++#             is always nearby, which is the gentler layout.
++#   suffix:K  the first K full_attention layers own their cache and every later
++#             one reads the K-th. This is the You Only Cache Once layout
++#             (arXiv 2405.05254) and the only one --kv-sharing-fast-prefill can
++#             use, because that flag needs the sharing layers to be a suffix.
++#
++# Qwen3.8-27B is 64 layers with full_attention every 4th, so 16 layers own a
++# cache of 2 * 4 heads * 256 head_dim * 2 bytes = 64 KiB/token at fp16.
++# group:2 halves that, group:4 quarters it.
++#
++# None of this is free: these layers were not trained to share, so the knob
++# exists to MEASURE the damage before anyone considers a fine-tune. See
++# bench/kv_share_sweep.py and docs/kv-sharing.md.
++def kv_sharing_target_layer(config, prefix: str) -> str | None:
++    spec = envs.VLLM_QWEN_KV_SHARE
++    if not spec:
++        return None
++    layer_types = getattr(config, "layer_types", None)
++    if not layer_types:
++        return None
++    full = [i for i, t in enumerate(layer_types) if t == "full_attention"]
++    idx = extract_layer_index(prefix)
++    if idx not in full:
++        return None
++    pos = full.index(idx)
++
++    mode, _, arg = spec.partition(":")
++    if mode == "group":
++        n = int(arg)
++        if n < 2:
++            raise ValueError(f"VLLM_QWEN_KV_SHARE=group:N needs N >= 2, got {n!r}")
++        owner = full[pos - (pos % n)]
++    elif mode == "suffix":
++        k = int(arg)
++        if not 1 <= k < len(full):
++            raise ValueError(
++                f"VLLM_QWEN_KV_SHARE=suffix:K needs 1 <= K < {len(full)}, got {k!r}"
++            )
++        if pos < k:
++            return None
++        owner = full[k - 1]
++    else:
++        raise ValueError(
++            f"VLLM_QWEN_KV_SHARE must be 'group:N' or 'suffix:K', got {spec!r}"
++        )
++    if owner == idx:
++        return None
++
++    # prefix is "<...>.layers.<idx>.self_attn"; the Attention module below is
++    # registered one level deeper, at "<...>.self_attn.attn". vLLM validates
++    # that the target comes BEFORE this layer and is the same attn_type, so a
++    # wrong name here fails at load rather than silently reading garbage.
++    head, sep, tail = prefix.rpartition(f"layers.{idx}")
++    if not sep:
++        return None
++    target = f"{head}layers.{owner}{tail}.attn"
++    owners = -(-len(full) // int(arg)) if mode == "group" else int(arg)
++    logger.info_once(
++        "Qwen3.5 KV sharing (%s): %d of %d full_attention layers own a cache, "
++        "global KV cache is %.2fx smaller",
++        spec,
++        owners,
++        len(full),
++        len(full) / owners,
++    )
++    return target
++
++
+ class Qwen3NextAttention(nn.Module):
+     def __init__(
+         self,
+@@ -304,6 +383,7 @@ class Qwen3NextAttention(nn.Module):
+             quant_config=quant_config,
+             prefix=f"{prefix}.attn",
+             attn_type=attn_type,
++            kv_sharing_target_layer_name=kv_sharing_target_layer(config, prefix),
+             **{
+                 "layer_idx": extract_layer_index(prefix),
+                 "dual_chunk_attention_config": self.dual_chunk_attention_config,

--- a/single-user/start_qwen.sh
+++ b/single-user/start_qwen.sh
@@ -119,6 +119,25 @@ INT8_LAYERS=${INT8_LAYERS-mlp|linear_attn|self_attn}
 # without quantization (a debugging mode); empty keeps FA2.
 PREFILL_ATTN=${PREFILL_ATTN-}
 [ -n "$PREFILL_ATTN" ] && export VLLM_PREFILL_ATTN=$PREFILL_ATTN
+# KV_SHARE: cross-layer KV cache sharing for the 16 full_attention layers
+# (patches/qwen3_5-kv-cache-sharing.patch). "group:N" groups consecutive
+# full_attention layers N at a time and gives the cache to the first of each;
+# "suffix:K" keeps the first K owners and points every later layer at the K-th
+# (You Only Cache Once layout). group:2 halves the global KV cache, group:4
+# quarters it, which at fp16 is 64 -> 32 -> 16 KiB per token.
+#
+# EXPERIMENTAL, and off for a reason: these layers were never trained to share,
+# so the quality cost is unmeasured and expected to be real. It boots and
+# answers fluently in either layout -- that is not evidence. bench/kv_share_sweep.py
+# runs the arms and scores them; docs/kv-sharing.md has the protocol. Do not put
+# this in a production unit until that sweep has a number attached.
+#
+# It changes the KV pool arithmetic, so the MAX_LEN each CTX profile picks below
+# is no longer the right ceiling: the same pinned KV_MEM now holds 2-4x the
+# tokens. Set MAX_LEN yourself when sweeping, or the profile will leave the
+# extra context on the floor.
+KV_SHARE=${KV_SHARE-}
+[ -n "$KV_SHARE" ] && export VLLM_QWEN_KV_SHARE=$KV_SHARE
 # 0.93 here, NOT batch mode's 0.972: the DeltaNet workspace in the MTP decode
 # path allocates beyond the startup memory profile (docs/gotchas.md, gotcha 4).
 GPU_UTIL=${GPU_UTIL:-0.93}


### PR DESCRIPTION
Cross-layer KV cache sharing for the 16 full-attention layers, off by default.
**The quality cost is unmeasured** — I had no GPU while writing this — so this is
a request for measurement as much as a patch.

## Why

DeepSeek-V4.1-Flash reports 890 bytes per token of KV cache. A large part of how
it gets there is that most of its attention layers do not own a cache: across 40
layers only four compress their own and the rest read those. Our 16
full-attention layers each own one, at 64 KiB/token combined at fp16.

vLLM already implements the mechanism. An `Attention` layer built with
`kv_sharing_target_layer_name` is skipped when the runner builds cache specs, so
no memory is allocated for it, and its tensor is aliased to the target's. It
validates that the target precedes the layer and matches its attention type.
The Qwen3.5 model code just never passes the argument, so the capability was
unreachable. This passes it.

```
KV_SHARE=group:2    # 8 of 16 layers own a cache, global KV cache halved
KV_SHARE=group:4    # 4 owners, quartered — DeepSeek's owner count
KV_SHARE=suffix:4   # 4 owners, You Only Cache Once layout
```

Unset is stock behaviour and changes nothing.

`group:N` groups consecutive full-attention layers N at a time and gives the
cache to the first of each, so the target is always nearby. `suffix:K` keeps the
first K owners and points everything later at the K-th; it should be the more
damaging layout, and it is the only one `--kv-sharing-fast-prefill` can use,
since that flag needs the sharing layers to form a suffix.

`VLLM_QWEN_KV_SHARE` is registered in `envs.py` so it takes part in the
torch.compile cache key. It changes which layers own a cache and therefore the
compiled graph; without that, a sweep would replay the previous arm's graph.

## What is verified, without a GPU

- The series applies to a pristine vLLM 0.28.0: 31 patches, 0 offsets, both CI passes.
- The layout helper, exercised over all 64 layers: for `group:2`, `group:4`,
  `suffix:8` and `suffix:4` every target precedes its layer and is itself an
  owner, so there are no chains. `group:1`, `suffix:0`, `suffix:16` and junk are
  rejected with a message.
- The launcher exports the variable only when `KV_SHARE` is non-empty.
- The sweep's log parsing, against a realistic log line.

## What is not verified

Everything that needs the card. It has never booted. In particular I expect
trouble in **cache group geometry** before model quality: shared layers get
appended to their target's group, and group composition on this hybrid model is
where #57 and #63 both came from.

## The ask

`bash bench/kv_share_sweep.sh` runs the arms and scores them on perplexity,
GSM8K and needle retrieval at depth. It boots on port 18021 so it will not fight
a production server. Budget about 25 minutes per arm, or start with
`GSM_N=100 NEEDLE=0` for a first look.

A shorter first question, if the full sweep is too much: **does `KV_SHARE=group:2`
boot at all, and what does the log say about the KV pool?** That alone settles
the geometry risk, which is the part most likely to kill this.

The harness refuses three mistakes this repo has already made: it verifies each
arm took effect by reading the owner count out of the server log rather than
trusting the env var, it boots each arm twice so a cold compile cache is never
compared against a warm one, and it measures perplexity with `PREFIX_CACHE=0`.

Untrained, the honest expectation is `group:2` degrades and `group:4` falls
apart. The useful output is the shape of the curve, because that says whether a
light fine-tune on the attention layers could close the gap or whether these
layers are too dissimilar to share at all. If `group:2` is already broken, this
PR should be closed and the result written up as a gotcha — that is a perfectly
good outcome and it is cheaper than the alternative of finding out later.

`docs/kv-sharing.md` has the protocol, the ship/no-ship criteria, and the
arithmetic on why the other DeepSeek-flavoured idea doing the rounds right now
(Late Layer KV Approximation, the `Q3-8B-KVA-Projector` projector) does **not**
port to this model: it needs the back half of the network to be skippable, and
three quarters of our layers are gated-delta-net whose recurrent state cannot be
written per-position. Its ceiling here is 4% of prefill at 4k and 12% at 51k,
against the ~50% it gets on the all-attention Qwen3-8B it was built for.

Drive-by: the README docs table still said `gotchas.md` had 18 entries. It has 53.
