### PR TITLE
Bump cuda base container version from 13.0.1 to 13.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # that only happens once.
 #
 #   docker compose --profile single up -d      (see docs/docker.md)
-FROM nvidia/cuda:13.0.1-base-ubuntu24.04
+FROM nvidia/cuda:13.0.3-base-ubuntu24.04
 
 ENV DEBIAN_FRONTEND=noninteractive PIP_NO_CACHE_DIR=1 PYTHONUNBUFFERED=1
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This is the current latest version in the 13.0 series.