### PR TITLE
hf: use the Xet high-performance transfer variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN set -e; SP=$(venv/bin/python -c 'import vllm, os; print(os.path.dirname(vllm
 # HOME is a volume: torch.compile cache (~/.cache/vllm), Triton (~/.triton),
 # FlashInfer JIT (~/.cache/flashinfer), HF hub cache.
 RUN mkdir -p /cache /app/models && chmod 1777 /cache
-ENV HOME=/cache VLLM_NO_USAGE_STATS=1 DO_NOT_TRACK=1 HF_HUB_ENABLE_HF_TRANSFER=1
+ENV HOME=/cache VLLM_NO_USAGE_STATS=1 DO_NOT_TRACK=1 HF_XET_HIGH_PERFORMANCE=1
 VOLUME ["/cache", "/app/models"]
 EXPOSE 18020
 ENTRYPOINT ["bash", "docker/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -757,7 +757,7 @@ venv/bin/pip install vllm==0.28.0 huggingface_hub hf_transfer ninja \
 # vLLM's C extension.
 
 # model, ~19.5 GB
-HF_HUB_ENABLE_HF_TRANSFER=1 venv/bin/hf download \
+HF_XET_HIGH_PERFORMANCE=1 venv/bin/hf download \
   dbirks/Qwen3.8-27B-W4A16-AutoRound \
   --local-dir models/Qwen3.8-27B-W4A16-AutoRound
 


### PR DESCRIPTION
huggingface_hub deprecated `HF_HUB_ENABLE_HF_TRANSFER` because hf_transfer is no longer used, and vLLM logged a FutureWarning for it on container start. Switch the container `ENV` and the documented host-side model download to `HF_XET_HIGH_PERFORMANCE` so fast transfers keep working through the supported Xet path.

Assisted-by: Crush:qwen3.8-27b