### PR TITLE
Mamba align: retire state blocks across null gaps (backport vllm #55450), peak pool pressure of long prefills halved

### DIFF
--- a/patches/mamba-align-retire-null-gaps.patch
+++ b/patches/mamba-align-retire-null-gaps.patch
@@ -25,7 +25,9 @@ Applies on top of mamba-align-checkpoint-order.patch.
              self._allocated_block_reqs: set[str] = set()
              # Requests that registered their own last-prompt-boundary partial
 @@ -1469,6 +1470,27 @@
+ 
          return mask
+ 
 +    def _remove_blocks_in_range(
 +        self, request_id: str, first_block: int, last_block: int
 +    ) -> None:

--- a/patches/mamba-align-retire-null-gaps.patch
+++ b/patches/mamba-align-retire-null-gaps.patch
@@ -1,0 +1,60 @@
+Mamba "align" prefix caching: retire state blocks across null gaps and stop
+rescanning the retired prefix (backport of upstream vllm#55450, merged
+2026-09-11, not in 0.29.0).
+In align mode a long prefill leaves null gaps between the state snapshots
+that await retirement. The base block remover walks backward and stops at
+the first null block, so every state older than the gap stays allocated
+until the request ends. Upstream measured 71 retained state blocks per
+Mamba group where 8 or 9 is the bound (480k-token prefill, MTP), and the
+same 71 reproduces on this tree with upstream test
+test_mamba_retirement_bounds_prefill_states. MambaManager now overrides the
+remover for align mode: skip nulls instead of stopping, and remember how
+far retirement has reached so the prefix is not rescanned. States are
+returned at request end either way; the cost is peak pool pressure during
+long prefills, not a permanent leak.
+Applies on top of mamba-align-checkpoint-order.patch.
+--- generated hunks below ---
+--- a/v1/core/single_type_kv_cache_manager.py
++++ b/v1/core/single_type_kv_cache_manager.py
+@@ -1317,6 +1317,7 @@
+             # Mapping from request ID to the index of the block
+             # allocated in the previous step
+             self.last_state_block_idx: dict[str, int] = {}
++            self._num_retired_blocks: dict[str, int] = {}
+             # The set of the requests that have been allocated blocks
+             self._allocated_block_reqs: set[str] = set()
+             # Requests that registered their own last-prompt-boundary partial
+@@ -1469,6 +1470,27 @@
+         return mask
++    def _remove_blocks_in_range(
++        self, request_id: str, first_block: int, last_block: int
++    ) -> None:
++        if self.mamba_cache_mode != "align":
++            return super()._remove_blocks_in_range(request_id, first_block, last_block)
++        blocks = self.req_to_blocks.get(request_id, [])
++        first_block = max(first_block, self._num_retired_blocks.get(request_id, 0))
++        last_block = min(last_block, len(blocks))
++        if first_block >= last_block:
++            return
++        freed: list[KVCacheBlock] = []
++        # Mamba prefill leaves null gaps between states awaiting retirement.
++        for i in range(last_block - 1, first_block - 1, -1):
++            if blocks[i].is_null:
++                continue
++            freed.append(blocks[i])
++            blocks[i] = self._null_block
++        if freed:
++            self.block_pool.free_blocks(freed)
++        self._num_retired_blocks[request_id] = last_block
++
+     def remove_skipped_blocks(
+         self,
+         request_id: str,
+@@ -1772,6 +1794,7 @@
+         if self.mamba_cache_mode == "align":
+             self._allocated_block_reqs.discard(request_id)
+             self.last_state_block_idx.pop(request_id, None)
++            self._num_retired_blocks.pop(request_id, None)
+             self._producer_partial_tail_reqs.pop(request_id, None)
+             # A hand-off whose request died in this same scheduling pass must
+             # not reach the connector: its unpin hook (free) has already run.


### PR DESCRIPTION
Backport of vllm-project/vllm#55450 (merged 2026-09-11, not in 0.29.0) onto the 0.28.0 tree, on top of `mamba-align-checkpoint-order.patch`.

**What it fixes.** In `--mamba-cache-mode align`, a long prefill leaves null gaps between the Mamba state snapshots that await retirement. The base block remover walks a request's blocks backward and stops at the first null block, so every state older than the gap stays allocated until the request ends. `MambaManager` now overrides the remover for align mode: skip nulls instead of stopping, and remember how far retirement has reached so the prefix is not rescanned. States come back at request end either way; the cost is peak pool pressure during long prefills, not a permanent leak, which is why an idle server shows nothing.

**Unit evidence, both boxes.** Upstream's `tests/v1/core/test_single_type_kv_cache_manager.py` at v0.28.0 with the PR's test additions, against this tree's manager (fork series applied): before, `test_mamba_retirement_crosses_null_gaps` fails and the 3584-token bounds tests fail with `71 == 7 + 1` and `71 == 7 + 2`, upstream's own numbers; after, 7 of 7 new tests and 18 of 18 in the file. Identical on a WSL2 4090 (fork image) and a native 3090 venv.

**Real-path evidence.** `SPEC=mtp CTX=long PREFIX_CACHE=1`, one long prompt per row, `vllm:kv_cache_usage_perc` sampled every 0.25 s during the prefill, pool verified identical between arms before comparing percentages.

WSL2 4090, `MAX_LEN=65536`, default prefill attention (no `PREFILL_ATTN=int8`), pool 148,501 tokens both arms as computed by the launcher; so the two tables share the long profile's KV dtype, drafter and a 65,536 ceiling, and differ in int8 prefill attention, the card, and the pool:

| prompt tokens | as shipped, peak | with the patch, peak |
|---|---|---|
| 21,642 | 36.8% | 21.2% |
| 56,107 | 68.9% | 40.6% |
| 21,642 replayed (prefix cached) | 18.4% | 18.4% |

Native 3090, `MAX_LEN=65536` (so the long profile's 150k ceiling was not in play), `PREFILL_ATTN=int8` inherited from that box's production in both arms, pool 161,051 tokens both arms as computed by the launcher for `CTX=long` (not a chosen pin). Both arms share all three, so the A/B is internally valid; the absolute percentages are not comparable to the 4090 rows above and would not be the numbers at a true 150k context:

| prompt tokens | as shipped, peak | with the patch, peak | pool tokens saved per prompt token |
|---|---|---|---|
| 20,808 | 32.2% | 19.1% | 1.01 |
| 30,586 | 44.8% | 23.9% | 1.10 |
| 43,171 | 60.4% | 30.4% | 1.12 |
| 20,808 replayed | 30.4% | 18.7% | 0.91 |

Settle is 0.0% on every arm. The un-retired states cost about one extra pool token per prompt token, and the ratio widens with prefill length (0.60 to 0.50 of the shipped peak across that ladder), so on a pinned single-card pool this is the difference between a 45k-token prompt fitting alongside other work or not. Prefix reuse is unaffected: the same 512..32k reuse ladder is byte-identical between arms on both boxes.

One note for anyone editing the patch file: it contains blank context lines that are a single space; a trailing-whitespace trim turns it into a malformed patch that `git apply --check` rejects.
